### PR TITLE
fix: use NullAzureService by default in lean interface

### DIFF
--- a/src/mcp_server_git/lean/__main__.py
+++ b/src/mcp_server_git/lean/__main__.py
@@ -37,18 +37,15 @@ def main():
     logger.info("Initializing mcp-git-lean server...")
 
     # Initialize services
-    # Note: These need to be properly initialized with repository paths
-    # For now, we'll create placeholder services
     git_service = GitService()
     github_service = GitHubService()
 
-    if AZURE_AVAILABLE:
-        azure_service = AzureClient()
-    else:
-        # Use null object pattern for Azure service
-        from .null_azure_service import NullAzureService
+    # Always use NullAzureService for lean interface
+    # Azure support requires token, organization, and session configuration
+    # which is not set up by default
+    from .null_azure_service import NullAzureService
 
-        azure_service = NullAzureService()
+    azure_service = NullAzureService()
 
     # Create lean interface
     app = create_git_lean_interface(

--- a/src/mcp_server_git/lean/__main__.py
+++ b/src/mcp_server_git/lean/__main__.py
@@ -12,14 +12,6 @@ from dotenv import load_dotenv
 from ..services.git_service import GitService
 from ..services.github_service import GitHubService
 
-# Import Azure service when available
-try:
-    from ..azure.client import AzureClient
-
-    AZURE_AVAILABLE = True
-except ImportError:
-    AZURE_AVAILABLE = False
-
 from .interface import create_git_lean_interface
 
 # Configure logging

--- a/tests/lean/test_main.py
+++ b/tests/lean/test_main.py
@@ -1,0 +1,115 @@
+"""Tests for lean MCP interface main entry point."""
+
+from unittest.mock import MagicMock, patch
+
+
+class TestLeanMain:
+    """Test lean interface main() function."""
+
+    @patch("mcp_server_git.lean.__main__.load_dotenv")
+    @patch("mcp_server_git.lean.__main__.create_git_lean_interface")
+    def test_main_initializes_without_azure_config(
+        self, mock_create_interface, _mock_load_dotenv
+    ):
+        """Test that main() initializes successfully without Azure configuration.
+
+        This test verifies the fix for the TypeError that occurred when
+        AzureClient was initialized without required arguments (token,
+        organization, session).
+
+        The fix ensures NullAzureService is always used in the lean interface,
+        regardless of whether the azure.client module is importable.
+        """
+        # Setup: Mock the FastMCP app to prevent actual server startup
+        mock_app = MagicMock()
+        mock_create_interface.return_value = mock_app
+
+        # Import main - this is where the bug would have occurred
+        from mcp_server_git.lean.__main__ import main
+
+        # Execute: Call main() - should not raise TypeError
+        try:
+            main()
+        except SystemExit:
+            # app.run() may call sys.exit(), which is fine
+            pass
+
+        # Verify: Check that services were initialized correctly
+        mock_create_interface.assert_called_once()
+        call_kwargs = mock_create_interface.call_args.kwargs
+
+        # Verify all three services are provided
+        assert "git_service" in call_kwargs
+        assert "github_service" in call_kwargs
+        assert "azure_service" in call_kwargs
+
+        # Verify azure_service is NullAzureService (not AzureClient)
+        azure_service = call_kwargs["azure_service"]
+        assert azure_service is not None
+        # NullAzureService doesn't require any initialization arguments
+        assert type(azure_service).__name__ == "NullAzureService"
+
+    @patch("mcp_server_git.lean.__main__.load_dotenv")
+    @patch("mcp_server_git.lean.__main__.create_git_lean_interface")
+    def test_main_uses_null_azure_service(
+        self, mock_create_interface, _mock_load_dotenv
+    ):
+        """Test that main() always uses NullAzureService.
+
+        Even if azure.client.AzureClient is importable, the lean interface
+        should use NullAzureService because Azure configuration (token,
+        organization, session) is not set up by default.
+        """
+        # Setup
+        mock_app = MagicMock()
+        mock_create_interface.return_value = mock_app
+
+        from mcp_server_git.lean.__main__ import main
+
+        # Execute
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify NullAzureService is used
+        call_kwargs = mock_create_interface.call_args.kwargs
+        azure_service = call_kwargs["azure_service"]
+
+        # Should be NullAzureService, not AzureClient
+        assert type(azure_service).__name__ == "NullAzureService"
+
+        # NullAzureService should have stub methods that don't require config
+        assert hasattr(azure_service, "azure_get_build_status")
+        assert hasattr(azure_service, "azure_get_build_logs")
+
+    @patch("mcp_server_git.lean.__main__.load_dotenv")
+    @patch("mcp_server_git.lean.__main__.create_git_lean_interface")
+    @patch("mcp_server_git.lean.__main__.logger")
+    def test_main_logs_initialization(
+        self, mock_logger, mock_create_interface, _mock_load_dotenv
+    ):
+        """Test that main() logs successful initialization."""
+        # Setup
+        mock_app = MagicMock()
+        mock_create_interface.return_value = mock_app
+
+        from mcp_server_git.lean.__main__ import main
+
+        # Execute
+        try:
+            main()
+        except SystemExit:
+            pass
+
+        # Verify logging
+        assert mock_logger.info.called
+        log_messages = [
+            call.args[0] for call in mock_logger.info.call_args_list
+        ]
+
+        # Should log initialization messages
+        assert any("Initializing" in msg for msg in log_messages)
+        assert any("initialized successfully" in msg for msg in log_messages)
+        assert any("3 meta-tools" in msg for msg in log_messages)
+        assert any("57 tools" in msg for msg in log_messages)


### PR DESCRIPTION
Fix AzureClient initialization error in lean interface __main__.py. AzureClient requires token, organization, and session arguments but was being initialized without any arguments when AZURE_AVAILABLE=True.

Since Azure configuration is not set up by default, always use NullAzureService which provides safe stub implementations for all Azure operations.

Error before fix:
```
TypeError: AzureClient.__init__() missing 3 required positional
arguments: 'token', 'organization', and 'session'
```

After fix: Lean interface starts successfully with NullAzureService.

Co-Authored-By: MementoRC (https://github.com/MementoRC)