### PR TITLE
fix: add pixi tasks for lean MCP interface

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,6 +250,10 @@ serve = "python -m mcp_server_git"
 pixi-git-server = { cmd = "python -m mcp_server_git", env = { PYTHONPATH = "src", CLAUDECODE = "0" } }
 pixi-git-server-debug = { cmd = "python -m mcp_server_git -vv --enable-file-logging", env = { PYTHONPATH = "src", LOG_LEVEL = "DEBUG", CLAUDECODE = "0" } }
 
+# Lean interface (3-meta-tool pattern, 95% context reduction)
+pixi-git-server-lean = { cmd = "python -m mcp_server_git.lean", env = { PYTHONPATH = "src", CLAUDECODE = "0" } }
+pixi-git-server-lean-debug = { cmd = "python -m mcp_server_git.lean -vv --enable-file-logging", env = { PYTHONPATH = "src", LOG_LEVEL = "DEBUG", CLAUDECODE = "0" } }
+
 # Auto-install and run MCP server (for ClaudeCode integration)
 mcp-server-git = { cmd = "python -m mcp_server_git", env = { PYTHONPATH = "src", CLAUDECODE = "0" } }
 


### PR DESCRIPTION
Add missing pixi tasks to run the lean interface that was implemented in PR #96:
- pixi-git-server-lean: Run lean interface (3 meta-tools, 95% context reduction)
- pixi-git-server-lean-debug: Run lean interface with verbose debugging

The lean interface entry point (mcp-git-lean) was created in PR #96 but no pixi task was added to actually run it. This prevented users from switching to the lean interface via MCP configuration.

Usage in .mcp.json:
```json
"git": {
  "command": "pixi",
  "args": [
    "run",
    "--manifest-path",
    "/path/to/mcp-git/development",
    "pixi-git-server-lean",
    "--repository",
    "/path/to/repo"
  ]
}
```

Related: #96

Co-Authored-By: MementoRC (https://github.com/MementoRC)