### PR TITLE
feat: add GitHub repository settings management tools (#41)

### DIFF
--- a/src/mcp_server_git/github/api.py
+++ b/src/mcp_server_git/github/api.py
@@ -2666,7 +2666,9 @@ async def github_get_security_analysis(
                         f"{'✅' if enabled else '❌'} Automated Security Fixes: {status}"
                     )
                 else:
-                    output.append("❌ Automated Security Fixes: DISABLED or unavailable")
+                    output.append(
+                        "❌ Automated Security Fixes: DISABLED or unavailable"
+                    )
                 checks_succeeded += 1
             except Exception as e:
                 logger.warning(f"Failed to check automated security fixes: {e}")

--- a/src/mcp_server_git/github/api.py
+++ b/src/mcp_server_git/github/api.py
@@ -1841,8 +1841,6 @@ async def github_update_repo_settings(
             if private is not None:
                 payload["private"] = private
             if visibility is not None:
-                if visibility not in ["public", "private", "internal"]:
-                    return "❌ visibility must be 'public', 'private', or 'internal'"
                 payload["visibility"] = visibility
             if has_issues is not None:
                 payload["has_issues"] = has_issues
@@ -2621,83 +2619,126 @@ async def github_get_security_analysis(
     - Automated security fixes (Dependabot security updates)
     - Secret scanning (if available)
     - Repository security settings
+
+    Each check is performed independently with graceful error handling,
+    so partial failures don't prevent other checks from completing.
     """
     logger.debug(f"🔍 Getting security analysis for {repo_owner}/{repo_name}")
 
+    output = [f"Security Analysis for {repo_owner}/{repo_name}:\n"]
+    checks_succeeded = 0
+    checks_failed = 0
+
     try:
         async with github_client_context() as client:
-            output = [f"Security Analysis for {repo_owner}/{repo_name}:\n"]
-
             # Check vulnerability alerts
-            vuln_response = await client.get(
-                f"/repos/{repo_owner}/{repo_name}/vulnerability-alerts"
-            )
-            if vuln_response.status == 204:
-                output.append("✅ Vulnerability Alerts (Dependabot): ENABLED")
-            else:
-                output.append("❌ Vulnerability Alerts (Dependabot): DISABLED")
+            try:
+                vuln_response = await client.get(
+                    f"/repos/{repo_owner}/{repo_name}/vulnerability-alerts"
+                )
+                if vuln_response.status == 204:
+                    output.append("✅ Vulnerability Alerts (Dependabot): ENABLED")
+                elif vuln_response.status == 404:
+                    output.append("❌ Vulnerability Alerts (Dependabot): DISABLED")
+                else:
+                    output.append(
+                        f"⚠️ Vulnerability Alerts: Unable to determine (HTTP {vuln_response.status})"
+                    )
+                checks_succeeded += 1
+            except Exception as e:
+                logger.warning(f"Failed to check vulnerability alerts: {e}")
+                output.append(f"⚠️ Vulnerability Alerts: Check failed ({e})")
+                checks_failed += 1
 
             # Check automated security fixes
-            auto_response = await client.get(
-                f"/repos/{repo_owner}/{repo_name}/automated-security-fixes"
-            )
-            if auto_response.status == 200:
-                auto_data = await auto_response.json()
-                enabled = auto_data.get("enabled", False)
-                paused = auto_data.get("paused", False)
-                status = "ENABLED" if enabled else "DISABLED"
-                if paused:
-                    status += " (PAUSED)"
-                output.append(
-                    f"{'✅' if enabled else '❌'} Automated Security Fixes: {status}"
+            try:
+                auto_response = await client.get(
+                    f"/repos/{repo_owner}/{repo_name}/automated-security-fixes"
                 )
-            else:
-                output.append("❌ Automated Security Fixes: DISABLED or unavailable")
+                if auto_response.status == 200:
+                    auto_data = await auto_response.json()
+                    enabled = auto_data.get("enabled", False)
+                    paused = auto_data.get("paused", False)
+                    status = "ENABLED" if enabled else "DISABLED"
+                    if paused:
+                        status += " (PAUSED)"
+                    output.append(
+                        f"{'✅' if enabled else '❌'} Automated Security Fixes: {status}"
+                    )
+                else:
+                    output.append("❌ Automated Security Fixes: DISABLED or unavailable")
+                checks_succeeded += 1
+            except Exception as e:
+                logger.warning(f"Failed to check automated security fixes: {e}")
+                output.append(f"⚠️ Automated Security Fixes: Check failed ({e})")
+                checks_failed += 1
 
             # Get repository settings for additional security info
-            repo_response = await client.get(f"/repos/{repo_owner}/{repo_name}")
-            if repo_response.status == 200:
-                repo_data = await repo_response.json()
+            try:
+                repo_response = await client.get(f"/repos/{repo_owner}/{repo_name}")
+                if repo_response.status == 200:
+                    repo_data = await repo_response.json()
 
-                # Security-related repo settings
-                output.append("\n📋 Repository Security Settings:")
-                output.append(
-                    f"   Visibility: {repo_data.get('visibility', 'unknown')}"
-                )
-                output.append(
-                    f"   Private: {'✅' if repo_data.get('private') else '❌'}"
-                )
-                output.append(
-                    f"   Archived: {'✅' if repo_data.get('archived') else '❌'}"
-                )
-
-                # Check for security policy
-                security_policy = repo_data.get("security_and_analysis", {})
-                if security_policy:
-                    output.append("\n🔐 Security & Analysis Features:")
-
-                    # Secret scanning
-                    secret_scanning = security_policy.get("secret_scanning", {})
-                    if secret_scanning.get("status") == "enabled":
-                        output.append("   ✅ Secret Scanning: ENABLED")
-                    else:
-                        output.append("   ❌ Secret Scanning: DISABLED")
-
-                    # Secret scanning push protection
-                    push_protection = security_policy.get(
-                        "secret_scanning_push_protection", {}
+                    # Security-related repo settings
+                    output.append("\n📋 Repository Security Settings:")
+                    output.append(
+                        f"   Visibility: {repo_data.get('visibility', 'unknown')}"
                     )
-                    if push_protection.get("status") == "enabled":
-                        output.append("   ✅ Secret Scanning Push Protection: ENABLED")
-                    else:
-                        output.append("   ❌ Secret Scanning Push Protection: DISABLED")
+                    output.append(
+                        f"   Private: {'✅' if repo_data.get('private') else '❌'}"
+                    )
+                    output.append(
+                        f"   Archived: {'✅' if repo_data.get('archived') else '❌'}"
+                    )
 
-                    # Dependabot security updates
-                    dependabot = security_policy.get("dependabot_security_updates", {})
-                    if dependabot.get("status") == "enabled":
-                        output.append("   ✅ Dependabot Security Updates: ENABLED")
-                    else:
-                        output.append("   ❌ Dependabot Security Updates: DISABLED")
+                    # Check for security policy
+                    security_policy = repo_data.get("security_and_analysis", {})
+                    if security_policy:
+                        output.append("\n🔐 Security & Analysis Features:")
+
+                        # Secret scanning
+                        secret_scanning = security_policy.get("secret_scanning", {})
+                        if secret_scanning.get("status") == "enabled":
+                            output.append("   ✅ Secret Scanning: ENABLED")
+                        else:
+                            output.append("   ❌ Secret Scanning: DISABLED")
+
+                        # Secret scanning push protection
+                        push_protection = security_policy.get(
+                            "secret_scanning_push_protection", {}
+                        )
+                        if push_protection.get("status") == "enabled":
+                            output.append(
+                                "   ✅ Secret Scanning Push Protection: ENABLED"
+                            )
+                        else:
+                            output.append(
+                                "   ❌ Secret Scanning Push Protection: DISABLED"
+                            )
+
+                        # Dependabot security updates
+                        dependabot = security_policy.get(
+                            "dependabot_security_updates", {}
+                        )
+                        if dependabot.get("status") == "enabled":
+                            output.append("   ✅ Dependabot Security Updates: ENABLED")
+                        else:
+                            output.append("   ❌ Dependabot Security Updates: DISABLED")
+                else:
+                    output.append(
+                        f"\n⚠️ Repository Settings: Unable to fetch (HTTP {repo_response.status})"
+                    )
+                checks_succeeded += 1
+            except Exception as e:
+                logger.warning(f"Failed to get repository settings: {e}")
+                output.append(f"\n⚠️ Repository Settings: Check failed ({e})")
+                checks_failed += 1
+
+            # Add summary if there were any failures
+            if checks_failed > 0:
+                output.append(
+                    f"\n⚠️ Note: {checks_failed} of {checks_succeeded + checks_failed} checks failed"
+                )
 
             output.append(
                 f"\n🔗 Security Settings: https://github.com/{repo_owner}/{repo_name}/settings/security_analysis"

--- a/src/mcp_server_git/github/api.py
+++ b/src/mcp_server_git/github/api.py
@@ -1709,6 +1709,1013 @@ async def github_await_workflow_completion(
         return f"Error awaiting workflow completion: {str(e)}"
 
 
+# ============================================================================
+# Repository Settings Management (Issue #41)
+# ============================================================================
+
+
+async def github_get_repo_settings(
+    repo_owner: str,
+    repo_name: str,
+) -> str:
+    """Get repository settings including features, merge options, and security settings."""
+    logger.debug(f"🔍 Getting repository settings for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.get(f"/repos/{repo_owner}/{repo_name}")
+
+            if response.status == 404:
+                return f"❌ Repository {repo_owner}/{repo_name} not found"
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to get repository settings: {response.status} - {error_text}"
+
+            repo = await response.json()
+
+            output = [f"Repository Settings for {repo_owner}/{repo_name}:\n"]
+
+            # Basic info
+            output.append("📋 Basic Information:")
+            output.append(f"   Name: {repo.get('name')}")
+            output.append(f"   Description: {repo.get('description') or '(none)'}")
+            output.append(f"   Visibility: {repo.get('visibility', 'unknown')}")
+            output.append(f"   Default Branch: {repo.get('default_branch')}")
+            output.append(f"   Homepage: {repo.get('homepage') or '(none)'}")
+            output.append("")
+
+            # Features
+            output.append("🔧 Features:")
+            output.append(f"   Issues: {'✅' if repo.get('has_issues') else '❌'}")
+            output.append(f"   Wiki: {'✅' if repo.get('has_wiki') else '❌'}")
+            output.append(f"   Projects: {'✅' if repo.get('has_projects') else '❌'}")
+            output.append(
+                f"   Discussions: {'✅' if repo.get('has_discussions') else '❌'}"
+            )
+            output.append("")
+
+            # Merge settings
+            output.append("🔀 Merge Settings:")
+            output.append(
+                f"   Allow Merge Commits: {'✅' if repo.get('allow_merge_commit') else '❌'}"
+            )
+            output.append(
+                f"   Allow Squash Merging: {'✅' if repo.get('allow_squash_merge') else '❌'}"
+            )
+            output.append(
+                f"   Allow Rebase Merging: {'✅' if repo.get('allow_rebase_merge') else '❌'}"
+            )
+            output.append(
+                f"   Allow Auto-merge: {'✅' if repo.get('allow_auto_merge') else '❌'}"
+            )
+            output.append(
+                f"   Delete Branch on Merge: {'✅' if repo.get('delete_branch_on_merge') else '❌'}"
+            )
+            output.append(
+                f"   Allow Update Branch: {'✅' if repo.get('allow_update_branch') else '❌'}"
+            )
+            output.append("")
+
+            # Security
+            output.append("🔒 Security:")
+            output.append(f"   Archived: {'✅' if repo.get('archived') else '❌'}")
+            output.append(
+                f"   Web Commit Signoff Required: {'✅' if repo.get('web_commit_signoff_required') else '❌'}"
+            )
+            output.append("")
+
+            # URLs
+            output.append("🔗 URLs:")
+            output.append(f"   HTML: {repo.get('html_url')}")
+            output.append(f"   Clone: {repo.get('clone_url')}")
+
+            return "\n".join(output)
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error getting repo settings: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error getting repo settings: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error getting repo settings: {e}", exc_info=True)
+        return f"❌ Error getting repository settings: {str(e)}"
+
+
+async def github_update_repo_settings(
+    repo_owner: str,
+    repo_name: str,
+    description: str | None = None,
+    homepage: str | None = None,
+    private: bool | None = None,
+    visibility: str | None = None,
+    has_issues: bool | None = None,
+    has_projects: bool | None = None,
+    has_wiki: bool | None = None,
+    has_discussions: bool | None = None,
+    allow_squash_merge: bool | None = None,
+    allow_merge_commit: bool | None = None,
+    allow_rebase_merge: bool | None = None,
+    allow_auto_merge: bool | None = None,
+    delete_branch_on_merge: bool | None = None,
+    allow_update_branch: bool | None = None,
+    squash_merge_commit_title: str | None = None,
+    squash_merge_commit_message: str | None = None,
+    merge_commit_title: str | None = None,
+    merge_commit_message: str | None = None,
+    archived: bool | None = None,
+    web_commit_signoff_required: bool | None = None,
+) -> str:
+    """Update repository settings."""
+    logger.debug(f"🚀 Updating repository settings for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            payload: dict[str, Any] = {}
+
+            # Build payload with only provided values
+            if description is not None:
+                payload["description"] = description
+            if homepage is not None:
+                payload["homepage"] = homepage
+            if private is not None:
+                payload["private"] = private
+            if visibility is not None:
+                if visibility not in ["public", "private", "internal"]:
+                    return "❌ visibility must be 'public', 'private', or 'internal'"
+                payload["visibility"] = visibility
+            if has_issues is not None:
+                payload["has_issues"] = has_issues
+            if has_projects is not None:
+                payload["has_projects"] = has_projects
+            if has_wiki is not None:
+                payload["has_wiki"] = has_wiki
+            if has_discussions is not None:
+                payload["has_discussions"] = has_discussions
+            if allow_squash_merge is not None:
+                payload["allow_squash_merge"] = allow_squash_merge
+            if allow_merge_commit is not None:
+                payload["allow_merge_commit"] = allow_merge_commit
+            if allow_rebase_merge is not None:
+                payload["allow_rebase_merge"] = allow_rebase_merge
+            if allow_auto_merge is not None:
+                payload["allow_auto_merge"] = allow_auto_merge
+            if delete_branch_on_merge is not None:
+                payload["delete_branch_on_merge"] = delete_branch_on_merge
+            if allow_update_branch is not None:
+                payload["allow_update_branch"] = allow_update_branch
+            if squash_merge_commit_title is not None:
+                payload["squash_merge_commit_title"] = squash_merge_commit_title
+            if squash_merge_commit_message is not None:
+                payload["squash_merge_commit_message"] = squash_merge_commit_message
+            if merge_commit_title is not None:
+                payload["merge_commit_title"] = merge_commit_title
+            if merge_commit_message is not None:
+                payload["merge_commit_message"] = merge_commit_message
+            if archived is not None:
+                payload["archived"] = archived
+            if web_commit_signoff_required is not None:
+                payload["web_commit_signoff_required"] = web_commit_signoff_required
+
+            if not payload:
+                return "⚠️ No update parameters provided"
+
+            response = await client.patch(
+                f"/repos/{repo_owner}/{repo_name}", json=payload
+            )
+
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to update repository settings: {response.status} - {error_text}"
+
+            result = await response.json()
+            updated_fields = list(payload.keys())
+            logger.info(
+                f"✅ Successfully updated repository settings: {updated_fields}"
+            )
+            return f"✅ Successfully updated repository settings for {result['full_name']}\nUpdated fields: {', '.join(updated_fields)}"
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error updating repo settings: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error updating repo settings: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error updating repo settings: {e}", exc_info=True)
+        return f"❌ Error updating repository settings: {str(e)}"
+
+
+# ============================================================================
+# GitHub Actions Configuration (Issue #41)
+# ============================================================================
+
+
+async def github_get_actions_permissions(
+    repo_owner: str,
+    repo_name: str,
+) -> str:
+    """Get GitHub Actions permissions for a repository."""
+    logger.debug(f"🔍 Getting Actions permissions for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.get(
+                f"/repos/{repo_owner}/{repo_name}/actions/permissions"
+            )
+
+            if response.status == 404:
+                return f"❌ Repository {repo_owner}/{repo_name} not found or Actions not enabled"
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to get Actions permissions: {response.status} - {error_text}"
+
+            data = await response.json()
+
+            output = [f"GitHub Actions Permissions for {repo_owner}/{repo_name}:\n"]
+            output.append(f"Enabled: {'✅' if data.get('enabled') else '❌'}")
+            output.append(f"Allowed Actions: {data.get('allowed_actions', 'N/A')}")
+
+            if data.get("selected_actions_url"):
+                output.append(f"Selected Actions URL: {data['selected_actions_url']}")
+
+            return "\n".join(output)
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error getting Actions permissions: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error getting Actions permissions: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error getting Actions permissions: {e}", exc_info=True
+        )
+        return f"❌ Error getting Actions permissions: {str(e)}"
+
+
+async def github_update_actions_permissions(
+    repo_owner: str,
+    repo_name: str,
+    enabled: bool | None = None,
+    allowed_actions: str | None = None,
+) -> str:
+    """Update GitHub Actions permissions for a repository."""
+    logger.debug(f"🚀 Updating Actions permissions for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            payload: dict[str, Any] = {}
+
+            if enabled is not None:
+                payload["enabled"] = enabled
+            if allowed_actions is not None:
+                if allowed_actions not in ["all", "local_only", "selected"]:
+                    return (
+                        "❌ allowed_actions must be 'all', 'local_only', or 'selected'"
+                    )
+                payload["allowed_actions"] = allowed_actions
+
+            if not payload:
+                return "⚠️ No update parameters provided"
+
+            response = await client.put(
+                f"/repos/{repo_owner}/{repo_name}/actions/permissions", json=payload
+            )
+
+            if response.status not in [200, 204]:
+                error_text = await response.text()
+                return f"❌ Failed to update Actions permissions: {response.status} - {error_text}"
+
+            logger.info("Successfully updated Actions permissions")
+            return f"✅ Successfully updated GitHub Actions permissions for {repo_owner}/{repo_name}"
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error updating Actions permissions: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error updating Actions permissions: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error updating Actions permissions: {e}", exc_info=True
+        )
+        return f"❌ Error updating Actions permissions: {str(e)}"
+
+
+async def github_get_workflow_permissions(
+    repo_owner: str,
+    repo_name: str,
+) -> str:
+    """Get default workflow permissions for a repository."""
+    logger.debug(f"🔍 Getting workflow permissions for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.get(
+                f"/repos/{repo_owner}/{repo_name}/actions/permissions/workflow"
+            )
+
+            if response.status == 404:
+                return f"❌ Repository {repo_owner}/{repo_name} not found"
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to get workflow permissions: {response.status} - {error_text}"
+
+            data = await response.json()
+
+            output = [f"Workflow Permissions for {repo_owner}/{repo_name}:\n"]
+            output.append(
+                f"Default Permissions: {data.get('default_workflow_permissions', 'N/A')}"
+            )
+            output.append(
+                f"Can Approve PR Reviews: {'✅' if data.get('can_approve_pull_request_reviews') else '❌'}"
+            )
+
+            return "\n".join(output)
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error getting workflow permissions: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error getting workflow permissions: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error getting workflow permissions: {e}", exc_info=True
+        )
+        return f"❌ Error getting workflow permissions: {str(e)}"
+
+
+async def github_update_workflow_permissions(
+    repo_owner: str,
+    repo_name: str,
+    default_workflow_permissions: str | None = None,
+    can_approve_pull_request_reviews: bool | None = None,
+) -> str:
+    """Update default workflow permissions for a repository."""
+    logger.debug(f"🚀 Updating workflow permissions for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            payload: dict[str, Any] = {}
+
+            if default_workflow_permissions is not None:
+                if default_workflow_permissions not in ["read", "write"]:
+                    return "❌ default_workflow_permissions must be 'read' or 'write'"
+                payload["default_workflow_permissions"] = default_workflow_permissions
+            if can_approve_pull_request_reviews is not None:
+                payload["can_approve_pull_request_reviews"] = (
+                    can_approve_pull_request_reviews
+                )
+
+            if not payload:
+                return "⚠️ No update parameters provided"
+
+            response = await client.put(
+                f"/repos/{repo_owner}/{repo_name}/actions/permissions/workflow",
+                json=payload,
+            )
+
+            if response.status not in [200, 204]:
+                error_text = await response.text()
+                return f"❌ Failed to update workflow permissions: {response.status} - {error_text}"
+
+            logger.info("Successfully updated workflow permissions")
+            return f"✅ Successfully updated workflow permissions for {repo_owner}/{repo_name}"
+
+    except ValueError as auth_error:
+        logger.error(
+            f"Authentication error updating workflow permissions: {auth_error}"
+        )
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error updating workflow permissions: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error updating workflow permissions: {e}", exc_info=True
+        )
+        return f"❌ Error updating workflow permissions: {str(e)}"
+
+
+# ============================================================================
+# Branch Protection Rules (Issue #41)
+# ============================================================================
+
+
+async def github_get_branch_protection(
+    repo_owner: str,
+    repo_name: str,
+    branch: str,
+) -> str:
+    """Get branch protection rules for a specific branch."""
+    logger.debug(f"🔍 Getting branch protection for {repo_owner}/{repo_name}:{branch}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.get(
+                f"/repos/{repo_owner}/{repo_name}/branches/{branch}/protection"
+            )
+
+            if response.status == 404:
+                return f"❌ Branch protection not found for {branch}. The branch may not exist or have no protection rules."
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to get branch protection: {response.status} - {error_text}"
+
+            data = await response.json()
+
+            output = [f"Branch Protection for {repo_owner}/{repo_name}:{branch}\n"]
+
+            # Required status checks
+            if data.get("required_status_checks"):
+                checks = data["required_status_checks"]
+                output.append("✅ Required Status Checks:")
+                output.append(f"   Strict: {'✅' if checks.get('strict') else '❌'}")
+                contexts = checks.get("contexts", [])
+                if contexts:
+                    output.append(f"   Contexts: {', '.join(contexts)}")
+                else:
+                    output.append("   Contexts: (none)")
+            else:
+                output.append("❌ Required Status Checks: Not configured")
+
+            # Required PR reviews
+            if data.get("required_pull_request_reviews"):
+                reviews = data["required_pull_request_reviews"]
+                output.append("\n✅ Required Pull Request Reviews:")
+                output.append(
+                    f"   Dismiss Stale Reviews: {'✅' if reviews.get('dismiss_stale_reviews') else '❌'}"
+                )
+                output.append(
+                    f"   Require Code Owner Reviews: {'✅' if reviews.get('require_code_owner_reviews') else '❌'}"
+                )
+                output.append(
+                    f"   Required Approving Review Count: {reviews.get('required_approving_review_count', 0)}"
+                )
+                output.append(
+                    f"   Require Last Push Approval: {'✅' if reviews.get('require_last_push_approval') else '❌'}"
+                )
+            else:
+                output.append("\n❌ Required Pull Request Reviews: Not configured")
+
+            # Enforce admins
+            if data.get("enforce_admins"):
+                output.append(
+                    f"\n👮 Enforce Admins: {'✅' if data['enforce_admins'].get('enabled') else '❌'}"
+                )
+
+            # Restrictions
+            if data.get("restrictions"):
+                output.append("\n🔒 Push Restrictions: Enabled")
+                restrictions = data["restrictions"]
+                if restrictions.get("users"):
+                    users = [u["login"] for u in restrictions["users"]]
+                    output.append(f"   Users: {', '.join(users)}")
+                if restrictions.get("teams"):
+                    teams = [t["slug"] for t in restrictions["teams"]]
+                    output.append(f"   Teams: {', '.join(teams)}")
+            else:
+                output.append("\n🔓 Push Restrictions: Not configured")
+
+            # Other settings
+            output.append("\n📋 Other Settings:")
+            output.append(
+                f"   Required Linear History: {'✅' if data.get('required_linear_history', {}).get('enabled') else '❌'}"
+            )
+            output.append(
+                f"   Allow Force Pushes: {'✅' if data.get('allow_force_pushes', {}).get('enabled') else '❌'}"
+            )
+            output.append(
+                f"   Allow Deletions: {'✅' if data.get('allow_deletions', {}).get('enabled') else '❌'}"
+            )
+            output.append(
+                f"   Required Conversation Resolution: {'✅' if data.get('required_conversation_resolution', {}).get('enabled') else '❌'}"
+            )
+            output.append(
+                f"   Lock Branch: {'✅' if data.get('lock_branch', {}).get('enabled') else '❌'}"
+            )
+
+            return "\n".join(output)
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error getting branch protection: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error getting branch protection: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error getting branch protection: {e}", exc_info=True)
+        return f"❌ Error getting branch protection: {str(e)}"
+
+
+async def github_update_branch_protection(
+    repo_owner: str,
+    repo_name: str,
+    branch: str,
+    required_status_checks_strict: bool | None = None,
+    required_status_checks_contexts: list[str] | None = None,
+    require_pull_request_reviews: bool | None = None,
+    dismiss_stale_reviews: bool | None = None,
+    require_code_owner_reviews: bool | None = None,
+    required_approving_review_count: int | None = None,
+    require_last_push_approval: bool | None = None,
+    enforce_admins: bool | None = None,
+    restrict_pushes: bool | None = None,
+    push_allowances_users: list[str] | None = None,
+    push_allowances_teams: list[str] | None = None,
+    required_linear_history: bool | None = None,
+    allow_force_pushes: bool | None = None,
+    allow_deletions: bool | None = None,
+    block_creations: bool | None = None,
+    required_conversation_resolution: bool | None = None,
+    lock_branch: bool | None = None,
+    allow_fork_syncing: bool | None = None,
+) -> str:
+    """Create or update branch protection rules."""
+    logger.debug(f"🚀 Updating branch protection for {repo_owner}/{repo_name}:{branch}")
+
+    try:
+        async with github_client_context() as client:
+            # Build the protection rules payload
+            # GitHub API requires specific structure for branch protection
+            payload: dict[str, Any] = {}
+
+            # Required status checks
+            if (
+                required_status_checks_strict is not None
+                or required_status_checks_contexts is not None
+            ):
+                payload["required_status_checks"] = {
+                    "strict": required_status_checks_strict or False,
+                    "contexts": required_status_checks_contexts or [],
+                }
+            else:
+                payload["required_status_checks"] = None
+
+            # Required pull request reviews
+            if require_pull_request_reviews:
+                pr_reviews: dict[str, Any] = {}
+                if dismiss_stale_reviews is not None:
+                    pr_reviews["dismiss_stale_reviews"] = dismiss_stale_reviews
+                if require_code_owner_reviews is not None:
+                    pr_reviews["require_code_owner_reviews"] = (
+                        require_code_owner_reviews
+                    )
+                if required_approving_review_count is not None:
+                    pr_reviews["required_approving_review_count"] = (
+                        required_approving_review_count
+                    )
+                if require_last_push_approval is not None:
+                    pr_reviews["require_last_push_approval"] = (
+                        require_last_push_approval
+                    )
+                payload["required_pull_request_reviews"] = pr_reviews or None
+            else:
+                payload["required_pull_request_reviews"] = None
+
+            # Enforce admins
+            payload["enforce_admins"] = (
+                enforce_admins if enforce_admins is not None else False
+            )
+
+            # Restrictions
+            if restrict_pushes:
+                restrictions: dict[str, Any] = {
+                    "users": push_allowances_users or [],
+                    "teams": push_allowances_teams or [],
+                }
+                payload["restrictions"] = restrictions
+            else:
+                payload["restrictions"] = None
+
+            # Other settings
+            if required_linear_history is not None:
+                payload["required_linear_history"] = required_linear_history
+            if allow_force_pushes is not None:
+                payload["allow_force_pushes"] = allow_force_pushes
+            if allow_deletions is not None:
+                payload["allow_deletions"] = allow_deletions
+            if block_creations is not None:
+                payload["block_creations"] = block_creations
+            if required_conversation_resolution is not None:
+                payload["required_conversation_resolution"] = (
+                    required_conversation_resolution
+                )
+            if lock_branch is not None:
+                payload["lock_branch"] = lock_branch
+            if allow_fork_syncing is not None:
+                payload["allow_fork_syncing"] = allow_fork_syncing
+
+            response = await client.put(
+                f"/repos/{repo_owner}/{repo_name}/branches/{branch}/protection",
+                json=payload,
+            )
+
+            if response.status not in [200, 201]:
+                error_text = await response.text()
+                return f"❌ Failed to update branch protection: {response.status} - {error_text}"
+
+            logger.info(f"✅ Successfully updated branch protection for {branch}")
+            return f"✅ Successfully updated branch protection for {repo_owner}/{repo_name}:{branch}"
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error updating branch protection: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error updating branch protection: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error updating branch protection: {e}", exc_info=True)
+        return f"❌ Error updating branch protection: {str(e)}"
+
+
+async def github_delete_branch_protection(
+    repo_owner: str,
+    repo_name: str,
+    branch: str,
+) -> str:
+    """Delete branch protection rules."""
+    logger.debug(f"🚀 Deleting branch protection for {repo_owner}/{repo_name}:{branch}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.delete(
+                f"/repos/{repo_owner}/{repo_name}/branches/{branch}/protection"
+            )
+
+            if response.status == 404:
+                return f"❌ Branch protection not found for {branch}"
+            if response.status != 204:
+                error_text = await response.text()
+                return f"❌ Failed to delete branch protection: {response.status} - {error_text}"
+
+            logger.info(f"✅ Successfully deleted branch protection for {branch}")
+            return f"✅ Successfully deleted branch protection for {repo_owner}/{repo_name}:{branch}"
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error deleting branch protection: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error deleting branch protection: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error deleting branch protection: {e}", exc_info=True)
+        return f"❌ Error deleting branch protection: {str(e)}"
+
+
+# ============================================================================
+# Security & Compliance (Issue #41)
+# ============================================================================
+
+
+async def github_get_vulnerability_alerts(
+    repo_owner: str,
+    repo_name: str,
+) -> str:
+    """Check if vulnerability alerts (Dependabot alerts) are enabled."""
+    logger.debug(f"🔍 Getting vulnerability alerts status for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.get(
+                f"/repos/{repo_owner}/{repo_name}/vulnerability-alerts"
+            )
+
+            if response.status == 204:
+                return f"✅ Vulnerability alerts (Dependabot) are ENABLED for {repo_owner}/{repo_name}"
+            elif response.status == 404:
+                return f"❌ Vulnerability alerts (Dependabot) are DISABLED for {repo_owner}/{repo_name}"
+            else:
+                error_text = await response.text()
+                return f"❌ Failed to check vulnerability alerts: {response.status} - {error_text}"
+
+    except ValueError as auth_error:
+        logger.error(
+            f"Authentication error checking vulnerability alerts: {auth_error}"
+        )
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error checking vulnerability alerts: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error checking vulnerability alerts: {e}", exc_info=True
+        )
+        return f"❌ Error checking vulnerability alerts: {str(e)}"
+
+
+async def github_enable_vulnerability_alerts(
+    repo_owner: str,
+    repo_name: str,
+) -> str:
+    """Enable vulnerability alerts (Dependabot alerts) for a repository."""
+    logger.debug(f"🚀 Enabling vulnerability alerts for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.put(
+                f"/repos/{repo_owner}/{repo_name}/vulnerability-alerts"
+            )
+
+            if response.status == 204:
+                logger.info(
+                    f"✅ Enabled vulnerability alerts for {repo_owner}/{repo_name}"
+                )
+                return f"✅ Successfully enabled vulnerability alerts (Dependabot) for {repo_owner}/{repo_name}"
+            else:
+                error_text = await response.text()
+                return f"❌ Failed to enable vulnerability alerts: {response.status} - {error_text}"
+
+    except ValueError as auth_error:
+        logger.error(
+            f"Authentication error enabling vulnerability alerts: {auth_error}"
+        )
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error enabling vulnerability alerts: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error enabling vulnerability alerts: {e}", exc_info=True
+        )
+        return f"❌ Error enabling vulnerability alerts: {str(e)}"
+
+
+async def github_disable_vulnerability_alerts(
+    repo_owner: str,
+    repo_name: str,
+) -> str:
+    """Disable vulnerability alerts (Dependabot alerts) for a repository."""
+    logger.debug(f"🚀 Disabling vulnerability alerts for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.delete(
+                f"/repos/{repo_owner}/{repo_name}/vulnerability-alerts"
+            )
+
+            if response.status == 204:
+                logger.info(
+                    f"✅ Disabled vulnerability alerts for {repo_owner}/{repo_name}"
+                )
+                return f"✅ Successfully disabled vulnerability alerts (Dependabot) for {repo_owner}/{repo_name}"
+            else:
+                error_text = await response.text()
+                return f"❌ Failed to disable vulnerability alerts: {response.status} - {error_text}"
+
+    except ValueError as auth_error:
+        logger.error(
+            f"Authentication error disabling vulnerability alerts: {auth_error}"
+        )
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error disabling vulnerability alerts: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error disabling vulnerability alerts: {e}", exc_info=True
+        )
+        return f"❌ Error disabling vulnerability alerts: {str(e)}"
+
+
+async def github_get_automated_security_fixes(
+    repo_owner: str,
+    repo_name: str,
+) -> str:
+    """Check if automated security fixes (Dependabot security updates) are enabled."""
+    logger.debug(
+        f"🔍 Getting automated security fixes status for {repo_owner}/{repo_name}"
+    )
+
+    try:
+        async with github_client_context() as client:
+            response = await client.get(
+                f"/repos/{repo_owner}/{repo_name}/automated-security-fixes"
+            )
+
+            if response.status == 200:
+                data = await response.json()
+                enabled = data.get("enabled", False)
+                paused = data.get("paused", False)
+
+                status_parts = []
+                if enabled:
+                    status_parts.append("ENABLED")
+                else:
+                    status_parts.append("DISABLED")
+                if paused:
+                    status_parts.append("(PAUSED)")
+
+                return f"{'✅' if enabled else '❌'} Automated security fixes (Dependabot security updates) are {' '.join(status_parts)} for {repo_owner}/{repo_name}"
+            elif response.status == 404:
+                return f"❌ Automated security fixes feature not available or disabled for {repo_owner}/{repo_name}"
+            else:
+                error_text = await response.text()
+                return f"❌ Failed to check automated security fixes: {response.status} - {error_text}"
+
+    except ValueError as auth_error:
+        logger.error(
+            f"Authentication error checking automated security fixes: {auth_error}"
+        )
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(
+            f"Connection error checking automated security fixes: {conn_error}"
+        )
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error checking automated security fixes: {e}", exc_info=True
+        )
+        return f"❌ Error checking automated security fixes: {str(e)}"
+
+
+async def github_enable_automated_security_fixes(
+    repo_owner: str,
+    repo_name: str,
+) -> str:
+    """Enable automated security fixes (Dependabot security updates) for a repository."""
+    logger.debug(f"🚀 Enabling automated security fixes for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.put(
+                f"/repos/{repo_owner}/{repo_name}/automated-security-fixes"
+            )
+
+            if response.status == 204:
+                logger.info(
+                    f"✅ Enabled automated security fixes for {repo_owner}/{repo_name}"
+                )
+                return f"✅ Successfully enabled automated security fixes (Dependabot security updates) for {repo_owner}/{repo_name}"
+            else:
+                error_text = await response.text()
+                return f"❌ Failed to enable automated security fixes: {response.status} - {error_text}"
+
+    except ValueError as auth_error:
+        logger.error(
+            f"Authentication error enabling automated security fixes: {auth_error}"
+        )
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(
+            f"Connection error enabling automated security fixes: {conn_error}"
+        )
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error enabling automated security fixes: {e}", exc_info=True
+        )
+        return f"❌ Error enabling automated security fixes: {str(e)}"
+
+
+async def github_disable_automated_security_fixes(
+    repo_owner: str,
+    repo_name: str,
+) -> str:
+    """Disable automated security fixes (Dependabot security updates) for a repository."""
+    logger.debug(f"🚀 Disabling automated security fixes for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.delete(
+                f"/repos/{repo_owner}/{repo_name}/automated-security-fixes"
+            )
+
+            if response.status == 204:
+                logger.info(
+                    f"✅ Disabled automated security fixes for {repo_owner}/{repo_name}"
+                )
+                return f"✅ Successfully disabled automated security fixes (Dependabot security updates) for {repo_owner}/{repo_name}"
+            else:
+                error_text = await response.text()
+                return f"❌ Failed to disable automated security fixes: {response.status} - {error_text}"
+
+    except ValueError as auth_error:
+        logger.error(
+            f"Authentication error disabling automated security fixes: {auth_error}"
+        )
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(
+            f"Connection error disabling automated security fixes: {conn_error}"
+        )
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error disabling automated security fixes: {e}", exc_info=True
+        )
+        return f"❌ Error disabling automated security fixes: {str(e)}"
+
+
+async def github_get_security_analysis(
+    repo_owner: str,
+    repo_name: str,
+) -> str:
+    """Get comprehensive security analysis status for a repository.
+
+    Checks and reports on:
+    - Vulnerability alerts (Dependabot alerts)
+    - Automated security fixes (Dependabot security updates)
+    - Secret scanning (if available)
+    - Repository security settings
+    """
+    logger.debug(f"🔍 Getting security analysis for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            output = [f"Security Analysis for {repo_owner}/{repo_name}:\n"]
+
+            # Check vulnerability alerts
+            vuln_response = await client.get(
+                f"/repos/{repo_owner}/{repo_name}/vulnerability-alerts"
+            )
+            if vuln_response.status == 204:
+                output.append("✅ Vulnerability Alerts (Dependabot): ENABLED")
+            else:
+                output.append("❌ Vulnerability Alerts (Dependabot): DISABLED")
+
+            # Check automated security fixes
+            auto_response = await client.get(
+                f"/repos/{repo_owner}/{repo_name}/automated-security-fixes"
+            )
+            if auto_response.status == 200:
+                auto_data = await auto_response.json()
+                enabled = auto_data.get("enabled", False)
+                paused = auto_data.get("paused", False)
+                status = "ENABLED" if enabled else "DISABLED"
+                if paused:
+                    status += " (PAUSED)"
+                output.append(
+                    f"{'✅' if enabled else '❌'} Automated Security Fixes: {status}"
+                )
+            else:
+                output.append("❌ Automated Security Fixes: DISABLED or unavailable")
+
+            # Get repository settings for additional security info
+            repo_response = await client.get(f"/repos/{repo_owner}/{repo_name}")
+            if repo_response.status == 200:
+                repo_data = await repo_response.json()
+
+                # Security-related repo settings
+                output.append("\n📋 Repository Security Settings:")
+                output.append(
+                    f"   Visibility: {repo_data.get('visibility', 'unknown')}"
+                )
+                output.append(
+                    f"   Private: {'✅' if repo_data.get('private') else '❌'}"
+                )
+                output.append(
+                    f"   Archived: {'✅' if repo_data.get('archived') else '❌'}"
+                )
+
+                # Check for security policy
+                security_policy = repo_data.get("security_and_analysis", {})
+                if security_policy:
+                    output.append("\n🔐 Security & Analysis Features:")
+
+                    # Secret scanning
+                    secret_scanning = security_policy.get("secret_scanning", {})
+                    if secret_scanning.get("status") == "enabled":
+                        output.append("   ✅ Secret Scanning: ENABLED")
+                    else:
+                        output.append("   ❌ Secret Scanning: DISABLED")
+
+                    # Secret scanning push protection
+                    push_protection = security_policy.get(
+                        "secret_scanning_push_protection", {}
+                    )
+                    if push_protection.get("status") == "enabled":
+                        output.append("   ✅ Secret Scanning Push Protection: ENABLED")
+                    else:
+                        output.append("   ❌ Secret Scanning Push Protection: DISABLED")
+
+                    # Dependabot security updates
+                    dependabot = security_policy.get("dependabot_security_updates", {})
+                    if dependabot.get("status") == "enabled":
+                        output.append("   ✅ Dependabot Security Updates: ENABLED")
+                    else:
+                        output.append("   ❌ Dependabot Security Updates: DISABLED")
+
+            output.append(
+                f"\n🔗 Security Settings: https://github.com/{repo_owner}/{repo_name}/settings/security_analysis"
+            )
+
+            return "\n".join(output)
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error getting security analysis: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error getting security analysis: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error getting security analysis: {e}", exc_info=True)
+        return f"❌ Error getting security analysis: {str(e)}"
+
+
 async def github_list_workflow_runs(
     repo_owner: str,
     repo_name: str,

--- a/src/mcp_server_git/github/models.py
+++ b/src/mcp_server_git/github/models.py
@@ -1,6 +1,61 @@
 """Pydantic models for GitHub API tools"""
 
+import re
+
 from pydantic import BaseModel, field_validator
+
+
+# ============================================================================
+# Validation Constants
+# ============================================================================
+
+# GitHub merge commit settings
+SQUASH_MERGE_COMMIT_TITLES = frozenset({"PR_TITLE", "COMMIT_OR_PR_TITLE"})
+SQUASH_MERGE_COMMIT_MESSAGES = frozenset({"PR_BODY", "COMMIT_MESSAGES", "BLANK"})
+MERGE_COMMIT_TITLES = frozenset({"PR_TITLE", "MERGE_MESSAGE"})
+MERGE_COMMIT_MESSAGES = frozenset({"PR_BODY", "PR_TITLE", "BLANK"})
+
+# Visibility settings
+REPO_VISIBILITY_OPTIONS = frozenset({"public", "private", "internal"})
+
+# Branch name validation pattern (based on git-check-ref-format rules)
+# Invalid patterns: starts with -, contains .., ~, ^, :, \, @{, ends with .lock
+INVALID_BRANCH_PATTERNS = re.compile(
+    r"(^-|"  # starts with -
+    r"\.\.|"  # contains ..
+    r"[\x00-\x1f\x7f]|"  # control characters
+    r"~|"  # tilde
+    r"\^|"  # caret
+    r":|"  # colon
+    r"\\|"  # backslash
+    r"@\{|"  # @{
+    r"^/|"  # starts with /
+    r"/$|"  # ends with /
+    r"\.lock$)"  # ends with .lock
+)
+
+
+def validate_branch_name(branch: str) -> str:
+    """Validate branch name follows git-check-ref-format rules.
+
+    Args:
+        branch: The branch name to validate
+
+    Returns:
+        The validated branch name
+
+    Raises:
+        ValueError: If the branch name is invalid
+    """
+    if not branch or not branch.strip():
+        raise ValueError("branch name cannot be empty")
+    if INVALID_BRANCH_PATTERNS.search(branch):
+        raise ValueError(
+            f"Invalid branch name '{branch}'. Branch names cannot: "
+            "start with '-' or '/', contain '..', '~', '^', ':', '\\', '@{{', "
+            "control characters, or end with '/' or '.lock'"
+        )
+    return branch
 
 
 class GitHubGetPRChecks(BaseModel):
@@ -361,6 +416,66 @@ class GitHubUpdateRepoSettings(BaseModel):
     archived: bool | None = None
     web_commit_signoff_required: bool | None = None
 
+    @field_validator("visibility")
+    @classmethod
+    def validate_visibility(cls, v: str | None) -> str | None:
+        """Validate visibility is a valid GitHub option."""
+        if v is None:
+            return v
+        if v not in REPO_VISIBILITY_OPTIONS:
+            raise ValueError(
+                f"visibility must be one of: {', '.join(sorted(REPO_VISIBILITY_OPTIONS))}"
+            )
+        return v
+
+    @field_validator("squash_merge_commit_title")
+    @classmethod
+    def validate_squash_merge_commit_title(cls, v: str | None) -> str | None:
+        """Validate squash merge commit title option."""
+        if v is None:
+            return v
+        if v not in SQUASH_MERGE_COMMIT_TITLES:
+            raise ValueError(
+                f"squash_merge_commit_title must be one of: {', '.join(sorted(SQUASH_MERGE_COMMIT_TITLES))}"
+            )
+        return v
+
+    @field_validator("squash_merge_commit_message")
+    @classmethod
+    def validate_squash_merge_commit_message(cls, v: str | None) -> str | None:
+        """Validate squash merge commit message option."""
+        if v is None:
+            return v
+        if v not in SQUASH_MERGE_COMMIT_MESSAGES:
+            raise ValueError(
+                f"squash_merge_commit_message must be one of: {', '.join(sorted(SQUASH_MERGE_COMMIT_MESSAGES))}"
+            )
+        return v
+
+    @field_validator("merge_commit_title")
+    @classmethod
+    def validate_merge_commit_title(cls, v: str | None) -> str | None:
+        """Validate merge commit title option."""
+        if v is None:
+            return v
+        if v not in MERGE_COMMIT_TITLES:
+            raise ValueError(
+                f"merge_commit_title must be one of: {', '.join(sorted(MERGE_COMMIT_TITLES))}"
+            )
+        return v
+
+    @field_validator("merge_commit_message")
+    @classmethod
+    def validate_merge_commit_message(cls, v: str | None) -> str | None:
+        """Validate merge commit message option."""
+        if v is None:
+            return v
+        if v not in MERGE_COMMIT_MESSAGES:
+            raise ValueError(
+                f"merge_commit_message must be one of: {', '.join(sorted(MERGE_COMMIT_MESSAGES))}"
+            )
+        return v
+
 
 # ============================================================================
 # GitHub Actions Configuration Models (Issue #41)
@@ -439,6 +554,12 @@ class GitHubGetBranchProtection(BaseModel):
     repo_name: str
     branch: str
 
+    @field_validator("branch")
+    @classmethod
+    def validate_branch(cls, v: str) -> str:
+        """Validate branch name is a valid Git reference."""
+        return validate_branch_name(v)
+
 
 class GitHubUpdateBranchProtection(BaseModel):
     """Model for creating/updating branch protection rules.
@@ -476,6 +597,12 @@ class GitHubUpdateBranchProtection(BaseModel):
     lock_branch: bool | None = None
     allow_fork_syncing: bool | None = None
 
+    @field_validator("branch")
+    @classmethod
+    def validate_branch(cls, v: str) -> str:
+        """Validate branch name is a valid Git reference."""
+        return validate_branch_name(v)
+
 
 class GitHubDeleteBranchProtection(BaseModel):
     """Model for deleting branch protection rules."""
@@ -483,6 +610,12 @@ class GitHubDeleteBranchProtection(BaseModel):
     repo_owner: str
     repo_name: str
     branch: str
+
+    @field_validator("branch")
+    @classmethod
+    def validate_branch(cls, v: str) -> str:
+        """Validate branch name is a valid Git reference."""
+        return validate_branch_name(v)
 
 
 # ============================================================================

--- a/src/mcp_server_git/github/models.py
+++ b/src/mcp_server_git/github/models.py
@@ -308,3 +308,246 @@ class GitHubUpdatePR(BaseModel):
     body: str | None = None
     state: str | None = None
     base: str | None = None
+
+
+# ============================================================================
+# Repository Settings Management Models (Issue #41)
+# ============================================================================
+
+
+class GitHubGetRepoSettings(BaseModel):
+    """Model for fetching repository settings."""
+
+    repo_owner: str
+    repo_name: str
+
+
+class GitHubUpdateRepoSettings(BaseModel):
+    """Model for updating repository settings.
+
+    Configurable settings include:
+    - Visibility and access settings
+    - Feature toggles (issues, wiki, projects, discussions)
+    - Merge strategies and options
+    - Branch and security settings
+    """
+
+    repo_owner: str
+    repo_name: str
+    # Basic settings
+    description: str | None = None
+    homepage: str | None = None
+    private: bool | None = None
+    visibility: str | None = None  # public, private, internal
+    # Feature toggles
+    has_issues: bool | None = None
+    has_projects: bool | None = None
+    has_wiki: bool | None = None
+    has_discussions: bool | None = None
+    # Merge settings
+    allow_squash_merge: bool | None = None
+    allow_merge_commit: bool | None = None
+    allow_rebase_merge: bool | None = None
+    allow_auto_merge: bool | None = None
+    delete_branch_on_merge: bool | None = None
+    allow_update_branch: bool | None = None
+    # Squash merge settings
+    squash_merge_commit_title: str | None = None  # PR_TITLE, COMMIT_OR_PR_TITLE
+    squash_merge_commit_message: str | None = None  # PR_BODY, COMMIT_MESSAGES, BLANK
+    # Merge commit settings
+    merge_commit_title: str | None = None  # PR_TITLE, MERGE_MESSAGE
+    merge_commit_message: str | None = None  # PR_BODY, PR_TITLE, BLANK
+    # Security settings
+    archived: bool | None = None
+    web_commit_signoff_required: bool | None = None
+
+
+# ============================================================================
+# GitHub Actions Configuration Models (Issue #41)
+# ============================================================================
+
+
+class GitHubGetActionsPermissions(BaseModel):
+    """Model for fetching GitHub Actions permissions for a repository."""
+
+    repo_owner: str
+    repo_name: str
+
+
+class GitHubUpdateActionsPermissions(BaseModel):
+    """Model for updating GitHub Actions permissions.
+
+    Settings include:
+    - enabled: Whether GitHub Actions is enabled
+    - allowed_actions: Which actions can be used (all, local_only, selected)
+    """
+
+    repo_owner: str
+    repo_name: str
+    enabled: bool | None = None
+    allowed_actions: str | None = None  # all, local_only, selected
+
+
+class GitHubGetAllowedActions(BaseModel):
+    """Model for fetching allowed actions for a repository."""
+
+    repo_owner: str
+    repo_name: str
+
+
+class GitHubUpdateAllowedActions(BaseModel):
+    """Model for updating allowed actions.
+
+    Specifies which actions and reusable workflows are allowed.
+    """
+
+    repo_owner: str
+    repo_name: str
+    github_owned_allowed: bool | None = None
+    verified_allowed: bool | None = None
+    patterns_allowed: list[str] | None = None  # e.g., ["actions/checkout@*"]
+
+
+class GitHubGetWorkflowPermissions(BaseModel):
+    """Model for fetching default workflow permissions."""
+
+    repo_owner: str
+    repo_name: str
+
+
+class GitHubUpdateWorkflowPermissions(BaseModel):
+    """Model for updating default workflow permissions.
+
+    Controls the default permissions granted to the GITHUB_TOKEN.
+    """
+
+    repo_owner: str
+    repo_name: str
+    default_workflow_permissions: str | None = None  # read, write
+    can_approve_pull_request_reviews: bool | None = None
+
+
+# ============================================================================
+# Branch Protection Rules Models (Issue #41)
+# ============================================================================
+
+
+class GitHubGetBranchProtection(BaseModel):
+    """Model for fetching branch protection rules."""
+
+    repo_owner: str
+    repo_name: str
+    branch: str
+
+
+class GitHubUpdateBranchProtection(BaseModel):
+    """Model for creating/updating branch protection rules.
+
+    Comprehensive branch protection settings including:
+    - Required status checks
+    - Required pull request reviews
+    - Enforce admins
+    - Restrictions on who can push
+    """
+
+    repo_owner: str
+    repo_name: str
+    branch: str
+    # Required status checks
+    required_status_checks_strict: bool | None = None
+    required_status_checks_contexts: list[str] | None = None
+    # Required pull request reviews
+    require_pull_request_reviews: bool | None = None
+    dismiss_stale_reviews: bool | None = None
+    require_code_owner_reviews: bool | None = None
+    required_approving_review_count: int | None = None
+    require_last_push_approval: bool | None = None
+    # Restrictions
+    enforce_admins: bool | None = None
+    restrict_pushes: bool | None = None
+    push_allowances_users: list[str] | None = None
+    push_allowances_teams: list[str] | None = None
+    # Other settings
+    required_linear_history: bool | None = None
+    allow_force_pushes: bool | None = None
+    allow_deletions: bool | None = None
+    block_creations: bool | None = None
+    required_conversation_resolution: bool | None = None
+    lock_branch: bool | None = None
+    allow_fork_syncing: bool | None = None
+
+
+class GitHubDeleteBranchProtection(BaseModel):
+    """Model for deleting branch protection rules."""
+
+    repo_owner: str
+    repo_name: str
+    branch: str
+
+
+# ============================================================================
+# Security & Compliance Models (Issue #41)
+# ============================================================================
+
+
+class GitHubGetVulnerabilityAlerts(BaseModel):
+    """Model for checking if vulnerability alerts are enabled."""
+
+    repo_owner: str
+    repo_name: str
+
+
+class GitHubEnableVulnerabilityAlerts(BaseModel):
+    """Model for enabling vulnerability alerts (Dependabot alerts)."""
+
+    repo_owner: str
+    repo_name: str
+
+
+class GitHubDisableVulnerabilityAlerts(BaseModel):
+    """Model for disabling vulnerability alerts."""
+
+    repo_owner: str
+    repo_name: str
+
+
+class GitHubGetAutomatedSecurityFixes(BaseModel):
+    """Model for checking if automated security fixes are enabled."""
+
+    repo_owner: str
+    repo_name: str
+
+
+class GitHubEnableAutomatedSecurityFixes(BaseModel):
+    """Model for enabling automated security fixes (Dependabot security updates)."""
+
+    repo_owner: str
+    repo_name: str
+
+
+class GitHubDisableAutomatedSecurityFixes(BaseModel):
+    """Model for disabling automated security fixes."""
+
+    repo_owner: str
+    repo_name: str
+
+
+class GitHubGetSecretScanning(BaseModel):
+    """Model for getting secret scanning status."""
+
+    repo_owner: str
+    repo_name: str
+
+
+class GitHubGetSecurityAnalysis(BaseModel):
+    """Model for getting comprehensive security analysis status.
+
+    Returns status of:
+    - Vulnerability alerts (Dependabot alerts)
+    - Automated security fixes (Dependabot security updates)
+    - Secret scanning
+    - Code scanning (if available)
+    """
+
+    repo_owner: str
+    repo_name: str

--- a/src/mcp_server_git/lean/tool_registry.py
+++ b/src/mcp_server_git/lean/tool_registry.py
@@ -1,12 +1,21 @@
 """
 Tool Registry for Git Lean MCP Interface.
 
-Registers all 51 tools across git, github, and azure domains with complete metadata.
+Registers all 68 tools across git, github, and azure domains with complete metadata.
 
 Tool Distribution:
 - Git tools (25): Core git operations
-- GitHub tools (22): PR, issues, workflows
+- GitHub tools (39): PR, issues, workflows, repo settings, actions, branch protection, security
 - Azure tools (4): Build logs and status
+
+New in Issue #41:
+- Repository Settings: get_repo_settings, update_repo_settings
+- Actions Config: get_actions_permissions, update_actions_permissions,
+                  get_workflow_permissions, update_workflow_permissions
+- Branch Protection: get_branch_protection, update_branch_protection, delete_branch_protection
+- Security: get_vulnerability_alerts, enable/disable_vulnerability_alerts,
+           get_automated_security_fixes, enable/disable_automated_security_fixes,
+           get_security_analysis
 """
 
 import logging
@@ -340,19 +349,35 @@ def _register_github_tools(interface: Any, github_service: Any):
         GitHubBulkUpdateIssues,
         GitHubCreateIssue,
         GitHubCreateIssueFromTemplate,
+        GitHubDeleteBranchProtection,
+        GitHubDisableAutomatedSecurityFixes,
+        GitHubDisableVulnerabilityAlerts,
         GitHubEditPRDescription,
+        GitHubEnableAutomatedSecurityFixes,
+        GitHubEnableVulnerabilityAlerts,
+        GitHubGetActionsPermissions,
+        GitHubGetAutomatedSecurityFixes,
+        GitHubGetBranchProtection,
         GitHubGetFailingJobs,
         GitHubGetIssue,
         GitHubGetPRChecks,
         GitHubGetPRDetails,
         GitHubGetPRFiles,
         GitHubGetPRStatus,
+        GitHubGetRepoSettings,
+        GitHubGetSecurityAnalysis,
+        GitHubGetVulnerabilityAlerts,
+        GitHubGetWorkflowPermissions,
         GitHubGetWorkflowRun,
         GitHubListIssues,
         GitHubListPullRequests,
         GitHubListWorkflowRuns,
         GitHubSearchIssues,
+        GitHubUpdateActionsPermissions,
+        GitHubUpdateBranchProtection,
         GitHubUpdateIssue,
+        GitHubUpdateRepoSettings,
+        GitHubUpdateWorkflowPermissions,
     )
 
     github_tools = [
@@ -593,6 +618,138 @@ def _register_github_tools(interface: Any, github_service: Any):
             },
             domain="github",
             complexity="focused",
+        ),
+        # Repository Settings Management (Issue #41)
+        ToolDefinition(
+            name="github_get_repo_settings",
+            implementation=github_ops.github_get_repo_settings,
+            description="Get repository settings including features, merge options, and security settings",
+            schema=GitHubGetRepoSettings.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_update_repo_settings",
+            implementation=github_ops.github_update_repo_settings,
+            description="Update repository settings (merge strategies, features, security)",
+            schema=GitHubUpdateRepoSettings.model_json_schema(),
+            domain="github",
+            complexity="comprehensive",
+        ),
+        # GitHub Actions Configuration (Issue #41)
+        ToolDefinition(
+            name="github_get_actions_permissions",
+            implementation=github_ops.github_get_actions_permissions,
+            description="Get GitHub Actions permissions for a repository",
+            schema=GitHubGetActionsPermissions.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_update_actions_permissions",
+            implementation=github_ops.github_update_actions_permissions,
+            description="Update GitHub Actions permissions (enable/disable, allowed actions)",
+            schema=GitHubUpdateActionsPermissions.model_json_schema(),
+            domain="github",
+            complexity="comprehensive",
+        ),
+        ToolDefinition(
+            name="github_get_workflow_permissions",
+            implementation=github_ops.github_get_workflow_permissions,
+            description="Get default workflow permissions (GITHUB_TOKEN permissions)",
+            schema=GitHubGetWorkflowPermissions.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_update_workflow_permissions",
+            implementation=github_ops.github_update_workflow_permissions,
+            description="Update default workflow permissions and PR approval settings",
+            schema=GitHubUpdateWorkflowPermissions.model_json_schema(),
+            domain="github",
+            complexity="comprehensive",
+        ),
+        # Branch Protection Rules (Issue #41)
+        ToolDefinition(
+            name="github_get_branch_protection",
+            implementation=github_ops.github_get_branch_protection,
+            description="Get branch protection rules for a specific branch",
+            schema=GitHubGetBranchProtection.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_update_branch_protection",
+            implementation=github_ops.github_update_branch_protection,
+            description="Create or update branch protection rules (status checks, reviews, restrictions)",
+            schema=GitHubUpdateBranchProtection.model_json_schema(),
+            domain="github",
+            complexity="comprehensive",
+        ),
+        ToolDefinition(
+            name="github_delete_branch_protection",
+            implementation=github_ops.github_delete_branch_protection,
+            description="Delete branch protection rules",
+            schema=GitHubDeleteBranchProtection.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        # Security & Compliance (Issue #41)
+        ToolDefinition(
+            name="github_get_vulnerability_alerts",
+            implementation=github_ops.github_get_vulnerability_alerts,
+            description="Check if vulnerability alerts (Dependabot alerts) are enabled",
+            schema=GitHubGetVulnerabilityAlerts.model_json_schema(),
+            domain="github",
+            complexity="core",
+        ),
+        ToolDefinition(
+            name="github_enable_vulnerability_alerts",
+            implementation=github_ops.github_enable_vulnerability_alerts,
+            description="Enable vulnerability alerts (Dependabot alerts) for a repository",
+            schema=GitHubEnableVulnerabilityAlerts.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_disable_vulnerability_alerts",
+            implementation=github_ops.github_disable_vulnerability_alerts,
+            description="Disable vulnerability alerts (Dependabot alerts) for a repository",
+            schema=GitHubDisableVulnerabilityAlerts.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_get_automated_security_fixes",
+            implementation=github_ops.github_get_automated_security_fixes,
+            description="Check if automated security fixes (Dependabot security updates) are enabled",
+            schema=GitHubGetAutomatedSecurityFixes.model_json_schema(),
+            domain="github",
+            complexity="core",
+        ),
+        ToolDefinition(
+            name="github_enable_automated_security_fixes",
+            implementation=github_ops.github_enable_automated_security_fixes,
+            description="Enable automated security fixes (Dependabot security updates)",
+            schema=GitHubEnableAutomatedSecurityFixes.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_disable_automated_security_fixes",
+            implementation=github_ops.github_disable_automated_security_fixes,
+            description="Disable automated security fixes (Dependabot security updates)",
+            schema=GitHubDisableAutomatedSecurityFixes.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_get_security_analysis",
+            implementation=github_ops.github_get_security_analysis,
+            description="Get comprehensive security analysis status (vulnerability alerts, security fixes, secret scanning)",
+            schema=GitHubGetSecurityAnalysis.model_json_schema(),
+            domain="github",
+            complexity="comprehensive",
         ),
     ]
 

--- a/tests/unit/github/test_github_actions_config.py
+++ b/tests/unit/github/test_github_actions_config.py
@@ -403,7 +403,9 @@ class TestGitHubUpdateActionsPermissions:
             )
 
             assert "❌" in result
