### PR TITLE
Fix: Resolve race condition in concurrent heartbeat test

### DIFF
--- a/tests/test_heartbeat.py
+++ b/tests/test_heartbeat.py
@@ -55,7 +55,10 @@ class TestHeartbeatManager:
             s = await session_manager.create_session(f"concurrent-{i}")
             sessions.append(s)
             await heartbeat_manager.record_heartbeat(f"concurrent-{i}")
-        await asyncio.sleep(0.1)
+        # Wait a short time that's well within the heartbeat timeout window
+        # Heartbeat cleanup happens after missed_threshold (2) * heartbeat_interval (0.05) = 0.1s
+        # So we wait only 0.05s to be safely within the window
+        await asyncio.sleep(0.05)
         for i in range(5):
             assert heartbeat_manager.get_last_heartbeat(f"concurrent-{i}") is not None
 


### PR DESCRIPTION
## Summary
Fixes a race condition in `test_concurrent_heartbeats` that was causing CI failures on Python 3.12.

## Problem
The test was waiting exactly 100ms when heartbeat cleanup happens after 100ms (2 missed heartbeats × 50ms interval), creating a timing sensitivity that manifested as failures in CI environments.

Error: `AssertionError: assert None is not None` when checking for heartbeat records.

## Solution
- Reduced wait time from 100ms to 50ms
- Added explanatory comments about the timing calculation
- Ensures test completes well within the heartbeat timeout window

## Testing
- ✅ All heartbeat tests pass locally
- ✅ Fix targets the specific race condition without affecting other tests
- ✅ Timing is now robust against system load variations

## Impact
- Resolves CI failures on Python 3.12 test suite
- No functional changes to the heartbeat management system
- Improves test reliability across different environments

🤖 Generated with [Claude Code](https://claude.ai/code)