### PR TITLE
fix(azure): Register Azure DevOps tools in list_tools()

### DIFF
--- a/src/mcp_server_git/applications/server_application.py
+++ b/src/mcp_server_git/applications/server_application.py
@@ -36,6 +36,14 @@ from ..services.github_service import GitHubServiceConfig
 from ..services.server_metrics import MetricsService
 from ..services.server_session import SessionManager
 
+# Azure DevOps models for tool registration
+from ..azure.models import (
+    AzureGetBuildLogs,
+    AzureGetBuildStatus,
+    AzureGetFailingJobs,
+    AzureListBuilds,
+)
+
 logger = logging.getLogger(__name__)
 
 # ===== MCP TOOL MODELS =====
@@ -1404,6 +1412,27 @@ class ServerApplication(DebuggableComponent):
                     name=GitHubTools.GET_FAILING_JOBS,
                     description="Get detailed information about failing CI jobs for a pull request",
                     inputSchema=GitHubGetFailingJobs.model_json_schema(),
+                ),
+                # Azure DevOps Tools
+                Tool(
+                    name=AzureTools.GET_BUILD_STATUS,
+                    description="Get the status of an Azure DevOps build/pipeline run",
+                    inputSchema=AzureGetBuildStatus.model_json_schema(),
+                ),
+                Tool(
+                    name=AzureTools.GET_BUILD_LOGS,
+                    description="Get logs from an Azure DevOps build",
+                    inputSchema=AzureGetBuildLogs.model_json_schema(),
+                ),
+                Tool(
+                    name=AzureTools.GET_FAILING_JOBS,
+                    description="Get detailed information about failing jobs in an Azure DevOps build",
+                    inputSchema=AzureGetFailingJobs.model_json_schema(),
+                ),
+                Tool(
+                    name=AzureTools.LIST_BUILDS,
+                    description="List Azure DevOps builds with filtering options",
+                    inputSchema=AzureListBuilds.model_json_schema(),
                 ),
             ]
 


### PR DESCRIPTION
## Summary

The migration from `server.py` to `server_application.py` included the Azure tool **call handlers** but failed to **register the tools** in `list_tools()`, making them invisible to MCP clients.

## Root Cause

| File | Tool Registration | Call Handling |
|------|------------------|---------------|
| `server.py` (dead code) | ✅ Had it | ❌ Missing |
| `server_application.py` (active) | ❌ **Missing** | ✅ Had it |

## Changes

- Import Azure models from `azure/models.py`
- Register 4 Azure tools in `list_tools()`:
  - `azure_get_build_status`
  - `azure_get_build_logs`
  - `azure_get_failing_jobs`
  - `azure_list_builds`

## Test Plan

- [ ] Verify Azure tools appear in MCP tool list
- [ ] Test `azure_get_build_status` with a real Azure DevOps build
- [ ] CI passes

## Related

- Fixes the Azure tools registration that PR #90 attempted to fix

🤖 Generated with [Claude Code](https://claude.ai/code)