-            assert "allowed_actions must be 'all', 'local_only', or 'selected'" in result
+            assert (
+                "allowed_actions must be 'all', 'local_only', or 'selected'" in result
+            )
 
     @pytest.mark.asyncio
     async def test_no_parameters_provided(self):

--- a/tests/unit/github/test_github_actions_config.py
+++ b/tests/unit/github/test_github_actions_config.py
@@ -1,0 +1,917 @@
+"""
+Unit tests for GitHub Actions configuration functions.
+
+Tests the GitHub Actions permissions and workflow configuration functionality including:
+- github_get_actions_permissions: successful retrieval, 404 error, auth error
+- github_update_actions_permissions: successful update, invalid allowed_actions validation
+- github_get_workflow_permissions: successful retrieval, error cases
+- github_update_workflow_permissions: successful update, invalid permissions validation
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.mcp_server_git.github.api import (
+    github_get_actions_permissions,
+    github_get_workflow_permissions,
+    github_update_actions_permissions,
+    github_update_workflow_permissions,
+)
+
+
+class TestGitHubGetActionsPermissions:
+    """Test github_get_actions_permissions function."""
+
+    @pytest.mark.asyncio
+    async def test_successful_retrieval_all_enabled(self):
+        """Test retrieving Actions permissions when enabled with all actions allowed."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "enabled": True,
+                "allowed_actions": "all",
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "GitHub Actions Permissions for owner/repo:" in result
+            assert "Enabled: ✅" in result
+            assert "Allowed Actions: all" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_retrieval_local_only(self):
+        """Test retrieving Actions permissions with local_only restriction."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "enabled": True,
+                "allowed_actions": "local_only",
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "Enabled: ✅" in result
+            assert "Allowed Actions: local_only" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_retrieval_selected_actions(self):
+        """Test retrieving Actions permissions with selected actions."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "enabled": True,
+                "allowed_actions": "selected",
+                "selected_actions_url": "https://api.github.com/repos/owner/repo/actions/permissions/selected-actions",
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "Enabled: ✅" in result
+            assert "Allowed Actions: selected" in result
+            assert "Selected Actions URL:" in result
+            assert "selected-actions" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_retrieval_disabled(self):
+        """Test retrieving Actions permissions when disabled."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "enabled": False,
+                "allowed_actions": "all",
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "Enabled: ❌" in result
+            assert "Allowed Actions: all" in result
+
+    @pytest.mark.asyncio
+    async def test_repository_not_found_404(self):
+        """Test that 404 error is handled with helpful message."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Repository owner/repo not found" in result
+            assert "Actions not enabled" in result
+
+    @pytest.mark.asyncio
+    async def test_authentication_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_get_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "GitHub token not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self):
+        """Test that connection errors are handled gracefully."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_get_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Network connection failed" in result
+            assert "Network timeout" in result
+
+    @pytest.mark.asyncio
+    async def test_generic_api_error(self):
+        """Test that other API errors are reported properly."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value="Internal Server Error")
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Failed to get Actions permissions" in result
+            assert "500" in result
+            assert "Internal Server Error" in result
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_handling(self):
+        """Test that unexpected errors are caught and reported."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = RuntimeError(
+                "Unexpected error"
+            )
+
+            result = await github_get_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Error getting Actions permissions" in result
+            assert "Unexpected error" in result
+
+
+class TestGitHubUpdateActionsPermissions:
+    """Test github_update_actions_permissions function."""
+
+    @pytest.mark.asyncio
+    async def test_successful_enable_actions(self):
+        """Test successfully enabling GitHub Actions."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                enabled=True,
+            )
+
+            assert "✅" in result
+            assert "Successfully updated GitHub Actions permissions" in result
+            assert "owner/repo" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_disable_actions(self):
+        """Test successfully disabling GitHub Actions."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 204
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                enabled=False,
+            )
+
+            assert "✅" in result
+            assert "Successfully updated GitHub Actions permissions" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_update_allowed_actions_all(self):
+        """Test successfully setting allowed_actions to 'all'."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                allowed_actions="all",
+            )
+
+            assert "✅" in result
+            assert "Successfully updated GitHub Actions permissions" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_update_allowed_actions_local_only(self):
+        """Test successfully setting allowed_actions to 'local_only'."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                allowed_actions="local_only",
+            )
+
+            assert "✅" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_update_allowed_actions_selected(self):
+        """Test successfully setting allowed_actions to 'selected'."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                allowed_actions="selected",
+            )
+
+            assert "✅" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_update_both_parameters(self):
+        """Test successfully updating both enabled and allowed_actions."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                enabled=True,
+                allowed_actions="local_only",
+            )
+
+            assert "✅" in result
+            assert "Successfully updated GitHub Actions permissions" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_allowed_actions_value(self):
+        """Test that invalid allowed_actions value is rejected."""
+        # Mock the client context to prevent authentication errors
+        mock_client = MagicMock()
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                allowed_actions="invalid",
+            )
+
+            assert "❌" in result
+            assert "allowed_actions must be 'all', 'local_only', or 'selected'" in result
+
+    @pytest.mark.asyncio
+    async def test_no_parameters_provided(self):
+        """Test that no parameters provided returns warning."""
+        # Mock the client context to prevent authentication errors
+        mock_client = MagicMock()
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "⚠️" in result
+            assert "No update parameters provided" in result
+
+    @pytest.mark.asyncio
+    async def test_api_error_response(self):
+        """Test that API errors are reported properly."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 403
+        mock_response.text = AsyncMock(return_value="Forbidden")
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                enabled=True,
+            )
+
+            assert "❌" in result
+            assert "Failed to update Actions permissions" in result
+            assert "403" in result
+            assert "Forbidden" in result
+
+    @pytest.mark.asyncio
+    async def test_authentication_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_update_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                enabled=True,
+            )
+
+            assert "❌" in result
+            assert "GitHub token not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self):
+        """Test that connection errors are handled gracefully."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_update_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                enabled=True,
+            )
+
+            assert "❌" in result
+            assert "Network connection failed" in result
+            assert "Network timeout" in result
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_handling(self):
+        """Test that unexpected errors are caught and reported."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = RuntimeError(
+                "Unexpected error"
+            )
+
+            result = await github_update_actions_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                enabled=True,
+            )
+
+            assert "❌" in result
+            assert "Error updating Actions permissions" in result
+            assert "Unexpected error" in result
+
+
+class TestGitHubGetWorkflowPermissions:
+    """Test github_get_workflow_permissions function."""
+
+    @pytest.mark.asyncio
+    async def test_successful_retrieval_read_permissions(self):
+        """Test retrieving workflow permissions with read-only default."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "default_workflow_permissions": "read",
+                "can_approve_pull_request_reviews": False,
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "Workflow Permissions for owner/repo:" in result
+            assert "Default Permissions: read" in result
+            assert "Can Approve PR Reviews: ❌" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_retrieval_write_permissions(self):
+        """Test retrieving workflow permissions with write default."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "default_workflow_permissions": "write",
+                "can_approve_pull_request_reviews": True,
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "Default Permissions: write" in result
+            assert "Can Approve PR Reviews: ✅" in result
+
+    @pytest.mark.asyncio
+    async def test_repository_not_found_404(self):
+        """Test that 404 error is handled with helpful message."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Repository owner/repo not found" in result
+
+    @pytest.mark.asyncio
+    async def test_authentication_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_get_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "GitHub token not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self):
+        """Test that connection errors are handled gracefully."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_get_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Network connection failed" in result
+            assert "Network timeout" in result
+
+    @pytest.mark.asyncio
+    async def test_generic_api_error(self):
+        """Test that other API errors are reported properly."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value="Internal Server Error")
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Failed to get workflow permissions" in result
+            assert "500" in result
+            assert "Internal Server Error" in result
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_handling(self):
+        """Test that unexpected errors are caught and reported."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = RuntimeError(
+                "Unexpected error"
+            )
+
+            result = await github_get_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Error getting workflow permissions" in result
+            assert "Unexpected error" in result
+
+
+class TestGitHubUpdateWorkflowPermissions:
+    """Test github_update_workflow_permissions function."""
+
+    @pytest.mark.asyncio
+    async def test_successful_update_to_read(self):
+        """Test successfully updating default permissions to read."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                default_workflow_permissions="read",
+            )
+
+            assert "✅" in result
+            assert "Successfully updated workflow permissions" in result
+            assert "owner/repo" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_update_to_write(self):
+        """Test successfully updating default permissions to write."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 204
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                default_workflow_permissions="write",
+            )
+
+            assert "✅" in result
+            assert "Successfully updated workflow permissions" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_update_pr_approval_enabled(self):
+        """Test successfully enabling PR approval by workflows."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                can_approve_pull_request_reviews=True,
+            )
+
+            assert "✅" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_update_pr_approval_disabled(self):
+        """Test successfully disabling PR approval by workflows."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                can_approve_pull_request_reviews=False,
+            )
+
+            assert "✅" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_update_both_parameters(self):
+        """Test successfully updating both workflow permissions parameters."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                default_workflow_permissions="read",
+                can_approve_pull_request_reviews=False,
+            )
+
+            assert "✅" in result
+            assert "Successfully updated workflow permissions" in result
+
+    @pytest.mark.asyncio
+    async def test_invalid_default_permissions_value(self):
+        """Test that invalid default_workflow_permissions value is rejected."""
+        # Mock the client context to prevent authentication errors
+        mock_client = MagicMock()
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                default_workflow_permissions="invalid",
+            )
+
+            assert "❌" in result
+            assert "default_workflow_permissions must be 'read' or 'write'" in result
+
+    @pytest.mark.asyncio
+    async def test_no_parameters_provided(self):
+        """Test that no parameters provided returns warning."""
+        # Mock the client context to prevent authentication errors
+        mock_client = MagicMock()
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "⚠️" in result
+            assert "No update parameters provided" in result
+
+    @pytest.mark.asyncio
+    async def test_api_error_response(self):
+        """Test that API errors are reported properly."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 403
+        mock_response.text = AsyncMock(return_value="Forbidden")
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                default_workflow_permissions="read",
+            )
+
+            assert "❌" in result
+            assert "Failed to update workflow permissions" in result
+            assert "403" in result
+            assert "Forbidden" in result
+
+    @pytest.mark.asyncio
+    async def test_authentication_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_update_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                default_workflow_permissions="read",
+            )
+
+            assert "❌" in result
+            assert "GitHub token not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self):
+        """Test that connection errors are handled gracefully."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_update_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                default_workflow_permissions="read",
+            )
+
+            assert "❌" in result
+            assert "Network connection failed" in result
+            assert "Network timeout" in result
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_handling(self):
+        """Test that unexpected errors are caught and reported."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = RuntimeError(
+                "Unexpected error"
+            )
+
+            result = await github_update_workflow_permissions(
+                repo_owner="owner",
+                repo_name="repo",
+                default_workflow_permissions="read",
+            )
+
+            assert "❌" in result
+            assert "Error updating workflow permissions" in result
+            assert "Unexpected error" in result

