### PR TITLE
fix: resolve MCP server crash from logging stdout conflicts

### DIFF
--- a/src/mcp_server_git/logging_config.py
+++ b/src/mcp_server_git/logging_config.py
@@ -35,7 +35,7 @@ def configure_logging(log_level: str = "INFO") -> None:
     """
     root_logger = logging.getLogger()
     root_logger.handlers.clear()
-    handler = logging.StreamHandler(sys.stdout)
+    handler = logging.StreamHandler(sys.stderr)
     formatter = StructuredLogFormatter()
     handler.setFormatter(formatter)
     root_logger.addHandler(handler)


### PR DESCRIPTION
## Summary
- Fixed critical MCP server crash caused by JSON-formatted logs being sent to stdout
- Changed logging configuration to use stderr instead of stdout
- Prevents JSON-RPC protocol conflicts that caused ZodError validation failures

## Root Cause Analysis
The MCP server was crashing because the `StructuredLogFormatter` was writing JSON-formatted log messages to stdout:
```json
{"timestamp": "...", "level": "INFO", "logger": "...", "message": "..."}
```

However, MCP clients expect only valid JSON-RPC 2.0 messages on stdout:
```json
{"jsonrpc": "2.0", "id": "...", "method": "...", "params": {...}}
```

## Solution
- Modified `src/mcp_server_git/logging_config.py:38`
- Changed `logging.StreamHandler(sys.stdout)` to `logging.StreamHandler(sys.stderr)`
- Maintains structured logging while preserving JSON-RPC protocol compliance

## Testing
✅ All logging and MCP verification tests pass
✅ Zero critical lint violations  
✅ No test regressions

## Impact
- **Fixes**: MCP server stability and protocol compliance
- **Risk**: Low - only changes logging destination, not functionality
- **Compatibility**: Maintains all existing logging features

🤖 Generated with [Claude Code](https://claude.ai/code)