### PR TITLE
fix(lean): add CLI argument parsing for --repository and --verbose

### DIFF
--- a/src/mcp_server_git/lean/__main__.py
+++ b/src/mcp_server_git/lean/__main__.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 def main(repository: Path | None, verbose: int) -> None:
     """MCP Git Lean Server - Git functionality with 95% context reduction."""
     # Set up logging level
-    logging_level = logging.WARN
+    logging_level = logging.WARNING
     if verbose == 1:
         logging_level = logging.INFO
     elif verbose >= 2:
@@ -39,8 +39,14 @@ def main(repository: Path | None, verbose: int) -> None:
         stream=sys.stderr,
     )
 
-    # Load environment variables from repository if it exists
+    # Validate repository path if provided
     if repository:
+        if not repository.exists():
+            logger.warning(f"Repository path does not exist: {repository}")
+        elif not (repository / ".git").exists() and not (repository / ".git").is_file():
+            # .git can be a file for worktrees
+            logger.warning(f"Path is not a git repository: {repository}")
+
         env_file = repository / ".env"
         if env_file.exists():
             load_dotenv(env_file)

--- a/src/mcp_server_git/lean/__main__.py
+++ b/src/mcp_server_git/lean/__main__.py
@@ -5,7 +5,10 @@ Initializes the lean MCP interface with 3 meta-tools for 95% context reduction.
 """
 
 import logging
+import sys
+from pathlib import Path
 
+import click
 from dotenv import load_dotenv
 
 # Import services from the main server
@@ -14,17 +17,36 @@ from ..services.github_service import GitHubService
 
 from .interface import create_git_lean_interface
 
-# Configure logging
-logging.basicConfig(
-    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-)
 logger = logging.getLogger(__name__)
 
 
-def main():
-    """Main entry point for mcp-git-lean server."""
-    # Load environment variables
-    load_dotenv()
+@click.command()
+@click.option("--repository", "-r", type=Path, help="Git repository path")
+@click.option("-v", "--verbose", count=True)
+def main(repository: Path | None, verbose: int) -> None:
+    """MCP Git Lean Server - Git functionality with 95% context reduction."""
+    # Set up logging level
+    logging_level = logging.WARN
+    if verbose == 1:
+        logging_level = logging.INFO
+    elif verbose >= 2:
+        logging_level = logging.DEBUG
+
+    # Configure logging
+    logging.basicConfig(
+        level=logging_level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stderr,
+    )
+
+    # Load environment variables from repository if it exists
+    if repository:
+        env_file = repository / ".env"
+        if env_file.exists():
+            load_dotenv(env_file)
+            logger.info(f"Loaded environment variables from {env_file}")
+    else:
+        load_dotenv()
 
     logger.info("Initializing mcp-git-lean server...")
 

--- a/tests/lean/test_main.py
+++ b/tests/lean/test_main.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+from click.testing import CliRunner
+
 
 class TestLeanMain:
     """Test lean interface main() function."""
@@ -27,12 +29,9 @@ class TestLeanMain:
         # Import main - this is where the bug would have occurred
         from mcp_server_git.lean.__main__ import main
 
-        # Execute: Call main() - should not raise TypeError
-        try:
-            main()
-        except SystemExit:
-            # app.run() may call sys.exit(), which is fine
-            pass
+        # Execute: Use CliRunner for click commands
+        runner = CliRunner()
+        runner.invoke(main, [])
 
         # Verify: Check that services were initialized correctly
         mock_create_interface.assert_called_once()
@@ -66,11 +65,9 @@ class TestLeanMain:
 
         from mcp_server_git.lean.__main__ import main
 
-        # Execute
-        try:
-            main()
-        except SystemExit:
-            pass
+        # Execute: Use CliRunner for click commands
+        runner = CliRunner()
+        runner.invoke(main, [])
 
         # Verify NullAzureService is used
         call_kwargs = mock_create_interface.call_args.kwargs
@@ -96,11 +93,9 @@ class TestLeanMain:
 
         from mcp_server_git.lean.__main__ import main
 
-        # Execute
-        try:
-            main()
-        except SystemExit:
-            pass
+        # Execute: Use CliRunner for click commands
+        runner = CliRunner()
+        runner.invoke(main, [])
 
         # Verify logging
         assert mock_logger.info.called
@@ -111,3 +106,59 @@ class TestLeanMain:
         assert any("initialized successfully" in msg for msg in log_messages)
         assert any("3 meta-tools" in msg for msg in log_messages)
         assert any("51 tools" in msg for msg in log_messages)
+
+    def test_main_shows_help(self):
+        """Test that --help flag shows usage information."""
+        from mcp_server_git.lean.__main__ import main
+
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+
+        assert result.exit_code == 0
+        assert "MCP Git Lean Server" in result.output
+        assert "--repository" in result.output
+        assert "--verbose" in result.output
+
+    @patch("mcp_server_git.lean.__main__.load_dotenv")
+    @patch("mcp_server_git.lean.__main__.create_git_lean_interface")
+    def test_main_accepts_repository_arg(
+        self, mock_create_interface, _mock_load_dotenv, tmp_path
+    ):
+        """Test that --repository argument is accepted."""
+        # Setup: Create a fake git repo
+        git_dir = tmp_path / ".git"
+        git_dir.mkdir()
+
+        mock_app = MagicMock()
+        mock_create_interface.return_value = mock_app
+
+        from mcp_server_git.lean.__main__ import main
+
+        # Execute with repository argument
+        runner = CliRunner()
+        result = runner.invoke(main, ["--repository", str(tmp_path)])
+
+        # Should not error on valid repo path
+        assert result.exit_code == 0 or mock_create_interface.called
+
+    @patch("mcp_server_git.lean.__main__.load_dotenv")
+    @patch("mcp_server_git.lean.__main__.create_git_lean_interface")
+    @patch("mcp_server_git.lean.__main__.logger")
+    def test_main_warns_on_invalid_repository(
+        self, mock_logger, mock_create_interface, _mock_load_dotenv, tmp_path
+    ):
+        """Test that invalid repository path logs a warning."""
+        mock_app = MagicMock()
+        mock_create_interface.return_value = mock_app
+
+        from mcp_server_git.lean.__main__ import main
+
+        # Execute with non-git directory
+        runner = CliRunner()
+        runner.invoke(main, ["--repository", str(tmp_path)])
+
+        # Should warn about invalid repo
+        warning_calls = [
+            call.args[0] for call in mock_logger.warning.call_args_list
+        ]
+        assert any("not a git repository" in msg for msg in warning_calls)


### PR DESCRIPTION
The lean server's __main__.py was ignoring CLI arguments, causing connection failures when invoked with --repository flag from MCP configs.

Changes:
- Add click decorator for CLI argument parsing
- Support --repository/-r for git repo path
- Support --verbose/-v for logging level control
- Configure logging inside main() to respect verbosity flag
- Load .env from repository path when provided