--- a/tests/unit/github/test_github_branch_protection.py
+++ b/tests/unit/github/test_github_branch_protection.py
@@ -159,9 +159,7 @@ class TestGitHubGetBranchProtection:
             )
 
             assert "❌ Branch protection not found for feature/new-branch" in result
-            assert (
-                "The branch may not exist or have no protection rules" in result
-            )
+            assert "The branch may not exist or have no protection rules" in result
 
     @pytest.mark.asyncio
     async def test_authentication_error(self):
@@ -208,7 +206,9 @@ class TestGitHubGetBranchProtection:
 
         mock_response = AsyncMock()
         mock_response.status = 403
-        mock_response.text = AsyncMock(return_value="Forbidden - insufficient permissions")
+        mock_response.text = AsyncMock(
+            return_value="Forbidden - insufficient permissions"
+        )
         mock_client.get = AsyncMock(return_value=mock_response)
 
         with patch(
@@ -277,9 +277,15 @@ class TestGitHubUpdateBranchProtection:
             assert call_args[0][0] == "/repos/owner/repo/branches/main/protection"
             payload = call_args[1]["json"]
             assert payload["required_status_checks"]["strict"] is True
-            assert payload["required_status_checks"]["contexts"] == ["ci/test", "ci/lint"]
+            assert payload["required_status_checks"]["contexts"] == [
+                "ci/test",
+                "ci/lint",
+            ]
 
-            assert "✅ Successfully updated branch protection for owner/repo:main" in result
+            assert (
+                "✅ Successfully updated branch protection for owner/repo:main"
+                in result
+            )
 
     @pytest.mark.asyncio
     async def test_successful_update_with_pr_reviews(self):
@@ -555,7 +561,10 @@ class TestGitHubDeleteBranchProtection:
                 "/repos/owner/repo/branches/main/protection"
             )
 
