### PR TITLE
fix: remove interactive options from git commands to prevent hanging

### DIFF
--- a/src/mcp_server_git/core/handlers.py
+++ b/src/mcp_server_git/core/handlers.py
@@ -139,7 +139,7 @@ class CallToolHandler:
             "git_rebase": self._create_git_handler(
                 git_rebase,
                 requires_repo=True,
-                extra_args=["target_branch", "interactive"],
+                extra_args=["target_branch"],
             ),
             "git_merge": self._create_git_handler(
                 git_merge,
@@ -290,7 +290,6 @@ class CallToolHandler:
                         elif arg in [
                             "oneline",
                             "graph",
-                            "interactive",
                             "set_upstream",
                             "force",
                             "no_commit",

--- a/src/mcp_server_git/core/prompts.py
+++ b/src/mcp_server_git/core/prompts.py
@@ -360,56 +360,6 @@ Include exact Git commands and explain what each command does."""
                 ],
             )
 
-        case "rebase-interactive":
-            commits = args.get("commits", "")
-            goal = args.get("goal", "clean up history")
-
-            prompt_text = f"""Guide through an interactive rebase operation.
-
-**Commits to Rebase:**
-```
-{commits}
-```
-
-**Goal:** {goal}
-
-Provide a comprehensive rebase guide:
-
-1. **Rebase Strategy**
-   - Recommended approach for the goal
-   - Which commits to pick, squash, edit, or drop
-   - Commit message improvements
-
-2. **Interactive Rebase Commands**
-   - Complete rebase plan with actions
-   - Explanation of each action
-   - Expected outcome
-
-3. **Execution Steps**
-   - Exact commands to run
-   - What to expect at each step
-   - How to handle conflicts
-
-4. **Safety Measures**
-   - Backup recommendations
-   - How to abort if needed
-   - Recovery procedures
-
-5. **Verification**
-   - How to verify the rebase succeeded
-   - Testing recommendations
-   - Push considerations
-
-Include the interactive rebase script with explanations."""
-
-            return GetPromptResult(
-                description="Interactive rebase guide",
-                messages=[
-                    PromptMessage(
-                        role="user", content=TextContent(type="text", text=prompt_text)
-                    )
-                ],
-            )
 
         case "release-notes":
             version = args.get("version", "")

--- a/src/mcp_server_git/core/prompts.py
+++ b/src/mcp_server_git/core/prompts.py
@@ -360,7 +360,6 @@ Include exact Git commands and explain what each command does."""
                 ],
             )
 
-
         case "release-notes":
             version = args.get("version", "")
             commits = args.get("commits", "")

--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -89,7 +89,6 @@ class GitDiffBranches(BaseModel):
 class GitRebase(BaseModel):
     repo_path: str
     target_branch: str
-    interactive: bool = False
 
 
 class GitMerge(BaseModel):

--- a/src/mcp_server_git/git/operations.py
+++ b/src/mcp_server_git/git/operations.py
@@ -445,7 +445,7 @@ def git_diff_branches(repo: Repo, base_branch: str, compare_branch: str) -> str:
         return f"❌ Diff error: {str(e)}"
 
 
-def git_rebase(repo: Repo, target_branch: str, interactive: bool = False) -> str:
+def git_rebase(repo: Repo, target_branch: str) -> str:
     """Rebase current branch onto target branch"""
     try:
         # Get current branch
@@ -467,13 +467,8 @@ def git_rebase(repo: Repo, target_branch: str, interactive: bool = False) -> str
         if target_branch not in all_branches:
             return f"❌ Target branch '{target_branch}' not found"
 
-        # Build rebase command
-        rebase_args = [target_branch]
-        if interactive:
-            rebase_args.insert(0, "--interactive")
-
-        # Perform rebase
-        result = repo.git.rebase(*rebase_args)
+        # Perform rebase (non-interactive only)
+        result = repo.git.rebase(target_branch)
 
         return (
             f"✅ Successfully rebased {current_branch} onto {target_branch}\n{result}"

--- a/src/mcp_server_git/server.py
+++ b/src/mcp_server_git/server.py
@@ -1833,7 +1833,6 @@ Transform technical commit messages into user-friendly changelog entries."""
                     ],
                 )
 
-
             case "github-actions-failure-analysis":
                 failure_logs = args.get("failure_logs", "")
                 workflow_file = args.get("workflow_file", "")

--- a/src/mcp_server_git/server.py
+++ b/src/mcp_server_git/server.py
@@ -504,7 +504,6 @@ class GitFetch(BaseModel):
 class GitRebase(BaseModel):
     repo_path: str
     target_branch: str
-    interactive: bool = False
 
 
 class GitMerge(BaseModel):
@@ -1327,22 +1326,6 @@ async def serve(repository: Path | None, test_mode: bool = False) -> None:
                     ),
                 ],
             ),
-            Prompt(
-                name="rebase-interactive",
-                description="Guide for interactive rebase operations",
-                arguments=[
-                    PromptArgument(
-                        name="commits",
-                        description="Commits to be rebased",
-                        required=True,
-                    ),
-                    PromptArgument(
-                        name="goal",
-                        description="What you want to achieve with the rebase",
-                        required=False,
-                    ),
-                ],
-            ),
             # GitHub Actions Prompts
             Prompt(
                 name="github-actions-failure-analysis",
@@ -1850,59 +1833,6 @@ Transform technical commit messages into user-friendly changelog entries."""
                     ],
                 )
 
