### PR TITLE
fix(types): resolve all pyright type errors and remove CI bypass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,11 @@ jobs:
       run: |
         echo "🔍 Running format checks..."
         pixi run -e quality format-check
-      continue-on-error: true
 
     - name: Run type checking with pyright
       run: |
         echo "🔍 Running type checking..."
         pixi run -e quality typecheck
-      continue-on-error: true
 
   # Job 2: Unit and Integration Tests
   test:

--- a/src/mcp_server_git/applications/server_application.py
+++ b/src/mcp_server_git/applications/server_application.py
@@ -32,6 +32,7 @@ from ..frameworks.server_security import SecurityFramework
 from ..operations.server_notifications import NotificationOperations
 from ..protocols.debugging_protocol import DebuggableComponent
 from ..services.git_service import GitService
+
 # GitHubServiceConfig imported from frameworks.server_github above
 from ..services.server_metrics import MetricsService
 from ..services.server_session import SessionManager
@@ -618,7 +619,9 @@ class ServerApplication(DebuggableComponent):
 
             # Phase 2: Initialize configuration management
             await self._initialize_configuration()
-            assert self._configuration_manager is not None, "Configuration manager must be initialized"
+            assert self._configuration_manager is not None, (
+                "Configuration manager must be initialized"
+            )
 
             # Phase 3: Initialize infrastructure components
             await self._initialize_infrastructure()
@@ -696,7 +699,9 @@ class ServerApplication(DebuggableComponent):
 
     async def _initialize_services(self) -> None:
         """Initialize service components."""
-        assert self._configuration_manager is not None, "Configuration manager must be initialized"
+        assert self._configuration_manager is not None, (
+            "Configuration manager must be initialized"
+        )
         logger.debug("Initializing service components...")
 
         # Get configuration for services
@@ -714,6 +719,7 @@ class ServerApplication(DebuggableComponent):
 
         # Initialize GitHub service
         from ..configuration.github_config import GitHubConfig
+
         github_config = GitHubServiceConfig(
             github_config=GitHubConfig(
                 api_token=server_config.github_token,
@@ -749,7 +755,9 @@ class ServerApplication(DebuggableComponent):
 
     async def _register_components(self) -> None:
         """Register all components with the framework."""
-        assert self._framework is not None, "Framework must be initialized before registering components"
+        assert self._framework is not None, (
+            "Framework must be initialized before registering components"
+        )
         logger.debug("Registering components with framework...")
 
         # Register core components
@@ -845,7 +853,9 @@ class ServerApplication(DebuggableComponent):
             logger.warning("ServerApplication already running")
             return
 
-        assert self._framework is not None, "Framework must be initialized before starting"
+        assert self._framework is not None, (
+            "Framework must be initialized before starting"
+        )
         logger.info("Starting ServerApplication...")
 
         try:
@@ -1109,16 +1119,32 @@ class ServerApplication(DebuggableComponent):
         # Return specific component state (convert to dict via state_data property)
         if path == "framework" and self._framework:
             state = self._framework.get_component_state()
-            return state.state_data if hasattr(state, "state_data") else {"state": str(state)}
+            return (
+                state.state_data
+                if hasattr(state, "state_data")
+                else {"state": str(state)}
+            )
         elif path == "git_service" and self._git_service:
             state = self._git_service.get_component_state()
-            return state.state_data if hasattr(state, "state_data") else {"state": str(state)}
+            return (
+                state.state_data
+                if hasattr(state, "state_data")
+                else {"state": str(state)}
+            )
         elif path == "github_service" and self._github_service:
             state = self._github_service.get_component_state()
-            return state.state_data if hasattr(state, "state_data") else {"state": str(state)}
+            return (
+                state.state_data
+                if hasattr(state, "state_data")
+                else {"state": str(state)}
+            )
         elif path == "security_framework" and self._security_framework:
             state = self._security_framework.get_component_state()
-            return state.state_data if hasattr(state, "state_data") else {"state": str(state)}
+            return (
+                state.state_data
+                if hasattr(state, "state_data")
+                else {"state": str(state)}
+            )
         else:
             return {"error": f"Component '{path}' not found or not initialized"}
 

--- a/src/mcp_server_git/applications/server_application.py
+++ b/src/mcp_server_git/applications/server_application.py
@@ -26,13 +26,13 @@ from pydantic import BaseModel, Field, field_validator
 from ..frameworks.mcp_server_framework import MCPServerFramework
 from ..frameworks.server_configuration import ServerConfigurationManager
 from ..frameworks.server_core import MCPGitServerCore
-from ..frameworks.server_github import GitHubService
+from ..frameworks.server_github import GitHubService, GitHubServiceConfig
 from ..frameworks.server_middleware import MiddlewareChainManager
 from ..frameworks.server_security import SecurityFramework
 from ..operations.server_notifications import NotificationOperations
 from ..protocols.debugging_protocol import DebuggableComponent
 from ..services.git_service import GitService
-from ..services.github_service import GitHubServiceConfig
+# GitHubServiceConfig imported from frameworks.server_github above
 from ..services.server_metrics import MetricsService
 from ..services.server_session import SessionManager
 from ..utils.repository_resolver import RepositoryResolver
@@ -614,9 +614,11 @@ class ServerApplication(DebuggableComponent):
         try:
             # Phase 1: Initialize core framework
             await self._initialize_core_framework()
+            assert self._framework is not None, "Framework must be initialized"
 
             # Phase 2: Initialize configuration management
             await self._initialize_configuration()
+            assert self._configuration_manager is not None, "Configuration manager must be initialized"
 
             # Phase 3: Initialize infrastructure components
             await self._initialize_infrastructure()
@@ -694,6 +696,7 @@ class ServerApplication(DebuggableComponent):
 
     async def _initialize_services(self) -> None:
         """Initialize service components."""
+        assert self._configuration_manager is not None, "Configuration manager must be initialized"
         logger.debug("Initializing service components...")
 
         # Get configuration for services
@@ -710,8 +713,11 @@ class ServerApplication(DebuggableComponent):
         self._git_service = GitService(config=git_config)
 
         # Initialize GitHub service
+        from ..configuration.github_config import GitHubConfig
         github_config = GitHubServiceConfig(
-            github_token=server_config.github_token,
+            github_config=GitHubConfig(
+                api_token=server_config.github_token,
+            ),
         )
         self._github_service = GitHubService(github_config)
 
@@ -743,6 +749,7 @@ class ServerApplication(DebuggableComponent):
 
     async def _register_components(self) -> None:
         """Register all components with the framework."""
+        assert self._framework is not None, "Framework must be initialized before registering components"
         logger.debug("Registering components with framework...")
 
         # Register core components
@@ -838,6 +845,7 @@ class ServerApplication(DebuggableComponent):
             logger.warning("ServerApplication already running")
             return
 
+        assert self._framework is not None, "Framework must be initialized before starting"
         logger.info("Starting ServerApplication...")
 
         try:
@@ -1064,7 +1072,7 @@ class ServerApplication(DebuggableComponent):
             # Add framework debug information
             if self._framework:
                 debug_info["framework_debug"] = self._framework.get_debug_info(
-                    detailed=True
+                    debug_level="DEBUG"
                 )
 
         return debug_info
@@ -1098,15 +1106,19 @@ class ServerApplication(DebuggableComponent):
                 },
             }
 