-            assert "✅ Successfully deleted branch protection for owner/repo:main" in result
+            assert (
+                "✅ Successfully deleted branch protection for owner/repo:main"
+                in result
+            )
 
     @pytest.mark.asyncio
     async def test_delete_not_found_404(self):

--- a/tests/unit/github/test_github_branch_protection.py
+++ b/tests/unit/github/test_github_branch_protection.py
@@ -1,0 +1,853 @@
+"""
+Unit tests for GitHub branch protection functions.
+
+Tests the GitHub branch protection functionality including:
+- Get branch protection rules with full configuration
+- Update branch protection with various options
+- Delete branch protection rules
+- 404 error handling (no protection, branch not found)
+- Authentication and connection error handling
+- Pydantic model validators for invalid branch names
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from src.mcp_server_git.github.api import (
+    github_delete_branch_protection,
+    github_get_branch_protection,
+    github_update_branch_protection,
+)
+from src.mcp_server_git.github.models import (
+    GitHubDeleteBranchProtection,
+    GitHubGetBranchProtection,
+    GitHubUpdateBranchProtection,
+)
+
+
+class TestGitHubGetBranchProtection:
+    """Test github_get_branch_protection function."""
+
+    @pytest.mark.asyncio
+    async def test_successful_branch_protection_full_rules(self):
+        """Test retrieving branch protection with all rules enabled."""
+        mock_client = MagicMock()
+
+        # Mock successful response with comprehensive protection rules
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "required_status_checks": {
+                    "strict": True,
+                    "contexts": ["ci/test", "ci/lint", "ci/security"],
+                },
+                "required_pull_request_reviews": {
+                    "dismiss_stale_reviews": True,
+                    "require_code_owner_reviews": True,
+                    "required_approving_review_count": 2,
+                    "require_last_push_approval": True,
+                },
+                "enforce_admins": {"enabled": True},
+                "restrictions": {
+                    "users": [{"login": "admin1"}, {"login": "admin2"}],
+                    "teams": [{"slug": "core-team"}, {"slug": "security-team"}],
+                },
+                "required_linear_history": {"enabled": True},
+                "allow_force_pushes": {"enabled": False},
+                "allow_deletions": {"enabled": False},
+                "required_conversation_resolution": {"enabled": True},
+                "lock_branch": {"enabled": False},
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+            )
+
+            # Verify API call
+            mock_client.get.assert_called_once_with(
+                "/repos/owner/repo/branches/main/protection"
+            )
+
+            # Verify output contains all expected fields
+            assert "Branch Protection for owner/repo:main" in result
+            assert "✅ Required Status Checks:" in result
+            assert "Strict: ✅" in result
+            assert "Contexts: ci/test, ci/lint, ci/security" in result
+            assert "✅ Required Pull Request Reviews:" in result
+            assert "Dismiss Stale Reviews: ✅" in result
+            assert "Require Code Owner Reviews: ✅" in result
+            assert "Required Approving Review Count: 2" in result
+            assert "Require Last Push Approval: ✅" in result
+            assert "👮 Enforce Admins: ✅" in result
+            assert "🔒 Push Restrictions: Enabled" in result
+            assert "Users: admin1, admin2" in result
+            assert "Teams: core-team, security-team" in result
+            assert "Required Linear History: ✅" in result
+            assert "Allow Force Pushes: ❌" in result
+            assert "Allow Deletions: ❌" in result
+            assert "Required Conversation Resolution: ✅" in result
+            assert "Lock Branch: ❌" in result
+
+    @pytest.mark.asyncio
+    async def test_minimal_branch_protection(self):
+        """Test retrieving branch protection with minimal rules."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "required_status_checks": None,
+                "required_pull_request_reviews": None,
+                "enforce_admins": None,
+                "restrictions": None,
+                "required_linear_history": {"enabled": False},
+                "allow_force_pushes": {"enabled": False},
+                "allow_deletions": {"enabled": False},
+                "required_conversation_resolution": {"enabled": False},
+                "lock_branch": {"enabled": False},
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="develop",
+            )
+
+            assert "Branch Protection for owner/repo:develop" in result
+            assert "❌ Required Status Checks: Not configured" in result
+            assert "❌ Required Pull Request Reviews: Not configured" in result
+            assert "🔓 Push Restrictions: Not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_branch_protection_not_found_404(self):
+        """Test that 404 error indicates no protection or branch not found."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="feature/new-branch",
+            )
+
+            assert "❌ Branch protection not found for feature/new-branch" in result
+            assert (
+                "The branch may not exist or have no protection rules" in result
+            )
+
+    @pytest.mark.asyncio
+    async def test_authentication_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_get_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+            )
+
+            assert "GitHub token not configured" in result
+            assert "❌" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self):
+        """Test that connection errors are handled gracefully."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_get_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+            )
+
+            assert "Network connection failed" in result
+            assert "Network timeout" in result
+
+    @pytest.mark.asyncio
+    async def test_api_error_403_forbidden(self):
+        """Test handling of 403 Forbidden error (insufficient permissions)."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 403
+        mock_response.text = AsyncMock(return_value="Forbidden - insufficient permissions")
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_branch_protection(
+                repo_owner="owner",
+                repo_name="private-repo",
+                branch="main",
+            )
+
+            assert "Failed to get branch protection" in result
+            assert "403" in result
+            assert "Forbidden - insufficient permissions" in result
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_handling(self):
+        """Test that unexpected errors are caught and reported."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = RuntimeError(
+                "Unexpected error"
+            )
+
+            result = await github_get_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+            )
+
+            assert "Error getting branch protection" in result
+            assert "Unexpected error" in result
+
+
+class TestGitHubUpdateBranchProtection:
+    """Test github_update_branch_protection function."""
+
+    @pytest.mark.asyncio
+    async def test_successful_update_with_status_checks(self):
+        """Test updating branch protection with required status checks."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+                required_status_checks_strict=True,
+                required_status_checks_contexts=["ci/test", "ci/lint"],
+            )
+
+            # Verify API call with correct payload
+            mock_client.put.assert_called_once()
+            call_args = mock_client.put.call_args
+            assert call_args[0][0] == "/repos/owner/repo/branches/main/protection"
+            payload = call_args[1]["json"]
+            assert payload["required_status_checks"]["strict"] is True
+            assert payload["required_status_checks"]["contexts"] == ["ci/test", "ci/lint"]
+
+            assert "✅ Successfully updated branch protection for owner/repo:main" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_update_with_pr_reviews(self):
+        """Test updating branch protection with PR review requirements."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+                require_pull_request_reviews=True,
+                dismiss_stale_reviews=True,
+                require_code_owner_reviews=True,
+                required_approving_review_count=2,
+                require_last_push_approval=True,
+            )
+
+            # Verify payload structure
+            call_args = mock_client.put.call_args
+            payload = call_args[1]["json"]
+            pr_reviews = payload["required_pull_request_reviews"]
+            assert pr_reviews["dismiss_stale_reviews"] is True
+            assert pr_reviews["require_code_owner_reviews"] is True
+            assert pr_reviews["required_approving_review_count"] == 2
+            assert pr_reviews["require_last_push_approval"] is True
+
+            assert "✅ Successfully updated branch protection" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_update_with_restrictions(self):
+        """Test updating branch protection with push restrictions."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+                restrict_pushes=True,
+                push_allowances_users=["admin1", "admin2"],
+                push_allowances_teams=["core-team"],
+            )
+
+            # Verify restrictions payload
+            call_args = mock_client.put.call_args
+            payload = call_args[1]["json"]
+            restrictions = payload["restrictions"]
+            assert restrictions["users"] == ["admin1", "admin2"]
+            assert restrictions["teams"] == ["core-team"]
+
+            assert "✅ Successfully updated branch protection" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_update_with_other_settings(self):
+        """Test updating branch protection with other settings."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+                enforce_admins=True,
+                required_linear_history=True,
+                allow_force_pushes=False,
+                allow_deletions=False,
+                required_conversation_resolution=True,
+                lock_branch=False,
+            )
+
+            # Verify other settings
+            call_args = mock_client.put.call_args
+            payload = call_args[1]["json"]
+            assert payload["enforce_admins"] is True
+            assert payload["required_linear_history"] is True
+            assert payload["allow_force_pushes"] is False
+            assert payload["allow_deletions"] is False
+            assert payload["required_conversation_resolution"] is True
+            assert payload["lock_branch"] is False
+
+            assert "✅ Successfully updated branch protection" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_update_with_201_created(self):
+        """Test that 201 Created status is also considered success."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 201
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+                required_linear_history=True,
+            )
+
+            assert "✅ Successfully updated branch protection" in result
+
+    @pytest.mark.asyncio
+    async def test_update_without_pr_reviews_sets_null(self):
+        """Test that not requiring PR reviews sets the field to None."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+                require_pull_request_reviews=False,
+            )
+
+            # Verify PR reviews is set to None when not required
+            call_args = mock_client.put.call_args
+            payload = call_args[1]["json"]
+            assert payload["required_pull_request_reviews"] is None
+
+            assert "✅ Successfully updated branch protection" in result
+
+    @pytest.mark.asyncio
+    async def test_update_api_error_422_validation(self):
+        """Test handling of 422 validation error."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 422
+        mock_response.text = AsyncMock(
+            return_value="Validation error: Invalid status check context"
+        )
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+                required_status_checks_contexts=["invalid context"],
+            )
+
+            assert "Failed to update branch protection" in result
+            assert "422" in result
+            assert "Validation error" in result
+
+    @pytest.mark.asyncio
+    async def test_update_authentication_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_update_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+                enforce_admins=True,
+            )
+
+            assert "GitHub token not configured" in result
+            assert "❌" in result
+
+    @pytest.mark.asyncio
+    async def test_update_connection_error(self):
+        """Test that connection errors are handled gracefully."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_update_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+                enforce_admins=True,
+            )
+
+            assert "Network connection failed" in result
+            assert "Network timeout" in result
+
+    @pytest.mark.asyncio
+    async def test_update_unexpected_error(self):
+        """Test that unexpected errors are caught and reported."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = RuntimeError(
+                "Unexpected error"
+            )
+
+            result = await github_update_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+                enforce_admins=True,
+            )
+
+            assert "Error updating branch protection" in result
+            assert "Unexpected error" in result
+
+
+class TestGitHubDeleteBranchProtection:
+    """Test github_delete_branch_protection function."""
+
+    @pytest.mark.asyncio
+    async def test_successful_delete(self):
+        """Test successfully deleting branch protection rules."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 204
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_delete_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+            )
+
+            # Verify API call
+            mock_client.delete.assert_called_once_with(
+                "/repos/owner/repo/branches/main/protection"
+            )
+
+            assert "✅ Successfully deleted branch protection for owner/repo:main" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_not_found_404(self):
+        """Test deleting non-existent branch protection returns 404."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_delete_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="non-existent-branch",
+            )
+
+            assert "❌ Branch protection not found for non-existent-branch" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_api_error_403_forbidden(self):
+        """Test handling of 403 Forbidden error (insufficient permissions)."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 403
+        mock_response.text = AsyncMock(return_value="Forbidden - admin access required")
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_delete_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+            )
+
+            assert "Failed to delete branch protection" in result
+            assert "403" in result
+            assert "Forbidden - admin access required" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_authentication_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_delete_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+            )
+
+            assert "GitHub token not configured" in result
+            assert "❌" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_connection_error(self):
+        """Test that connection errors are handled gracefully."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_delete_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+            )
+
+            assert "Network connection failed" in result
+            assert "Network timeout" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_unexpected_error(self):
+        """Test that unexpected errors are caught and reported."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = RuntimeError(
+                "Unexpected error"
+            )
+
+            result = await github_delete_branch_protection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="main",
+            )
+
+            assert "Error deleting branch protection" in result
+            assert "Unexpected error" in result
+
+
+class TestBranchNameValidation:
+    """Test Pydantic model validators for branch names."""
+
+    def test_valid_branch_names(self):
+        """Test that valid branch names pass validation."""
+        valid_branches = [
+            "main",
+            "develop",
+            "feature/new-feature",
+            "bugfix/issue-123",
+            "release/v1.0.0",
+            "hotfix/urgent-fix",
+            "user/john/experimental",
+        ]
+
+        for branch in valid_branches:
+            # Test GitHubGetBranchProtection
+            model = GitHubGetBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch=branch,
+            )
+            assert model.branch == branch
+
+            # Test GitHubUpdateBranchProtection
+            model = GitHubUpdateBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch=branch,
+            )
+            assert model.branch == branch
+
+            # Test GitHubDeleteBranchProtection
+            model = GitHubDeleteBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch=branch,
+            )
+            assert model.branch == branch
+
+    def test_invalid_branch_starting_with_dash(self):
+        """Test that branch names starting with - are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubGetBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="-invalid-branch",
+            )
+        assert "Invalid branch name" in str(exc_info.value)
+        assert "start with '-'" in str(exc_info.value)
+
+    def test_invalid_branch_containing_double_dots(self):
+        """Test that branch names containing .. are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubUpdateBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="feature..invalid",
+            )
+        assert "Invalid branch name" in str(exc_info.value)
+        assert "contain '..'" in str(exc_info.value)
+
+    def test_invalid_branch_containing_tilde(self):
+        """Test that branch names containing ~ are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubDeleteBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="feature~invalid",
+            )
+        assert "Invalid branch name" in str(exc_info.value)
+        assert "'~'" in str(exc_info.value)
+
+    def test_invalid_branch_containing_caret(self):
+        """Test that branch names containing ^ are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubGetBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="feature^invalid",
+            )
+        assert "Invalid branch name" in str(exc_info.value)
+        assert "'^'" in str(exc_info.value)
+
+    def test_invalid_branch_containing_colon(self):
+        """Test that branch names containing : are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubUpdateBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="feature:invalid",
+            )
+        assert "Invalid branch name" in str(exc_info.value)
+        assert "':'" in str(exc_info.value)
+
+    def test_invalid_branch_containing_backslash(self):
+        """Test that branch names containing \\ are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubDeleteBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="feature\\invalid",
+            )
+        assert "Invalid branch name" in str(exc_info.value)
+        # The error message contains a single backslash in the display
+        assert "'\\\\" in str(exc_info.value) or "'\\" in str(exc_info.value)
+
+    def test_invalid_branch_containing_at_brace(self):
+        """Test that branch names containing @{ are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubGetBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="feature@{invalid",
+            )
+        assert "Invalid branch name" in str(exc_info.value)
+        # The error message may contain '@{' or '@{{' depending on escaping
+        assert "'@{" in str(exc_info.value)
+
+    def test_invalid_branch_ending_with_lock(self):
+        """Test that branch names ending with .lock are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubUpdateBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="feature.lock",
+            )
+        assert "Invalid branch name" in str(exc_info.value)
+        assert "end with '/' or '.lock'" in str(exc_info.value)
+
+    def test_invalid_branch_starting_with_slash(self):
+        """Test that branch names starting with / are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubDeleteBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="/invalid-branch",
+            )
+        assert "Invalid branch name" in str(exc_info.value)
+        assert "start with '-' or '/'" in str(exc_info.value)
+
+    def test_invalid_branch_ending_with_slash(self):
+        """Test that branch names ending with / are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubGetBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="invalid-branch/",
+            )
+        assert "Invalid branch name" in str(exc_info.value)
+        assert "end with '/' or '.lock'" in str(exc_info.value)
+
+    def test_invalid_empty_branch_name(self):
+        """Test that empty branch names are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubUpdateBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="",
+            )
+        assert "branch name cannot be empty" in str(exc_info.value)
+
+    def test_invalid_whitespace_only_branch_name(self):
+        """Test that whitespace-only branch names are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubDeleteBranchProtection(
+                repo_owner="owner",
+                repo_name="repo",
+                branch="   ",
+            )
+        assert "branch name cannot be empty" in str(exc_info.value)
+
+    def test_multiple_invalid_patterns(self):
+        """Test branch names with multiple invalid patterns."""
+        invalid_branches = [
+            "-feature..invalid~branch",
+            "feature^branch:invalid",
+            "branch\\with@{multiple",
+            "/start/and/end/",
+        ]
+
+        for branch in invalid_branches:
+            with pytest.raises(ValidationError) as exc_info:
+                GitHubGetBranchProtection(
+                    repo_owner="owner",
+                    repo_name="repo",
+                    branch=branch,
+                )
+            assert "Invalid branch name" in str(exc_info.value)