-            case "rebase-interactive":
-                commits = args.get("commits", "")
-                goal = args.get("goal", "")
-
-                goal_section = f"\n**Goal:** {goal}\n" if goal else ""
-
-                prompt_text = f"""Guide me through an interactive rebase for these commits:
-
-{commits}
-{goal_section}
-Provide comprehensive rebase guidance:
-
-1. **Rebase Planning**
-   - Analysis of current commits
-   - Recommended rebase actions
-   - Potential risks and considerations
-
-2. **Interactive Rebase Commands**
-   - pick: keep commit as-is
-   - reword: change commit message
-   - edit: modify commit content
-   - squash: combine with previous commit
-   - fixup: combine with previous, discard message
-   - drop: remove commit entirely
-
-3. **Step-by-Step Process**
-   - Command to start interactive rebase
-   - How to edit the rebase todo list
-   - Resolving conflicts during rebase
-   - Completing the rebase process
-
-4. **Best Practices**
-   - When to use each rebase action
-   - Maintaining commit history clarity
-   - Testing between rebase steps
-   - Safety with force pushing
-
-5. **Troubleshooting**
-   - Common rebase issues
-   - How to abort if needed
-   - Recovering from mistakes
-
-Include specific commands and editor instructions."""
-
-                return GetPromptResult(
-                    description="Interactive rebase guide",
-                    messages=[
-                        PromptMessage(
-                            role="user",
-                            content=TextContent(type="text", text=prompt_text),
-                        )
-                    ],
-                )
 
             case "github-actions-failure-analysis":
                 failure_logs = args.get("failure_logs", "")
@@ -2462,7 +2392,6 @@ Provide specific, actionable recommendations for each area."""
                     result = git_rebase(
                         repo,
                         arguments["target_branch"],
-                        arguments.get("interactive", False),
                     )
                     return [TextContent(type="text", text=result)]
 

--- a/src/mcp_server_git/server_modular.py
+++ b/src/mcp_server_git/server_modular.py
@@ -476,7 +476,6 @@ async def serve_modular(repository: Path | None = None):
                         rebase_result = git_rebase(
                             repo,
                             arguments["target_branch"],
-                            arguments.get("interactive", False),
                         )
                         result = [TextContent(type="text", text=rebase_result)]
 


### PR DESCRIPTION
## Summary
- Remove interactive parameter from GitRebase model and operations across all server implementations
- Update git_rebase function to only support non-interactive mode  
- Remove rebase-interactive prompt functionality entirely
- Clean up parameter processing in handlers to exclude interactive option

## Problem Solved
The interactive option in git commands (particularly `git rebase --interactive`) would open vi or other editors and hang forever in the MCP server context, as there's no user to interact with the editor.

## Changes Made
- **Models**: Removed `interactive: bool = False` from GitRebase models in `git/models.py` and `server.py`
- **Operations**: Updated `git_rebase()` function in `git/operations.py` to remove interactive parameter and logic
- **Handlers**: Cleaned up parameter processing in `core/handlers.py` to exclude interactive option
- **Servers**: Updated tool call handlers in `server.py` and `server_modular.py` to remove interactive argument passing  
- **Prompts**: Removed entire "rebase-interactive" prompt functionality from `core/prompts.py` and `server.py`

## Quality Validation
- ✅ All linting checks pass (F,E9 violations resolved)
- ✅ All modified files compile correctly
- ✅ Core functionality imports successfully
- ✅ Non-interactive rebase functionality preserved

## Test plan
- [x] Verify git rebase operations work without interactive parameter
- [x] Confirm no hanging occurs on rebase commands
- [x] Validate all server implementations compile and start correctly
- [x] Check that prompt functionality no longer includes interactive rebase guidance

🤖 Generated with [Claude Code](https://claude.ai/code)