### PR TITLE
fix: Add auto-install MCP server task for ClaudeCode integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,9 @@ serve-simple = "python -m mcp_server_git.server_simple"
 mcp-server = { cmd = "python -m mcp_server_git", env = { PYTHONPATH = "src", CLAUDECODE = "0" } }
 mcp-server-debug = { cmd = "python -m mcp_server_git -vv --enable-file-logging", env = { PYTHONPATH = "src", LOG_LEVEL = "DEBUG", CLAUDECODE = "0" } }
 
+# Auto-install and run MCP server (for ClaudeCode integration)
+mcp-server-git = { depends-on = ["install-editable"], cmd = "mcp-server-git" }
+
 
 # ===== LEGACY/SPECIALIZED TASKS =====
 # Keep existing specialized tasks - with Claude Code git bypass


### PR DESCRIPTION
- Add mcp-server-git task that depends on install-editable
- Ensures MCP server automatically installs in development mode when started by ClaudeCode
- Removes CLAUDECODE=0 to maintain proper git redirector integration
- Fixes connection issues where MCP server wasn't available after ClaudeCode restart

🤖 Generated with [Claude Code](https://claude.ai/code)