-        # Return specific component state
+        # Return specific component state (convert to dict via state_data property)
         if path == "framework" and self._framework:
-            return self._framework.get_component_state()
+            state = self._framework.get_component_state()
+            return state.state_data if hasattr(state, "state_data") else {"state": str(state)}
         elif path == "git_service" and self._git_service:
-            return self._git_service.get_component_state()
+            state = self._git_service.get_component_state()
+            return state.state_data if hasattr(state, "state_data") else {"state": str(state)}
         elif path == "github_service" and self._github_service:
-            return self._github_service.get_component_state()
+            state = self._github_service.get_component_state()
+            return state.state_data if hasattr(state, "state_data") else {"state": str(state)}
         elif path == "security_framework" and self._security_framework:
-            return self._security_framework.get_component_state()
+            state = self._security_framework.get_component_state()
+            return state.state_data if hasattr(state, "state_data") else {"state": str(state)}
         else:
             return {"error": f"Component '{path}' not found or not initialized"}
 
@@ -1582,6 +1594,11 @@ class ServerApplication(DebuggableComponent):
             git_status,
         )
         from ..utils.git_import import Repo
+
+        # Initialize repo_path (will be set for git operations, unused for GitHub operations)
+        repo_path: str = ""
+        # Initialize result (will be set by one of the operation branches)
+        result: Any = None
 
         # Check if this is a GitHub operation (which doesn't need repository path resolution)
         github_operations = [

--- a/src/mcp_server_git/azure/api.py
+++ b/src/mcp_server_git/azure/api.py
@@ -176,8 +176,7 @@ async def azure_get_build_logs(
                     log_lines = log_lines[-tail_lines:]
                     log_content = "\n".join(log_lines)
                     log_content = (
-                        f"... [truncated {truncated_count} lines] ...\n\n"
-                        + log_content
+                        f"... [truncated {truncated_count} lines] ...\n\n" + log_content
                     )
                     header = f"Log #{log_id} for Build #{build_id} (showing last {tail_lines} of {original_line_count} lines):\n\n"
                 else:
@@ -307,7 +306,7 @@ async def azure_get_failing_jobs(
                                 # Plain text response
                                 log_text = await log_response.text()
                                 log_lines = log_text.split("\n")
-                            
+
                             # Get last N lines
                             original_line_count = len(log_lines)
                             if len(log_lines) > log_tail_lines:
@@ -316,7 +315,9 @@ async def azure_get_failing_jobs(
                                 output.append(
                                     f"   Log excerpt (showing last {log_tail_lines} of {original_line_count} lines):"
                                 )
-                                output.append(f"   ... [truncated {truncated_count} lines] ...")
+                                output.append(
+                                    f"   ... [truncated {truncated_count} lines] ..."
+                                )
                             else:
                                 excerpt_lines = log_lines
                                 output.append(

--- a/src/mcp_server_git/config/token_limits.py
+++ b/src/mcp_server_git/config/token_limits.py
@@ -166,7 +166,10 @@ class TokenLimitConfigManager:
         self._lock = threading.Lock()
 
     def load_configuration(
-        self, config_file: str | None = None, profile: TokenLimitProfile | None = None, **overrides
+        self,
+        config_file: str | None = None,
+        profile: TokenLimitProfile | None = None,
+        **overrides,
     ) -> TokenLimitSettings:
         """
         Load configuration from multiple sources.

--- a/src/mcp_server_git/config/token_limits.py
+++ b/src/mcp_server_git/config/token_limits.py
@@ -161,12 +161,12 @@ class TokenLimitConfigManager:
 
     def __init__(self):
         self.logger = logging.getLogger(f"{__name__}.TokenLimitConfigManager")
-        self._settings: TokenLimitSettings = None
-        self._config_file_path: Path = None
+        self._settings: TokenLimitSettings | None = None
+        self._config_file_path: Path | None = None
         self._lock = threading.Lock()
 
     def load_configuration(
-        self, config_file: str = None, profile: TokenLimitProfile = None, **overrides
+        self, config_file: str | None = None, profile: TokenLimitProfile | None = None, **overrides
     ) -> TokenLimitSettings:
         """
         Load configuration from multiple sources.

--- a/src/mcp_server_git/core/enhanced_error_handling.py
+++ b/src/mcp_server_git/core/enhanced_error_handling.py
@@ -299,6 +299,17 @@ class EnhancedErrorHandler:
                 self._log_error(error, operation_name, {"timeout": True})
                 return self._create_error_response(error, operation_name)
 
+            except json.JSONDecodeError as e:
+                # Must catch JSONDecodeError before ValueError since it's a subclass
+                error = GitHubAPIError(
+                    f"Invalid JSON response from GitHub API: {e}",
+                    category=ErrorCategory.NETWORK,
+                    severity=ErrorSeverity.MEDIUM,
+                    suggestion="GitHub API returned malformed data. Try again or check API status",
+                )
+                self._log_error(error, operation_name, {"json_error": str(e)})
+                return self._create_error_response(error, operation_name)
+
             except ValueError as e:
                 if "authentication" in str(e).lower() or "token" in str(e).lower():
                     error = GitHubAPIError(
@@ -316,16 +327,6 @@ class EnhancedErrorHandler:
                         suggestion="Verify API parameters match GitHub API requirements",
                     )
                 self._log_error(error, operation_name, {"args": args, "kwargs": kwargs})
-                return self._create_error_response(error, operation_name)
-
-            except json.JSONDecodeError as e:
-                error = GitHubAPIError(
-                    f"Invalid JSON response from GitHub API: {e}",
-                    category=ErrorCategory.NETWORK,
-                    severity=ErrorSeverity.MEDIUM,
-                    suggestion="GitHub API returned malformed data. Try again or check API status",
-                )
-                self._log_error(error, operation_name, {"json_error": str(e)})
                 return self._create_error_response(error, operation_name)
 
             except Exception as e:
@@ -378,6 +379,17 @@ class EnhancedErrorHandler:
                 self._log_error(error, operation_name, {"timeout": True})
                 return self._create_error_response(error, operation_name)
 
+            except json.JSONDecodeError as e:
+                # Must catch JSONDecodeError before ValueError since it's a subclass
+                error = AzureAPIError(
+                    f"Invalid JSON response from Azure DevOps API: {e}",
+                    category=ErrorCategory.NETWORK,
+                    severity=ErrorSeverity.MEDIUM,
+                    suggestion="Azure DevOps API returned malformed data. Try again or check API status",
+                )
+                self._log_error(error, operation_name, {"json_error": str(e)})
+                return self._create_error_response(error, operation_name)
+
             except ValueError as e:
                 if "authentication" in str(e).lower() or "token" in str(e).lower():
                     error = AzureAPIError(
@@ -395,16 +407,6 @@ class EnhancedErrorHandler:
                         suggestion="Verify API parameters match Azure DevOps API requirements",
                     )
                 self._log_error(error, operation_name, {"args": args, "kwargs": kwargs})
-                return self._create_error_response(error, operation_name)
-
-            except json.JSONDecodeError as e:
-                error = AzureAPIError(
-                    f"Invalid JSON response from Azure DevOps API: {e}",
-                    category=ErrorCategory.NETWORK,
-                    severity=ErrorSeverity.MEDIUM,
-                    suggestion="Azure DevOps API returned malformed data. Try again or check API status",
-                )
-                self._log_error(error, operation_name, {"json_error": str(e)})
                 return self._create_error_response(error, operation_name)
 
             except Exception as e:

--- a/src/mcp_server_git/debugging/performance_profiler.py
+++ b/src/mcp_server_git/debugging/performance_profiler.py
@@ -189,9 +189,9 @@ class PerformanceProfiler:
                 disk_read_mb = (current_io.read_bytes - self._initial_io.read_bytes) / (
                     1024 * 1024
                 )
-                disk_write_mb = (current_io.write_bytes - self._initial_io.write_bytes) / (
-                    1024 * 1024
-                )
+                disk_write_mb = (
+                    current_io.write_bytes - self._initial_io.write_bytes
+                ) / (1024 * 1024)
             else:
                 disk_read_mb = 0.0
                 disk_write_mb = 0.0

--- a/src/mcp_server_git/debugging/performance_profiler.py
+++ b/src/mcp_server_git/debugging/performance_profiler.py
@@ -185,12 +185,16 @@ class PerformanceProfiler:
 
             # Disk I/O
             current_io = self._process.io_counters()
-            disk_read_mb = (current_io.read_bytes - self._initial_io.read_bytes) / (
-                1024 * 1024
-            )
-            disk_write_mb = (current_io.write_bytes - self._initial_io.write_bytes) / (
-                1024 * 1024
-            )
+            if self._initial_io is not None:
+                disk_read_mb = (current_io.read_bytes - self._initial_io.read_bytes) / (
+                    1024 * 1024
+                )
+                disk_write_mb = (current_io.write_bytes - self._initial_io.write_bytes) / (
+                    1024 * 1024
+                )
+            else:
+                disk_read_mb = 0.0
+                disk_write_mb = 0.0
 
             # Network I/O
             current_net = psutil.net_io_counters()

--- a/src/mcp_server_git/frameworks/mcp_server_framework.py
+++ b/src/mcp_server_git/frameworks/mcp_server_framework.py
@@ -687,7 +687,7 @@ class MCPServerFramework(DebuggableComponent):
             logger.error(f"Failed to export state as JSON: {e}")
             return json.dumps({"error": f"JSON export failed: {e}"})
 
-    def health_check(self) -> dict[str, bool | str | int | float]:
+    def health_check(self) -> dict[str, bool | str | int | float | None]:
         """Perform framework health check."""
         healthy = True
         status = "healthy"

--- a/src/mcp_server_git/frameworks/server_configuration.py
+++ b/src/mcp_server_git/frameworks/server_configuration.py
@@ -539,7 +539,7 @@ class ServerConfigurationManager(DebuggableComponent):
 
         return json.dumps(export_data, indent=2, default=str)
 
-    def health_check(self) -> dict[str, bool | str | int | float]:
+    def health_check(self) -> dict[str, bool | str | int | float | None]:
         """Perform a health check on the component."""
         is_healthy = True
         status = "healthy"
@@ -594,7 +594,7 @@ class ServerConfigurationManager(DebuggableComponent):
         Raises:
             ConfigurationError: If updates are invalid or update fails
         """
-        if not self._initialized:
+        if not self._initialized or self._current_config is None:
             raise ConfigurationError("Configuration not initialized")
 
         # Merge updates with current config

--- a/src/mcp_server_git/frameworks/server_github.py
+++ b/src/mcp_server_git/frameworks/server_github.py
@@ -493,7 +493,7 @@ class GitHubService(DebuggableComponent):
 
             @property
             def debug_data(self) -> dict[str, Any]:
-                data = {
+                data: dict[str, Any] = {
                     "service_state": {
                         "initialized": self._state.is_initialized,
                         "running": self._state.is_running,

--- a/src/mcp_server_git/frameworks/server_middleware.py
+++ b/src/mcp_server_git/frameworks/server_middleware.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from typing import Any
 
 from mcp.types import (
+    ErrorData,
     JSONRPCError,
 )
 
@@ -154,11 +155,11 @@ class AuthenticationMiddleware(BaseMiddleware):
         return JSONRPCError(
             jsonrpc="2.0",
             id="auth-error",
-            error={
-                "code": -32001,
-                "message": "Authentication Error",
-                "data": {"details": message},
-            },
+            error=ErrorData(
+                code=-32001,
+                message="Authentication Error",
+                data={"details": message},
+            ),
         )
 
 
@@ -287,11 +288,11 @@ class ErrorHandlingMiddleware(BaseMiddleware):
         return JSONRPCError(
             jsonrpc="2.0",
             id="error",
-            error={
-                "code": error_code,
-                "message": "Internal Server Error",
-                "data": {"details": error_message, "error_type": type(error).__name__},
-            },
+            error=ErrorData(
+                code=error_code,
+                message="Internal Server Error",
+                data={"details": error_message, "error_type": type(error).__name__},
+            ),
         )
 
     def _mask_sensitive_info(self, message: str) -> str:

--- a/src/mcp_server_git/git/operations.py
+++ b/src/mcp_server_git/git/operations.py
@@ -644,6 +644,9 @@ def git_add(
             else:
                 return "⚠️ No changes detected in specified files"
 
+        # Fallback (should not be reached due to parameter validation above)
+        return "❌ No files specified. Use files, add_all, update_only, or patterns parameter."
+
     except GitCommandError as e:
         # Handle GitCommandError string representation variations
         error_msg = str(e)
@@ -675,11 +678,13 @@ def _file_exists_or_in_git(repo: Repo, file: str, status_files: set) -> bool:
         if hasattr(repo_path, "_mock_name") or str(type(repo_path).__name__) == "Mock":
             # Test environment - try to work with mocked Path
             file_path = _get_mocked_file_path(repo_path, repo.working_dir, file)
-            if hasattr(file_path, "exists") and callable(file_path.exists):
-                file_exists = file_path.exists()
-                if hasattr(file_path, "is_symlink") and callable(file_path.is_symlink):
-                    file_exists = file_exists or file_path.is_symlink()
+            if hasattr(file_path, "exists") and callable(getattr(file_path, "exists", None)):
+                file_exists: bool = bool(file_path.exists())  # type: ignore[union-attr]
+                if hasattr(file_path, "is_symlink") and callable(getattr(file_path, "is_symlink", None)):
+                    file_exists = file_exists or bool(file_path.is_symlink())  # type: ignore[union-attr]
                 return file_exists or file in status_files
+            # Mock doesn't have exists method - fall back to status_files
+            return file in status_files
         else:
             # Production - normal Path operations
             file_path = repo_path / file
@@ -698,13 +703,14 @@ def _get_mocked_file_path(repo_path, working_dir: str, file: str):
         # Try the / operator
         return repo_path / file
     except (TypeError, AttributeError):
-        # Fallback: try to use Path class side_effect
+        # Fallback: try to use Path class side_effect (when Path is mocked)
         path_class = Path
-        if hasattr(path_class, "side_effect") and callable(path_class.side_effect):
+        side_effect = getattr(path_class, "side_effect", None)
+        if side_effect is not None and callable(side_effect):
             import os
 
             full_path = os.path.join(working_dir, file)
-            return path_class.side_effect(full_path)
+            return side_effect(full_path)
         else:
             # Last resort: create a basic mock
             from unittest.mock import Mock
@@ -1116,8 +1122,6 @@ def git_push(
         # GitHub HTTPS authentication handling
         if is_github and remote_url.startswith("https://"):
             # Try to load .env from current repository first
-            from pathlib import Path
-
             from dotenv import load_dotenv
 
             repo_env = Path(repo.working_dir) / ".env"

--- a/src/mcp_server_git/git/operations.py
+++ b/src/mcp_server_git/git/operations.py
@@ -678,9 +678,13 @@ def _file_exists_or_in_git(repo: Repo, file: str, status_files: set) -> bool:
         if hasattr(repo_path, "_mock_name") or str(type(repo_path).__name__) == "Mock":
             # Test environment - try to work with mocked Path
             file_path = _get_mocked_file_path(repo_path, repo.working_dir, file)
-            if hasattr(file_path, "exists") and callable(getattr(file_path, "exists", None)):
+            if hasattr(file_path, "exists") and callable(
+                getattr(file_path, "exists", None)
+            ):
                 file_exists: bool = bool(file_path.exists())  # type: ignore[union-attr]
-                if hasattr(file_path, "is_symlink") and callable(getattr(file_path, "is_symlink", None)):
+                if hasattr(file_path, "is_symlink") and callable(
+                    getattr(file_path, "is_symlink", None)
+                ):
                     file_exists = file_exists or bool(file_path.is_symlink())  # type: ignore[union-attr]
                 return file_exists or file in status_files
             # Mock doesn't have exists method - fall back to status_files
@@ -1575,7 +1579,7 @@ def git_continue(repo: Repo, operation: str) -> str:
             cwd=repo.working_dir,
             capture_output=True,
             text=True,
-            timeout=60  # 60 second timeout for continue operations
+            timeout=60,  # 60 second timeout for continue operations
         )
 
         if result.returncode == 0:
@@ -1592,7 +1596,11 @@ def git_continue(repo: Repo, operation: str) -> str:
                 error_output = result.stdout.strip()
 
             # Provide helpful error messages based on common scenarios
-            if "No rebase in progress" in error_output or "no merge in progress" in error_output or "no cherry-pick in progress" in error_output:
+            if (
+                "No rebase in progress" in error_output
+                or "no merge in progress" in error_output
+                or "no cherry-pick in progress" in error_output
+            ):
                 return f"❌ No {operation} in progress to continue"
             elif "conflicts" in error_output.lower():
                 return f"❌ Unresolved conflicts remain. Resolve conflicts before continuing {operation}"

--- a/src/mcp_server_git/github/api.py
+++ b/src/mcp_server_git/github/api.py
@@ -681,8 +681,9 @@ async def github_update_pr(
     title: str | None = None,
     body: str | None = None,
     state: str | None = None,
+    base: str | None = None,
 ) -> str:
-    """Update a pull request's title, body, or state."""
+    """Update a pull request's title, body, state, or base branch."""
     logger.debug(f"🚀 Updating PR #{pr_number} in {repo_owner}/{repo_name}")
 
     try:
@@ -696,9 +697,11 @@ async def github_update_pr(
                 if state not in ["open", "closed"]:
                     return "❌ State must be 'open' or 'closed'"
                 payload["state"] = state
+            if base is not None:
+                payload["base"] = base
 
             if not payload:
-                return "⚠️ No update parameters provided. Please specify title, body, or state."
+                return "⚠️ No update parameters provided. Please specify title, body, state, or base."
 
             response = await client.patch(
                 f"/repos/{repo_owner}/{repo_name}/pulls/{pr_number}", json=payload

--- a/src/mcp_server_git/lean/interface.py
+++ b/src/mcp_server_git/lean/interface.py
@@ -243,9 +243,15 @@ class GitLeanInterface:
                 "total_tools": len(self.tool_registry),
                 "filtered_count": len(tools),
                 "domains": {
-                    "git": len([t for t in self.tool_registry.values() if t.domain == "git"]),
-                    "github": len([t for t in self.tool_registry.values() if t.domain == "github"]),
-                    "azure": len([t for t in self.tool_registry.values() if t.domain == "azure"]),
+                    "git": len(
+                        [t for t in self.tool_registry.values() if t.domain == "git"]
+                    ),
+                    "github": len(
+                        [t for t in self.tool_registry.values() if t.domain == "github"]
+                    ),
+                    "azure": len(
+                        [t for t in self.tool_registry.values() if t.domain == "azure"]
+                    ),
                 },
                 "context_saving": f"~{len(self.tool_registry) * 0.5}K tokens saved vs traditional MCP",
             }

--- a/src/mcp_server_git/repository_binding.py
+++ b/src/mcp_server_git/repository_binding.py
@@ -137,6 +137,7 @@ class RepositoryBindingManager:
         """
         async with self._lock:
             if self._state == RepositoryBindingState.BOUND and not force:
+                assert self._binding is not None, "Binding must exist when state is BOUND"
                 raise RepositoryBindingError(
                     f"Server already bound to {self._binding.repository_path}. "
                     f"Use force=True or unbind first."
@@ -197,6 +198,7 @@ class RepositoryBindingManager:
                     "Cannot unbind protected repository. Use force=True if necessary."
                 )
 
+            assert self._binding is not None, "Binding must exist when not in UNBOUND state"
             old_binding = self._binding
             self._binding = None
             self._state = RepositoryBindingState.UNBOUND

--- a/src/mcp_server_git/repository_binding.py
+++ b/src/mcp_server_git/repository_binding.py
@@ -137,7 +137,9 @@ class RepositoryBindingManager:
         """
         async with self._lock:
             if self._state == RepositoryBindingState.BOUND and not force:
-                assert self._binding is not None, "Binding must exist when state is BOUND"
+                assert self._binding is not None, (
+                    "Binding must exist when state is BOUND"
+                )
                 raise RepositoryBindingError(
                     f"Server already bound to {self._binding.repository_path}. "
                     f"Use force=True or unbind first."
@@ -198,7 +200,9 @@ class RepositoryBindingManager:
                     "Cannot unbind protected repository. Use force=True if necessary."
                 )
 
-            assert self._binding is not None, "Binding must exist when not in UNBOUND state"
+            assert self._binding is not None, (
+                "Binding must exist when not in UNBOUND state"
+            )
             old_binding = self._binding
             self._binding = None
             self._state = RepositoryBindingState.UNBOUND

--- a/src/mcp_server_git/repository_binding_tools.py
+++ b/src/mcp_server_git/repository_binding_tools.py
@@ -110,10 +110,11 @@ async def handle_repository_bind(
             f"Binding Hash: {binding_info['binding_hash'][:16]}...\n"
             f"Session: {result['binding']['session_id']}"
         )
+    except RemoteContaminationError as e:
+        # Must catch subclass before parent class
+        return f"🚨 Remote contamination detected: {e}"
     except RepositoryBindingError as e:
         return f"❌ Repository binding failed: {e}"
-    except RemoteContaminationError as e:
-        return f"🚨 Remote contamination detected: {e}"
     except Exception as e:
         return f"💥 Unexpected error during binding: {e}"
 

--- a/src/mcp_server_git/services/github_service.py
+++ b/src/mcp_server_git/services/github_service.py
@@ -614,7 +614,7 @@ class GitHubService(DebuggableComponent):
             indent=2,
         )
 
-    def health_check(self) -> dict[str, bool | str | int | float]:
+    def health_check(self) -> dict[str, bool | str | int | float | None]:
         """Perform health check on the GitHub service."""
         return {
             "healthy": self.state.is_running and self.state.is_authenticated,

--- a/src/mcp_server_git/services/server_metrics.py
+++ b/src/mcp_server_git/services/server_metrics.py
@@ -463,7 +463,7 @@ class MetricsService(DebuggableComponent):
 
         return json.dumps(state, indent=2, default=str)
 
-    def health_check(self) -> dict[str, bool | str | int | float]:
+    def health_check(self) -> dict[str, bool | str | int | float | None]:
         """Perform a health check on the component."""
         current_time = datetime.now()
         uptime = (current_time - self._start_time).total_seconds()

--- a/tests/lean/test_main.py
+++ b/tests/lean/test_main.py
@@ -158,7 +158,5 @@ class TestLeanMain:
         runner.invoke(main, ["--repository", str(tmp_path)])
 
         # Should warn about invalid repo
-        warning_calls = [
-            call.args[0] for call in mock_logger.warning.call_args_list
-        ]
+        warning_calls = [call.args[0] for call in mock_logger.warning.call_args_list]
         assert any("not a git repository" in msg for msg in warning_calls)

--- a/tests/unit/applications/test_repo_path_resolution.py
+++ b/tests/unit/applications/test_repo_path_resolution.py
@@ -32,27 +32,24 @@ class TestRepoPathResolution:
         with tempfile.TemporaryDirectory() as tmpdir:
             repo_path = Path(tmpdir) / "test_repo"
             repo_path.mkdir()
-            
+
             # Initialize a git repository
             subprocess.run(
-                ["git", "init"], 
-                cwd=repo_path, 
-                capture_output=True, 
-                check=True
+                ["git", "init"], cwd=repo_path, capture_output=True, check=True
             )
             subprocess.run(
                 ["git", "config", "user.email", "test@example.com"],
                 cwd=repo_path,
                 capture_output=True,
-                check=True
+                check=True,
             )
             subprocess.run(
                 ["git", "config", "user.name", "Test User"],
                 cwd=repo_path,
                 capture_output=True,
-                check=True
+                check=True,
             )
-            
+
             # Create an initial commit
             test_file = repo_path / "test.txt"
             test_file.write_text("test content")
@@ -60,15 +57,15 @@ class TestRepoPathResolution:
                 ["git", "add", "test.txt"],
                 cwd=repo_path,
                 capture_output=True,
-                check=True
+                check=True,
             )
             subprocess.run(
                 ["git", "commit", "-m", "Initial commit"],
                 cwd=repo_path,
                 capture_output=True,
-                check=True
+                check=True,
             )
-            
+
             yield repo_path
 
     @pytest.fixture
@@ -94,19 +91,18 @@ class TestRepoPathResolution:
     async def test_repo_path_dot_with_bound_repo(self, server_app_with_repo, temp_repo):
         """Test that repo_path='.' resolves to bound repository."""
         # Mock the git operations to avoid actual git calls
-        with patch('mcp_server_git.git.operations.git_status') as mock_status:
+        with patch("mcp_server_git.git.operations.git_status") as mock_status:
             mock_status.return_value = "Mock status"
-            
-            with patch('mcp_server_git.utils.git_import.Repo') as mock_repo_class:
+
+            with patch("mcp_server_git.utils.git_import.Repo") as mock_repo_class:
                 mock_repo = MagicMock()
                 mock_repo_class.return_value = mock_repo
-                
+
                 # Execute tool with repo_path="."
                 result = await server_app_with_repo._execute_tool_operation(
-                    GitTools.STATUS,
-                    {"repo_path": "."}
+                    GitTools.STATUS, {"repo_path": "."}
                 )
-                
+
                 # Verify that Repo was called with the absolute path of bound repository
                 called_path = mock_repo_class.call_args[0][0]
                 assert Path(called_path).resolve() == temp_repo.resolve()
@@ -115,48 +111,48 @@ class TestRepoPathResolution:
         """Test that repo_path='.' without bound repository raises error."""
         with pytest.raises(ValueError) as exc_info:
             await server_app_no_repo._execute_tool_operation(
-                GitTools.STATUS,
-                {"repo_path": "."}
+                GitTools.STATUS, {"repo_path": "."}
             )
-        
+
         assert "Cannot determine target repository" in str(exc_info.value)
         assert "absolute" in str(exc_info.value).lower()
 
     async def test_repo_path_absolute_path(self, server_app_with_repo, temp_repo):
         """Test that absolute path is used directly."""
-        with patch('mcp_server_git.git.operations.git_status') as mock_status:
+        with patch("mcp_server_git.git.operations.git_status") as mock_status:
             mock_status.return_value = "Mock status"
-            
-            with patch('mcp_server_git.utils.git_import.Repo') as mock_repo_class:
+
+            with patch("mcp_server_git.utils.git_import.Repo") as mock_repo_class:
                 mock_repo = MagicMock()
                 mock_repo_class.return_value = mock_repo
-                
+
                 # Execute tool with absolute path
                 abs_path = str(temp_repo.resolve())
                 result = await server_app_with_repo._execute_tool_operation(
-                    GitTools.STATUS,
-                    {"repo_path": abs_path}
+                    GitTools.STATUS, {"repo_path": abs_path}
                 )
-                
+
                 # Verify that Repo was called with the provided absolute path
                 called_path = mock_repo_class.call_args[0][0]
                 assert called_path == abs_path
 
-    async def test_repo_path_none_with_bound_repo(self, server_app_with_repo, temp_repo):
+    async def test_repo_path_none_with_bound_repo(
+        self, server_app_with_repo, temp_repo
+    ):
         """Test that None repo_path uses bound repository."""
-        with patch('mcp_server_git.git.operations.git_status') as mock_status:
+        with patch("mcp_server_git.git.operations.git_status") as mock_status:
             mock_status.return_value = "Mock status"
-            
-            with patch('mcp_server_git.utils.git_import.Repo') as mock_repo_class:
+
+            with patch("mcp_server_git.utils.git_import.Repo") as mock_repo_class:
                 mock_repo = MagicMock()
                 mock_repo_class.return_value = mock_repo
-                
+
                 # Execute tool without repo_path argument
                 result = await server_app_with_repo._execute_tool_operation(
                     GitTools.STATUS,
-                    {}  # No repo_path provided
+                    {},  # No repo_path provided
                 )
-                
+
                 # Verify that Repo was called with bound repository path
                 called_path = mock_repo_class.call_args[0][0]
                 assert Path(called_path).resolve() == temp_repo.resolve()
@@ -166,9 +162,9 @@ class TestRepoPathResolution:
         with pytest.raises(ValueError) as exc_info:
             await server_app_no_repo._execute_tool_operation(
                 GitTools.STATUS,
-                {}  # No repo_path provided
+                {},  # No repo_path provided
             )
-        
+
         assert "Cannot determine target repository" in str(exc_info.value)
 
     async def test_git_init_with_path(self, server_app_no_repo):
@@ -176,16 +172,15 @@ class TestRepoPathResolution:
         with tempfile.TemporaryDirectory() as tmpdir:
             new_repo_path = Path(tmpdir) / "new_repo"
             new_repo_path.mkdir()
-            
-            with patch('mcp_server_git.git.operations.git_init') as mock_init:
+
+            with patch("mcp_server_git.git.operations.git_init") as mock_init:
                 mock_init.return_value = "Initialized"
-                
+
                 # Execute git_init with explicit path
                 result = await server_app_no_repo._execute_tool_operation(
-                    GitTools.INIT,
-                    {"repo_path": str(new_repo_path)}
+                    GitTools.INIT, {"repo_path": str(new_repo_path)}
                 )
-                
+
                 # Verify git_init was called with resolved absolute path
                 called_path = mock_init.call_args[0][0]
                 assert Path(called_path).resolve() == new_repo_path.resolve()
@@ -195,9 +190,9 @@ class TestRepoPathResolution:
         with pytest.raises(ValueError) as exc_info:
             await server_app_no_repo._execute_tool_operation(
                 GitTools.INIT,
-                {}  # No repo_path provided
+                {},  # No repo_path provided
             )
-        
+
         assert "git_init requires a repository path" in str(exc_info.value)
 
     async def test_relative_path_converted_to_absolute(self, server_app_no_repo):
@@ -207,26 +202,22 @@ class TestRepoPathResolution:
             old_cwd = os.getcwd()
             try:
                 os.chdir(tmpdir)
-                
+
                 # Create a test repo in a subdirectory
                 test_repo = Path(tmpdir) / "test_repo"
                 test_repo.mkdir()
                 subprocess.run(
-                    ["git", "init"], 
-                    cwd=test_repo, 
-                    capture_output=True, 
-                    check=True
+                    ["git", "init"], cwd=test_repo, capture_output=True, check=True
                 )
-                
-                with patch('mcp_server_git.git.operations.git_init') as mock_init:
+
+                with patch("mcp_server_git.git.operations.git_init") as mock_init:
                     mock_init.return_value = "Initialized"
-                    
+
                     # Execute with relative path
                     result = await server_app_no_repo._execute_tool_operation(
-                        GitTools.INIT,
-                        {"repo_path": "./test_repo"}
+                        GitTools.INIT, {"repo_path": "./test_repo"}
                     )
-                    
+
                     # Verify the path was converted to absolute
                     called_path = mock_init.call_args[0][0]
                     assert Path(called_path).is_absolute()
@@ -236,10 +227,12 @@ class TestRepoPathResolution:
 
     async def test_repository_resolver_instance_exists(self, server_app_with_repo):
         """Test that ServerApplication has a RepositoryResolver instance."""
-        assert hasattr(server_app_with_repo, '_repository_resolver')
+        assert hasattr(server_app_with_repo, "_repository_resolver")
         assert server_app_with_repo._repository_resolver is not None
 
-    async def test_repository_resolver_bound_path(self, server_app_with_repo, temp_repo):
+    async def test_repository_resolver_bound_path(
+        self, server_app_with_repo, temp_repo
+    ):
         """Test that RepositoryResolver is initialized with bound repository path."""
         resolver = server_app_with_repo._repository_resolver
         assert resolver.bound_repository_path is not None

--- a/tests/unit/azure/test_azure_api.py
+++ b/tests/unit/azure/test_azure_api.py
@@ -151,13 +151,11 @@ class TestAzureGetBuildLogs:
         mock_response.status = 200
         mock_response.headers = {"Content-Type": "application/json"}
         # Azure DevOps returns log content as JSON with a "value" array
-        mock_response.json = AsyncMock(return_value={
-            "value": [
-                "Build log line 1",
-                "Build log line 2",
-                "Build log line 3"
-            ]
-        })
+        mock_response.json = AsyncMock(
+            return_value={
+                "value": ["Build log line 1", "Build log line 2", "Build log line 3"]
+            }
+        )
         mock_client.get = AsyncMock(return_value=mock_response)
 
         with patch("src.mcp_server_git.azure.api.azure_client_context") as mock_context:
@@ -176,7 +174,7 @@ class TestAzureGetBuildLogs:
     async def test_get_specific_log_with_tail_lines(self):
         """Test getting a specific log with tail_lines parameter."""
         mock_client = MagicMock()
-        
+
         mock_response = AsyncMock()
         mock_response.status = 200
         mock_response.headers = {"Content-Type": "application/json"}
@@ -184,19 +182,21 @@ class TestAzureGetBuildLogs:
         log_lines = [f"Log line {i}" for i in range(1, 101)]
         mock_response.json = AsyncMock(return_value={"value": log_lines})
         mock_client.get = AsyncMock(return_value=mock_response)
-        
-        with patch('src.mcp_server_git.azure.api.azure_client_context') as mock_context:
+
+        with patch("src.mcp_server_git.azure.api.azure_client_context") as mock_context:
             mock_context.return_value.__aenter__.return_value = mock_client
-            
+
             result = await azure_get_build_logs(
                 project="myproject", build_id=123, log_id=1, tail_lines=20
             )
-            
+
             assert "Log #1" in result
             assert "Log line 81" in result  # Should start from line 81 (100 - 20 + 1)
             assert "Log line 100" in result
             # Check that early lines are not in the output (avoiding the truncation message)
-            assert "Log line 10\n" not in result  # Early line with newline to avoid matching in message
+            assert (
+                "Log line 10\n" not in result
+            )  # Early line with newline to avoid matching in message
             assert "truncated 80 lines" in result
             assert "showing last 20 of 100 lines" in result  # New format
 
@@ -246,9 +246,9 @@ class TestAzureGetFailingJobs:
         log_response = AsyncMock()
         log_response.status = 200
         log_response.headers = {"Content-Type": "application/json"}
-        log_response.json = AsyncMock(return_value={
-            "value": ["Error log line 1", "Error log line 2"]
-        })
+        log_response.json = AsyncMock(
+            return_value={"value": ["Error log line 1", "Error log line 2"]}
+        )
 
         async def mock_get(url, **kwargs):
             if "timeline" in url:

--- a/tests/unit/git/test_git_continue.py
+++ b/tests/unit/git/test_git_continue.py
@@ -44,7 +44,7 @@ class TestGitContinueSubprocessFix:
             cwd="/test/repo",
             capture_output=True,
             text=True,
-            timeout=60
+            timeout=60,
         )
 
     @patch("mcp_server_git.git.operations.subprocess.run")
@@ -70,7 +70,7 @@ class TestGitContinueSubprocessFix:
             cwd="/test/repo",
             capture_output=True,
             text=True,
-            timeout=60
+            timeout=60,
         )
 
     @patch("mcp_server_git.git.operations.subprocess.run")
@@ -96,7 +96,7 @@ class TestGitContinueSubprocessFix:
             cwd="/test/repo",
             capture_output=True,
             text=True,
-            timeout=60
+            timeout=60,
         )
 
     @patch("mcp_server_git.git.operations.subprocess.run")
@@ -165,8 +165,7 @@ class TestGitContinueSubprocessFix:
         mock_repo.working_dir = "/test/repo"
 
         mock_subprocess.side_effect = subprocess.TimeoutExpired(
-            cmd=["git", "rebase", "--continue"],
-            timeout=60
+            cmd=["git", "rebase", "--continue"], timeout=60
         )
 
         # Act


### PR DESCRIPTION
This commit fixes 30+ type errors that were previously hidden by `continue-on-error: true` in the CI workflow.

Key fixes:
- Add assertions for Optional member access (framework, config_manager)
- Fix exception ordering (JSONDecodeError before ValueError)
- Fix return type annotations for health_check methods (add None)
- Fix parameter names (detailed -> debug_level, github_token -> api_token)
- Add base parameter to github_update_pr function
- Fix possibly unbound variables (repo_path, result, start_time)
- Use ErrorData from mcp.types instead of raw dicts
- Remove redundant Path import causing shadow issues
- Fix GitHubServiceConfig usage with proper nested config

CI changes:
- Remove `continue-on-error: true` from format-check and typecheck steps
- Type errors will now properly fail CI builds

Result: 0 errors, 27 warnings (down from 30+ errors)