--- a/tests/unit/github/test_github_repo_settings.py
+++ b/tests/unit/github/test_github_repo_settings.py
@@ -1,0 +1,766 @@
+"""
+Unit tests for GitHub repository settings functions.
+
+Tests the GitHub repository settings retrieval and update functionality including:
+- Successful repository settings retrieval with all fields
+- 404 error handling for non-existent repositories
+- Authentication error handling
+- Connection error handling
+- Successful repository settings update with various configurations
+- Validation errors for invalid settings
+- Pydantic model validators for GitHubUpdateRepoSettings
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from src.mcp_server_git.github.api import (
+    github_get_repo_settings,
+    github_update_repo_settings,
+)
+from src.mcp_server_git.github.models import GitHubUpdateRepoSettings
+
+
+class TestGitHubGetRepoSettings:
+    """Test github_get_repo_settings function."""
+
+    @pytest.mark.asyncio
+    async def test_successful_repo_settings_retrieval(self):
+        """Test retrieving complete repository settings with all fields."""
+        mock_client = MagicMock()
+
+        # Mock successful repository settings response
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "name": "test-repo",
+                "description": "A test repository for unit testing",
+                "visibility": "public",
+                "default_branch": "main",
+                "homepage": "https://example.com",
+                "has_issues": True,
+                "has_wiki": True,
+                "has_projects": True,
+                "has_discussions": False,
+                "allow_merge_commit": True,
+                "allow_squash_merge": True,
+                "allow_rebase_merge": False,
+                "allow_auto_merge": True,
+                "delete_branch_on_merge": True,
+                "allow_update_branch": False,
+                "squash_merge_commit_title": "PR_TITLE",
+                "squash_merge_commit_message": "COMMIT_MESSAGES",
+                "merge_commit_title": "PR_TITLE",
+                "merge_commit_message": "PR_BODY",
+                "archived": False,
+                "web_commit_signoff_required": False,
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+            )
+
+            # Verify all sections are present
+            assert "Repository Settings for testowner/test-repo" in result
+            assert "📋 Basic Information:" in result
+            assert "Name: test-repo" in result
+            assert "Description: A test repository for unit testing" in result
+            assert "Visibility: public" in result
+            assert "Default Branch: main" in result
+            assert "Homepage: https://example.com" in result
+
+            # Verify features section
+            assert "🔧 Features:" in result
+            assert "Issues: ✅" in result
+            assert "Wiki: ✅" in result
+            assert "Projects: ✅" in result
+            assert "Discussions: ❌" in result
+
+            # Verify merge settings
+            assert "🔀 Merge Settings:" in result
+            assert "Allow Merge Commits: ✅" in result
+            assert "Allow Squash Merging: ✅" in result
+            assert "Allow Rebase Merging: ❌" in result
+
+    @pytest.mark.asyncio
+    async def test_repo_settings_with_minimal_fields(self):
+        """Test retrieving repository settings with minimal/missing fields."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "name": "minimal-repo",
+                "description": None,
+                "visibility": "private",
+                "default_branch": "master",
+                "homepage": None,
+                "has_issues": False,
+                "has_wiki": False,
+                "has_projects": False,
+                "has_discussions": False,
+                "allow_merge_commit": False,
+                "allow_squash_merge": False,
+                "allow_rebase_merge": False,
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_repo_settings(
+                repo_owner="testowner",
+                repo_name="minimal-repo",
+            )
+
+            assert "Name: minimal-repo" in result
+            assert "Description: (none)" in result
+            assert "Visibility: private" in result
+            assert "Homepage: (none)" in result
+
+    @pytest.mark.asyncio
+    async def test_repository_not_found_404_error(self):
+        """Test that 404 error is handled properly for non-existent repository."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_repo_settings(
+                repo_owner="nonexistent",
+                repo_name="fake-repo",
+            )
+
+            assert "❌ Repository nonexistent/fake-repo not found" in result
+
+    @pytest.mark.asyncio
+    async def test_authentication_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_get_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+            )
+
+            assert "❌ GitHub token not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self):
+        """Test that connection errors are handled gracefully."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_get_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+            )
+
+            assert "❌ Network connection failed" in result
+            assert "Network timeout" in result
+
+    @pytest.mark.asyncio
+    async def test_generic_api_error(self):
+        """Test that other API errors are reported properly."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value="Internal Server Error")
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+            )
+
+            assert "❌ Failed to get repository settings" in result
+            assert "500" in result
+            assert "Internal Server Error" in result
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_handling(self):
+        """Test that unexpected errors are caught and reported."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = RuntimeError(
+                "Unexpected error occurred"
+            )
+
+            result = await github_get_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+            )
+
+            assert "❌ Error getting repository settings" in result
+            assert "Unexpected error occurred" in result
+
+
+class TestGitHubUpdateRepoSettings:
+    """Test github_update_repo_settings function."""
+
+    @pytest.mark.asyncio
+    async def test_successful_basic_settings_update(self):
+        """Test updating basic repository settings (description, homepage)."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "testowner/test-repo",
+                "description": "Updated description",
+                "homepage": "https://new-homepage.com",
+            }
+        )
+        mock_client.patch = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                description="Updated description",
+                homepage="https://new-homepage.com",
+            )
+
+            assert "✅ Successfully updated repository settings" in result
+            assert "testowner/test-repo" in result
+            assert "description" in result
+            assert "homepage" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_visibility_update(self):
+        """Test updating repository visibility settings."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "testowner/test-repo",
+                "visibility": "private",
+            }
+        )
+        mock_client.patch = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                visibility="private",
+            )
+
+            assert "✅ Successfully updated repository settings" in result
+            assert "visibility" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_feature_toggles_update(self):
+        """Test updating repository feature toggles (issues, wiki, projects)."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "testowner/test-repo",
+                "has_issues": False,
+                "has_wiki": True,
+                "has_projects": False,
+                "has_discussions": True,
+            }
+        )
+        mock_client.patch = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                has_issues=False,
+                has_wiki=True,
+                has_projects=False,
+                has_discussions=True,
+            )
+
+            assert "✅ Successfully updated repository settings" in result
+            assert "has_issues" in result
+            assert "has_wiki" in result
+            assert "has_projects" in result
+            assert "has_discussions" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_merge_settings_update(self):
+        """Test updating repository merge settings."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "testowner/test-repo",
+                "allow_squash_merge": True,
+                "allow_merge_commit": False,
+                "allow_rebase_merge": True,
+                "allow_auto_merge": True,
+                "delete_branch_on_merge": True,
+            }
+        )
+        mock_client.patch = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                allow_squash_merge=True,
+                allow_merge_commit=False,
+                allow_rebase_merge=True,
+                allow_auto_merge=True,
+                delete_branch_on_merge=True,
+            )
+
+            assert "✅ Successfully updated repository settings" in result
+            assert "allow_squash_merge" in result
+            assert "allow_merge_commit" in result
+            assert "allow_rebase_merge" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_squash_merge_commit_options_update(self):
+        """Test updating squash merge commit title and message options."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "testowner/test-repo",
+                "squash_merge_commit_title": "COMMIT_OR_PR_TITLE",
+                "squash_merge_commit_message": "BLANK",
+            }
+        )
+        mock_client.patch = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                squash_merge_commit_title="COMMIT_OR_PR_TITLE",
+                squash_merge_commit_message="BLANK",
+            )
+
+            assert "✅ Successfully updated repository settings" in result
+            assert "squash_merge_commit_title" in result
+            assert "squash_merge_commit_message" in result
+
+    @pytest.mark.asyncio
+    async def test_successful_merge_commit_options_update(self):
+        """Test updating merge commit title and message options."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "testowner/test-repo",
+                "merge_commit_title": "MERGE_MESSAGE",
+                "merge_commit_message": "PR_TITLE",
+            }
+        )
+        mock_client.patch = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                merge_commit_title="MERGE_MESSAGE",
+                merge_commit_message="PR_TITLE",
+            )
+
+            assert "✅ Successfully updated repository settings" in result
+            assert "merge_commit_title" in result
+            assert "merge_commit_message" in result
+
+    @pytest.mark.asyncio
+    async def test_no_parameters_provided(self):
+        """Test that providing no update parameters returns a warning."""
+        mock_client = MagicMock()
+        mock_client.patch = AsyncMock()
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+            )
+
+            assert "⚠️ No update parameters provided" in result
+            # Ensure no API call was made
+            mock_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_authentication_error_on_update(self):
+        """Test that authentication errors are handled properly during update."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_update_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                description="New description",
+            )
+
+            assert "❌ GitHub token not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_connection_error_on_update(self):
+        """Test that connection errors are handled gracefully during update."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_update_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                description="New description",
+            )
+
+            assert "❌ Network connection failed" in result
+            assert "Network timeout" in result
+
+    @pytest.mark.asyncio
+    async def test_api_error_on_update(self):
+        """Test that API errors are reported properly during update."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 422
+        mock_response.text = AsyncMock(
+            return_value="Unprocessable Entity: Invalid field value"
+        )
+        mock_client.patch = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                description="New description",
+            )
+
+            assert "❌ Failed to update repository settings" in result
+            assert "422" in result
+            assert "Unprocessable Entity" in result
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error_on_update(self):
+        """Test that unexpected errors are caught and reported during update."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = RuntimeError(
+                "Unexpected error occurred"
+            )
+
+            result = await github_update_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                description="New description",
+            )
+
+            assert "❌ Error updating repository settings" in result
+            assert "Unexpected error occurred" in result
+
+
+class TestGitHubUpdateRepoSettingsModel:
+    """Test Pydantic model validators for GitHubUpdateRepoSettings."""
+
+    def test_valid_visibility_public(self):
+        """Test that 'public' visibility is valid."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            visibility="public",
+        )
+        assert model.visibility == "public"
+
+    def test_valid_visibility_private(self):
+        """Test that 'private' visibility is valid."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            visibility="private",
+        )
+        assert model.visibility == "private"
+
+    def test_valid_visibility_internal(self):
+        """Test that 'internal' visibility is valid."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            visibility="internal",
+        )
+        assert model.visibility == "internal"
+
+    def test_invalid_visibility(self):
+        """Test that invalid visibility value raises ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubUpdateRepoSettings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                visibility="invalid-visibility",
+            )
+        assert "visibility must be one of" in str(exc_info.value)
+
+    def test_valid_squash_merge_commit_title_pr_title(self):
+        """Test that 'PR_TITLE' is valid for squash_merge_commit_title."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            squash_merge_commit_title="PR_TITLE",
+        )
+        assert model.squash_merge_commit_title == "PR_TITLE"
+
+    def test_valid_squash_merge_commit_title_commit_or_pr_title(self):
+        """Test that 'COMMIT_OR_PR_TITLE' is valid for squash_merge_commit_title."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            squash_merge_commit_title="COMMIT_OR_PR_TITLE",
+        )
+        assert model.squash_merge_commit_title == "COMMIT_OR_PR_TITLE"
+
+    def test_invalid_squash_merge_commit_title(self):
+        """Test that invalid squash_merge_commit_title raises ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubUpdateRepoSettings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                squash_merge_commit_title="INVALID_VALUE",
+            )
+        assert "squash_merge_commit_title must be one of" in str(exc_info.value)
+
+    def test_valid_squash_merge_commit_message_pr_body(self):
+        """Test that 'PR_BODY' is valid for squash_merge_commit_message."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            squash_merge_commit_message="PR_BODY",
+        )
+        assert model.squash_merge_commit_message == "PR_BODY"
+
+    def test_valid_squash_merge_commit_message_commit_messages(self):
+        """Test that 'COMMIT_MESSAGES' is valid for squash_merge_commit_message."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            squash_merge_commit_message="COMMIT_MESSAGES",
+        )
+        assert model.squash_merge_commit_message == "COMMIT_MESSAGES"
+
+    def test_valid_squash_merge_commit_message_blank(self):
+        """Test that 'BLANK' is valid for squash_merge_commit_message."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            squash_merge_commit_message="BLANK",
+        )
+        assert model.squash_merge_commit_message == "BLANK"
+
+    def test_invalid_squash_merge_commit_message(self):
+        """Test that invalid squash_merge_commit_message raises ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubUpdateRepoSettings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                squash_merge_commit_message="INVALID_VALUE",
+            )
+        assert "squash_merge_commit_message must be one of" in str(exc_info.value)
+
+    def test_valid_merge_commit_title_pr_title(self):
+        """Test that 'PR_TITLE' is valid for merge_commit_title."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            merge_commit_title="PR_TITLE",
+        )
+        assert model.merge_commit_title == "PR_TITLE"
+
+    def test_valid_merge_commit_title_merge_message(self):
+        """Test that 'MERGE_MESSAGE' is valid for merge_commit_title."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            merge_commit_title="MERGE_MESSAGE",
+        )
+        assert model.merge_commit_title == "MERGE_MESSAGE"
+
+    def test_invalid_merge_commit_title(self):
+        """Test that invalid merge_commit_title raises ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubUpdateRepoSettings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                merge_commit_title="INVALID_VALUE",
+            )
+        assert "merge_commit_title must be one of" in str(exc_info.value)
+
+    def test_valid_merge_commit_message_pr_body(self):
+        """Test that 'PR_BODY' is valid for merge_commit_message."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            merge_commit_message="PR_BODY",
+        )
+        assert model.merge_commit_message == "PR_BODY"
+
+    def test_valid_merge_commit_message_pr_title(self):
+        """Test that 'PR_TITLE' is valid for merge_commit_message."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            merge_commit_message="PR_TITLE",
+        )
+        assert model.merge_commit_message == "PR_TITLE"
+
+    def test_valid_merge_commit_message_blank(self):
+        """Test that 'BLANK' is valid for merge_commit_message."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            merge_commit_message="BLANK",
+        )
+        assert model.merge_commit_message == "BLANK"
+
+    def test_invalid_merge_commit_message(self):
+        """Test that invalid merge_commit_message raises ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubUpdateRepoSettings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                merge_commit_message="INVALID_VALUE",
+            )
+        assert "merge_commit_message must be one of" in str(exc_info.value)
+
+    def test_none_values_are_valid(self):
+        """Test that None values pass validation for optional fields."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            visibility=None,
+            squash_merge_commit_title=None,
+            squash_merge_commit_message=None,
+            merge_commit_title=None,
+            merge_commit_message=None,
+        )
+        assert model.visibility is None
+        assert model.squash_merge_commit_title is None
+        assert model.squash_merge_commit_message is None
+        assert model.merge_commit_title is None
+        assert model.merge_commit_message is None
+
+    def test_model_with_all_valid_fields(self):
+        """Test creating model with all valid fields populated."""
+        model = GitHubUpdateRepoSettings(
+            repo_owner="testowner",
+            repo_name="test-repo",
+            description="Test description",
+            homepage="https://example.com",
+            private=True,
+            visibility="private",
+            has_issues=True,
+            has_projects=False,
+            has_wiki=True,
+            has_discussions=False,
+            allow_squash_merge=True,
+            allow_merge_commit=False,
+            allow_rebase_merge=True,
+            allow_auto_merge=False,
+            delete_branch_on_merge=True,
+            allow_update_branch=False,
+            squash_merge_commit_title="PR_TITLE",
+            squash_merge_commit_message="COMMIT_MESSAGES",
+            merge_commit_title="MERGE_MESSAGE",
+            merge_commit_message="PR_BODY",
+            archived=False,
+            web_commit_signoff_required=True,
+        )
+
+        assert model.repo_owner == "testowner"
+        assert model.repo_name == "test-repo"
+        assert model.description == "Test description"
+        assert model.visibility == "private"
+        assert model.has_issues is True
+        assert model.allow_squash_merge is True
+        assert model.squash_merge_commit_title == "PR_TITLE"
+        assert model.merge_commit_message == "PR_BODY"

--- a/tests/unit/github/test_github_security.py
+++ b/tests/unit/github/test_github_security.py
@@ -633,9 +633,7 @@ class TestGitHubGetSecurityAnalysis:
             assert "✅ Dependabot Security Updates: ENABLED" in result
 
             # Verify settings URL
-            assert (
-                "https://github.com/owner/repo/settings/security_analysis" in result
-            )
+            assert "https://github.com/owner/repo/settings/security_analysis" in result
 
             # Should not have failure warnings
             assert "checks failed" not in result
@@ -878,9 +876,7 @@ class TestGitHubGetSecurityAnalysis:
 
             # Should still have header and settings URL
             assert "Security Analysis for owner/repo" in result
-            assert (
-                "https://github.com/owner/repo/settings/security_analysis" in result
-            )
+            assert "https://github.com/owner/repo/settings/security_analysis" in result
 
     @pytest.mark.asyncio
     async def test_security_analysis_auth_error(self):

--- a/tests/unit/github/test_github_security.py
+++ b/tests/unit/github/test_github_security.py
@@ -1,0 +1,1119 @@
+"""
+Unit tests for GitHub security functions.
+
+Tests the GitHub security management functionality including:
+- Vulnerability alerts checking and toggling (Dependabot alerts)
+- Automated security fixes checking and toggling (Dependabot security updates)
+- Comprehensive security analysis with graceful partial failure handling
+- Authentication and connection error handling
+- API error responses
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.mcp_server_git.github.api import (
+    github_disable_automated_security_fixes,
+    github_disable_vulnerability_alerts,
+    github_enable_automated_security_fixes,
+    github_enable_vulnerability_alerts,
+    github_get_automated_security_fixes,
+    github_get_security_analysis,
+    github_get_vulnerability_alerts,
+)
+
+
+class TestGitHubGetVulnerabilityAlerts:
+    """Test github_get_vulnerability_alerts function."""
+
+    @pytest.mark.asyncio
+    async def test_vulnerability_alerts_enabled(self):
+        """Test that enabled vulnerability alerts return 204 status."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 204
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_vulnerability_alerts(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "✅" in result
+            assert "ENABLED" in result
+            assert "owner/repo" in result
+            assert "Dependabot" in result
+            mock_client.get.assert_called_once_with(
+                "/repos/owner/repo/vulnerability-alerts"
+            )
+
+    @pytest.mark.asyncio
+    async def test_vulnerability_alerts_disabled(self):
+        """Test that disabled vulnerability alerts return 404 status."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_vulnerability_alerts(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "DISABLED" in result
+            assert "owner/repo" in result
+
+    @pytest.mark.asyncio
+    async def test_vulnerability_alerts_api_error(self):
+        """Test that API errors are handled gracefully."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value="Internal Server Error")
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_vulnerability_alerts(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Failed to check vulnerability alerts" in result
+            assert "500" in result
+            assert "Internal Server Error" in result
+
+    @pytest.mark.asyncio
+    async def test_vulnerability_alerts_auth_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_get_vulnerability_alerts(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "GitHub token not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_vulnerability_alerts_connection_error(self):
+        """Test that connection errors are handled gracefully."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_get_vulnerability_alerts(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Network connection failed" in result
+            assert "Network timeout" in result
+
+    @pytest.mark.asyncio
+    async def test_vulnerability_alerts_unexpected_error(self):
+        """Test that unexpected errors are caught and reported."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = RuntimeError(
+                "Unexpected error"
+            )
+
+            result = await github_get_vulnerability_alerts(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Error checking vulnerability alerts" in result
+            assert "Unexpected error" in result
+
+
+class TestGitHubEnableVulnerabilityAlerts:
+    """Test github_enable_vulnerability_alerts function."""
+
+    @pytest.mark.asyncio
+    async def test_enable_vulnerability_alerts_success(self):
+        """Test successfully enabling vulnerability alerts."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 204
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_enable_vulnerability_alerts(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "✅" in result
+            assert "Successfully enabled" in result
+            assert "owner/repo" in result
+            mock_client.put.assert_called_once_with(
+                "/repos/owner/repo/vulnerability-alerts"
+            )
+
+    @pytest.mark.asyncio
+    async def test_enable_vulnerability_alerts_error(self):
+        """Test error handling when enabling fails."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 403
+        mock_response.text = AsyncMock(return_value="Forbidden")
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_enable_vulnerability_alerts(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Failed to enable" in result
+            assert "403" in result
+            assert "Forbidden" in result
+
+    @pytest.mark.asyncio
+    async def test_enable_vulnerability_alerts_auth_error(self):
+        """Test authentication error handling."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_enable_vulnerability_alerts(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "GitHub token not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_enable_vulnerability_alerts_connection_error(self):
+        """Test connection error handling."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_enable_vulnerability_alerts(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Network connection failed" in result
+
+
+class TestGitHubDisableVulnerabilityAlerts:
+    """Test github_disable_vulnerability_alerts function."""
+
+    @pytest.mark.asyncio
+    async def test_disable_vulnerability_alerts_success(self):
+        """Test successfully disabling vulnerability alerts."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 204
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_disable_vulnerability_alerts(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "✅" in result
+            assert "Successfully disabled" in result
+            assert "owner/repo" in result
+            mock_client.delete.assert_called_once_with(
+                "/repos/owner/repo/vulnerability-alerts"
+            )
+
+    @pytest.mark.asyncio
+    async def test_disable_vulnerability_alerts_error(self):
+        """Test error handling when disabling fails."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 403
+        mock_response.text = AsyncMock(return_value="Forbidden")
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_disable_vulnerability_alerts(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Failed to disable" in result
+            assert "403" in result
+
+
+class TestGitHubGetAutomatedSecurityFixes:
+    """Test github_get_automated_security_fixes function."""
+
+    @pytest.mark.asyncio
+    async def test_automated_security_fixes_enabled(self):
+        """Test that enabled automated security fixes are reported correctly."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "enabled": True,
+                "paused": False,
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_automated_security_fixes(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "✅" in result
+            assert "ENABLED" in result
+            assert "owner/repo" in result
+            assert "Dependabot security updates" in result
+            assert "PAUSED" not in result
+
+    @pytest.mark.asyncio
+    async def test_automated_security_fixes_disabled(self):
+        """Test that disabled automated security fixes are reported correctly."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "enabled": False,
+                "paused": False,
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_automated_security_fixes(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "DISABLED" in result
+            assert "owner/repo" in result
+
+    @pytest.mark.asyncio
+    async def test_automated_security_fixes_paused(self):
+        """Test that paused automated security fixes are reported correctly."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "enabled": True,
+                "paused": True,
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_automated_security_fixes(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "✅" in result
+            assert "ENABLED" in result
+            assert "PAUSED" in result
+            assert "owner/repo" in result
+
+    @pytest.mark.asyncio
+    async def test_automated_security_fixes_not_available(self):
+        """Test that 404 status is handled for unavailable feature."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_automated_security_fixes(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "not available or disabled" in result
+
+    @pytest.mark.asyncio
+    async def test_automated_security_fixes_api_error(self):
+        """Test that API errors are handled gracefully."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value="Internal Server Error")
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_automated_security_fixes(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Failed to check" in result
+            assert "500" in result
+
+
+class TestGitHubEnableAutomatedSecurityFixes:
+    """Test github_enable_automated_security_fixes function."""
+
+    @pytest.mark.asyncio
+    async def test_enable_automated_security_fixes_success(self):
+        """Test successfully enabling automated security fixes."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 204
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_enable_automated_security_fixes(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "✅" in result
+            assert "Successfully enabled" in result
+            assert "owner/repo" in result
+            mock_client.put.assert_called_once_with(
+                "/repos/owner/repo/automated-security-fixes"
+            )
+
+    @pytest.mark.asyncio
+    async def test_enable_automated_security_fixes_error(self):
+        """Test error handling when enabling fails."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 403
+        mock_response.text = AsyncMock(return_value="Forbidden")
+        mock_client.put = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_enable_automated_security_fixes(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Failed to enable" in result
+            assert "403" in result
+
+
+class TestGitHubDisableAutomatedSecurityFixes:
+    """Test github_disable_automated_security_fixes function."""
+
+    @pytest.mark.asyncio
+    async def test_disable_automated_security_fixes_success(self):
+        """Test successfully disabling automated security fixes."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 204
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_disable_automated_security_fixes(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "✅" in result
+            assert "Successfully disabled" in result
+            assert "owner/repo" in result
+            mock_client.delete.assert_called_once_with(
+                "/repos/owner/repo/automated-security-fixes"
+            )
+
+    @pytest.mark.asyncio
+    async def test_disable_automated_security_fixes_error(self):
+        """Test error handling when disabling fails."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 403
+        mock_response.text = AsyncMock(return_value="Forbidden")
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_disable_automated_security_fixes(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Failed to disable" in result
+            assert "403" in result
+
+
+class TestGitHubGetSecurityAnalysis:
+    """Test github_get_security_analysis function."""
+
+    @pytest.mark.asyncio
+    async def test_security_analysis_full_success(self):
+        """Test comprehensive security analysis with all checks succeeding."""
+        mock_client = MagicMock()
+
+        # Mock vulnerability alerts response (enabled)
+        vuln_response = AsyncMock()
+        vuln_response.status = 204
+
+        # Mock automated security fixes response (enabled)
+        auto_response = AsyncMock()
+        auto_response.status = 200
+        auto_response.json = AsyncMock(
+            return_value={
+                "enabled": True,
+                "paused": False,
+            }
+        )
+
+        # Mock repository settings response with security features
+        repo_response = AsyncMock()
+        repo_response.status = 200
+        repo_response.json = AsyncMock(
+            return_value={
+                "visibility": "private",
+                "private": True,
+                "archived": False,
+                "security_and_analysis": {
+                    "secret_scanning": {"status": "enabled"},
+                    "secret_scanning_push_protection": {"status": "enabled"},
+                    "dependabot_security_updates": {"status": "enabled"},
+                },
+            }
+        )
+
+        # Setup mock to return different responses for each endpoint
+        async def mock_get(url):
+            if "vulnerability-alerts" in url:
+                return vuln_response
+            elif "automated-security-fixes" in url:
+                return auto_response
+            else:
+                return repo_response
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_security_analysis(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            # Verify header
+            assert "Security Analysis for owner/repo" in result
+
+            # Verify vulnerability alerts check
+            assert "✅ Vulnerability Alerts (Dependabot): ENABLED" in result
+
+            # Verify automated security fixes check
+            assert "✅ Automated Security Fixes: ENABLED" in result
+
+            # Verify repository settings
+            assert "📋 Repository Security Settings:" in result
+            assert "Visibility: private" in result
+            assert "Private: ✅" in result
+            assert "Archived: ❌" in result
+
+            # Verify security features
+            assert "🔐 Security & Analysis Features:" in result
+            assert "✅ Secret Scanning: ENABLED" in result
+            assert "✅ Secret Scanning Push Protection: ENABLED" in result
+            assert "✅ Dependabot Security Updates: ENABLED" in result
+
+            # Verify settings URL
+            assert (
+                "https://github.com/owner/repo/settings/security_analysis" in result
+            )
+
+            # Should not have failure warnings
+            assert "checks failed" not in result
+
+    @pytest.mark.asyncio
+    async def test_security_analysis_partial_failure_vulnerability_check(self):
+        """Test that vulnerability alerts check failure doesn't prevent other checks."""
+        mock_client = MagicMock()
+
+        # Mock automated security fixes response (succeeds)
+        auto_response = AsyncMock()
+        auto_response.status = 200
+        auto_response.json = AsyncMock(
+            return_value={
+                "enabled": True,
+                "paused": False,
+            }
+        )
+
+        # Mock repository settings response (succeeds)
+        repo_response = AsyncMock()
+        repo_response.status = 200
+        repo_response.json = AsyncMock(
+            return_value={
+                "visibility": "public",
+                "private": False,
+                "archived": False,
+                "security_and_analysis": {
+                    "secret_scanning": {"status": "disabled"},
+                },
+            }
+        )
+
+        # Setup mock to fail vulnerability check but succeed others
+        async def mock_get(url):
+            if "vulnerability-alerts" in url:
+                raise RuntimeError("Temporary API error")
+            elif "automated-security-fixes" in url:
+                return auto_response
+            else:
+                return repo_response
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_security_analysis(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            # Verify the failure is reported
+            assert "⚠️ Vulnerability Alerts: Check failed" in result
+            assert "Temporary API error" in result
+
+            # Verify other checks still completed
+            assert "✅ Automated Security Fixes: ENABLED" in result
+            assert "📋 Repository Security Settings:" in result
+
+            # Verify failure summary
+            assert "1 of 3 checks failed" in result
+
+    @pytest.mark.asyncio
+    async def test_security_analysis_partial_failure_security_fixes_check(self):
+        """Test that security fixes check failure doesn't prevent other checks."""
+        mock_client = MagicMock()
+
+        # Mock vulnerability alerts response (succeeds)
+        vuln_response = AsyncMock()
+        vuln_response.status = 204
+
+        # Mock repository settings response (succeeds)
+        repo_response = AsyncMock()
+        repo_response.status = 200
+        repo_response.json = AsyncMock(
+            return_value={
+                "visibility": "public",
+                "private": False,
+                "archived": False,
+            }
+        )
+
+        # Setup mock to fail security fixes check but succeed others
+        async def mock_get(url):
+            if "vulnerability-alerts" in url:
+                return vuln_response
+            elif "automated-security-fixes" in url:
+                raise RuntimeError("API timeout")
+            else:
+                return repo_response
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_security_analysis(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            # Verify the failure is reported
+            assert "⚠️ Automated Security Fixes: Check failed" in result
+            assert "API timeout" in result
+
+            # Verify other checks still completed
+            assert "✅ Vulnerability Alerts (Dependabot): ENABLED" in result
+            assert "📋 Repository Security Settings:" in result
+
+            # Verify failure summary
+            assert "1 of 3 checks failed" in result
+
+    @pytest.mark.asyncio
+    async def test_security_analysis_partial_failure_repo_settings(self):
+        """Test that repo settings check failure doesn't prevent other checks."""
+        mock_client = MagicMock()
+
+        # Mock vulnerability alerts response (succeeds)
+        vuln_response = AsyncMock()
+        vuln_response.status = 404  # Disabled
+
+        # Mock automated security fixes response (succeeds)
+        auto_response = AsyncMock()
+        auto_response.status = 200
+        auto_response.json = AsyncMock(
+            return_value={
+                "enabled": False,
+                "paused": False,
+            }
+        )
+
+        # Setup mock to fail repo settings check but succeed others
+        async def mock_get(url):
+            if "vulnerability-alerts" in url:
+                return vuln_response
+            elif "automated-security-fixes" in url:
+                return auto_response
+            else:
+                raise RuntimeError("Database connection failed")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_security_analysis(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            # Verify the failure is reported
+            assert "⚠️ Repository Settings: Check failed" in result
+            assert "Database connection failed" in result
+
+            # Verify other checks still completed
+            assert "❌ Vulnerability Alerts (Dependabot): DISABLED" in result
+            assert "❌ Automated Security Fixes: DISABLED" in result
+
+            # Verify failure summary
+            assert "1 of 3 checks failed" in result
+
+    @pytest.mark.asyncio
+    async def test_security_analysis_multiple_failures(self):
+        """Test that multiple check failures are counted correctly."""
+        mock_client = MagicMock()
+
+        # Mock automated security fixes response (succeeds)
+        auto_response = AsyncMock()
+        auto_response.status = 200
+        auto_response.json = AsyncMock(
+            return_value={
+                "enabled": True,
+                "paused": False,
+            }
+        )
+
+        # Setup mock to fail two checks
+        async def mock_get(url):
+            if "vulnerability-alerts" in url:
+                raise RuntimeError("Error 1")
+            elif "automated-security-fixes" in url:
+                return auto_response
+            else:
+                raise RuntimeError("Error 2")
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_security_analysis(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            # Verify both failures are reported
+            assert "⚠️ Vulnerability Alerts: Check failed" in result
+            assert "⚠️ Repository Settings: Check failed" in result
+
+            # Verify the one success is reported
+            assert "✅ Automated Security Fixes: ENABLED" in result
+
+            # Verify failure summary
+            assert "2 of 3 checks failed" in result
+
+    @pytest.mark.asyncio
+    async def test_security_analysis_all_checks_fail(self):
+        """Test graceful handling when all individual checks fail."""
+        mock_client = MagicMock()
+
+        # Setup mock to fail all checks
+        mock_client.get = AsyncMock(side_effect=RuntimeError("API unavailable"))
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_security_analysis(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            # Verify all failures are reported
+            assert "⚠️ Vulnerability Alerts: Check failed" in result
+            assert "⚠️ Automated Security Fixes: Check failed" in result
+            assert "⚠️ Repository Settings: Check failed" in result
+
+            # Verify failure summary
+            assert "3 of 3 checks failed" in result
+
+            # Should still have header and settings URL
+            assert "Security Analysis for owner/repo" in result
+            assert (
+                "https://github.com/owner/repo/settings/security_analysis" in result
+            )
+
+    @pytest.mark.asyncio
+    async def test_security_analysis_auth_error(self):
+        """Test that authentication errors are handled at the top level."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_get_security_analysis(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "GitHub token not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_security_analysis_connection_error(self):
+        """Test that connection errors are handled at the top level."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_get_security_analysis(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Network connection failed" in result
+            assert "Network timeout" in result
+
+    @pytest.mark.asyncio
+    async def test_security_analysis_unexpected_error(self):
+        """Test that unexpected errors are caught and reported."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = RuntimeError(
+                "Unexpected error"
+            )
+
+            result = await github_get_security_analysis(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌" in result
+            assert "Error getting security analysis" in result
+            assert "Unexpected error" in result
+
+    @pytest.mark.asyncio
+    async def test_security_analysis_disabled_features(self):
+        """Test reporting when security features are disabled."""
+        mock_client = MagicMock()
+
+        # Mock vulnerability alerts response (disabled)
+        vuln_response = AsyncMock()
+        vuln_response.status = 404
+
+        # Mock automated security fixes response (disabled)
+        auto_response = AsyncMock()
+        auto_response.status = 200
+        auto_response.json = AsyncMock(
+            return_value={
+                "enabled": False,
+                "paused": False,
+            }
+        )
+
+        # Mock repository settings response with disabled features
+        repo_response = AsyncMock()
+        repo_response.status = 200
+        repo_response.json = AsyncMock(
+            return_value={
+                "visibility": "public",
+                "private": False,
+                "archived": False,
+                "security_and_analysis": {
+                    "secret_scanning": {"status": "disabled"},
+                    "secret_scanning_push_protection": {"status": "disabled"},
+                    "dependabot_security_updates": {"status": "disabled"},
+                },
+            }
+        )
+
+        # Setup mock to return different responses for each endpoint
+        async def mock_get(url):
+            if "vulnerability-alerts" in url:
+                return vuln_response
+            elif "automated-security-fixes" in url:
+                return auto_response
+            else:
+                return repo_response
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_security_analysis(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            # Verify all features show as disabled
+            assert "❌ Vulnerability Alerts (Dependabot): DISABLED" in result
+            assert "❌ Automated Security Fixes: DISABLED" in result
+            assert "❌ Secret Scanning: DISABLED" in result
+            assert "❌ Secret Scanning Push Protection: DISABLED" in result
+            assert "❌ Dependabot Security Updates: DISABLED" in result
+
+            # Should not have failure warnings (all checks succeeded)
+            assert "checks failed" not in result
+
+    @pytest.mark.asyncio
+    async def test_security_analysis_paused_security_fixes(self):
+        """Test reporting when automated security fixes are paused."""
+        mock_client = MagicMock()
+
+        # Mock vulnerability alerts response (enabled)
+        vuln_response = AsyncMock()
+        vuln_response.status = 204
+
+        # Mock automated security fixes response (enabled but paused)
+        auto_response = AsyncMock()
+        auto_response.status = 200
+        auto_response.json = AsyncMock(
+            return_value={
+                "enabled": True,
+                "paused": True,
+            }
+        )
+
+        # Mock repository settings response
+        repo_response = AsyncMock()
+        repo_response.status = 200
+        repo_response.json = AsyncMock(
+            return_value={
+                "visibility": "public",
+                "private": False,
+                "archived": False,
+            }
+        )
+
+        # Setup mock to return different responses for each endpoint
+        async def mock_get(url):
+            if "vulnerability-alerts" in url:
+                return vuln_response
+            elif "automated-security-fixes" in url:
+                return auto_response
+            else:
+                return repo_response
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_security_analysis(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            # Verify paused status is reported
+            assert "✅ Automated Security Fixes: ENABLED (PAUSED)" in result
+            assert "✅ Vulnerability Alerts (Dependabot): ENABLED" in result
+
+    @pytest.mark.asyncio
+    async def test_security_analysis_minimal_repo_data(self):
+        """Test handling of repository with minimal security data."""
+        mock_client = MagicMock()
+
+        # Mock vulnerability alerts response (enabled)
+        vuln_response = AsyncMock()
+        vuln_response.status = 204
+
+        # Mock automated security fixes response (disabled)
+        auto_response = AsyncMock()
+        auto_response.status = 200
+        auto_response.json = AsyncMock(
+            return_value={
+                "enabled": False,
+            }
+        )
+
+        # Mock repository settings response without security_and_analysis
+        repo_response = AsyncMock()
+        repo_response.status = 200
+        repo_response.json = AsyncMock(
+            return_value={
+                "visibility": "public",
+                "private": False,
+                "archived": False,
+                # No security_and_analysis field
+            }
+        )
+
+        # Setup mock to return different responses for each endpoint
+        async def mock_get(url):
+            if "vulnerability-alerts" in url:
+                return vuln_response
+            elif "automated-security-fixes" in url:
+                return auto_response
+            else:
+                return repo_response
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_security_analysis(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            # Verify basic checks completed
+            assert "✅ Vulnerability Alerts (Dependabot): ENABLED" in result
+            assert "❌ Automated Security Fixes: DISABLED" in result
+            assert "📋 Repository Security Settings:" in result
+
+            # Should not have security features section since data is missing
+            assert "🔐 Security & Analysis Features:" not in result


### PR DESCRIPTION
## Summary

This PR implements GitHub Repository Settings Management (Issue #41), adding 17 new tools for automated configuration of GitHub repository settings via mcp-git.

### Features Added

#### 1. Repository Settings Management (2 tools)
- `github_get_repo_settings` - Get repository features, merge options, security settings
- `github_update_repo_settings` - Update merge strategies, features, visibility, and more

#### 2. GitHub Actions Configuration (4 tools)
- `github_get_actions_permissions` - Get Actions enabled/allowed status
- `github_update_actions_permissions` - Enable/disable Actions, set allowed actions
- `github_get_workflow_permissions` - Get GITHUB_TOKEN default permissions
- `github_update_workflow_permissions` - Set workflow permissions, PR approval authority

#### 3. Branch Protection Rules (3 tools)
- `github_get_branch_protection` - Get protection rules for a branch
- `github_update_branch_protection` - Create/update status checks, reviews, restrictions
- `github_delete_branch_protection` - Remove branch protection rules

#### 4. Security & Compliance (8 tools)
- `github_get_vulnerability_alerts` - Check Dependabot alerts status
- `github_enable_vulnerability_alerts` - Enable Dependabot alerts
- `github_disable_vulnerability_alerts` - Disable Dependabot alerts
- `github_get_automated_security_fixes` - Check security updates status
- `github_enable_automated_security_fixes` - Enable Dependabot updates
- `github_disable_automated_security_fixes` - Disable Dependabot updates
- `github_get_security_analysis` - Comprehensive security status report

### Tool Count Change
- Before: 51 tools (git: 25, github: 22, azure: 4)
- After: 68 tools (git: 25, github: 39, azure: 4)

### Files Changed
- `src/mcp_server_git/github/models.py` - Added 17 Pydantic models
- `src/mcp_server_git/github/api.py` - Added 17 async API functions
- `src/mcp_server_git/lean/tool_registry.py` - Registered 17 new tools

## Test Plan

- [x] Unit tests pass (`pixi run test-unit`)
- [x] Lint checks pass (`pixi run lint`)
- [x] Format checks pass (`pixi run format`)
- [ ] Manual testing of tools with real GitHub repositories
- [ ] Integration tests for new tools (follow-up PR)

## Related Issue

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)