### PR TITLE
feat(github): add GitHub Release Management tools (#57)

### DIFF
--- a/src/mcp_server_git/applications/server_application.py
+++ b/src/mcp_server_git/applications/server_application.py
@@ -23,6 +23,13 @@ from typing import Any, Literal
 from mcp.types import Tool
 from pydantic import BaseModel, Field, field_validator
 
+# Azure DevOps models for tool registration
+from ..azure.models import (
+    AzureGetBuildLogs,
+    AzureGetBuildStatus,
+    AzureGetFailingJobs,
+    AzureListBuilds,
+)
 from ..frameworks.mcp_server_framework import MCPServerFramework
 from ..frameworks.server_configuration import ServerConfigurationManager
 from ..frameworks.server_core import MCPGitServerCore
@@ -37,14 +44,6 @@ from ..services.git_service import GitService
 from ..services.server_metrics import MetricsService
 from ..services.server_session import SessionManager
 from ..utils.repository_resolver import RepositoryResolver
-
-# Azure DevOps models for tool registration
-from ..azure.models import (
-    AzureGetBuildLogs,
-    AzureGetBuildStatus,
-    AzureGetFailingJobs,
-    AzureListBuilds,
-)
 
 logger = logging.getLogger(__name__)
 

--- a/src/mcp_server_git/github/api.py
+++ b/src/mcp_server_git/github/api.py
@@ -3,9 +3,11 @@
 import asyncio
 import json
 import logging
+import mimetypes
 import time
 from contextlib import asynccontextmanager
 from datetime import datetime
+from pathlib import Path
 from typing import Any
 
 from .client import get_github_client
@@ -2759,6 +2761,594 @@ async def github_get_security_analysis(
         return f"❌ Error getting security analysis: {str(e)}"
 
 
+# ============================================================================
+# Release Management Functions
+# ============================================================================
+
+
+async def github_create_release(
+    repo_owner: str,
+    repo_name: str,
+    tag_name: str,
+    name: str | None = None,
+    body: str | None = None,
+    draft: bool = False,
+    prerelease: bool = False,
+    target_commitish: str | None = None,
+    generate_release_notes: bool = False,
+) -> str:
+    """Create a new GitHub release.
+
+    Args:
+        repo_owner: Repository owner
+        repo_name: Repository name
+        tag_name: Git tag name for the release
+        name: Release title (defaults to tag_name if not provided)
+        body: Release description/notes
+        draft: If true, creates a draft (unpublished) release
+        prerelease: If true, marks as pre-release
+        target_commitish: Branch or commit SHA for the release (defaults to default branch)
+        generate_release_notes: Auto-generate release notes from commits
+    """
+    logger.debug(f"🚀 Creating release {tag_name} for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            payload: dict[str, Any] = {
+                "tag_name": tag_name,
+                "draft": draft,
+                "prerelease": prerelease,
+            }
+
+            if name:
+                payload["name"] = name
+            if body:
+                payload["body"] = body
+            if target_commitish:
+                payload["target_commitish"] = target_commitish
+            if generate_release_notes:
+                payload["generate_release_notes"] = generate_release_notes
+
+            response = await client.post(
+                f"/repos/{repo_owner}/{repo_name}/releases",
+                json=payload,
+            )
+
+            if response.status == 404:
+                return f"❌ Repository {repo_owner}/{repo_name} not found"
+            if response.status == 422:
+                error_data = await response.json()
+                error_msg = error_data.get("message", "Validation failed")
+                return f"❌ Failed to create release: {error_msg}"
+            if response.status not in (200, 201):
+                error_text = await response.text()
+                return f"❌ Failed to create release: {response.status} - {error_text}"
+
+            release = await response.json()
+            release_url = release.get("html_url", "")
+            release_id = release.get("id", "")
+
+            status = []
+            if draft:
+                status.append("draft")
+            if prerelease:
+                status.append("pre-release")
+            status_str = f" ({', '.join(status)})" if status else ""
+
+            return f"✅ Release {tag_name} created successfully{status_str}\n🔗 URL: {release_url}\n📋 Release ID: {release_id}"
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error creating release: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error creating release: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error creating release: {e}", exc_info=True)
+        return f"❌ Error creating release: {str(e)}"
+
+
+async def github_get_release(
+    repo_owner: str,
+    repo_name: str,
+    release_id: int | None = None,
+    tag: str | None = None,
+) -> str:
+    """Get a GitHub release by ID or tag.
+
+    Args:
+        repo_owner: Repository owner
+        repo_name: Repository name
+        release_id: Release ID (mutually exclusive with tag)
+        tag: Tag name (mutually exclusive with release_id)
+    """
+    if not release_id and not tag:
+        return "❌ Either release_id or tag must be provided"
+    if release_id and tag:
+        return "❌ Only one of release_id or tag can be provided"
+
+    identifier = f"ID: {release_id}" if release_id else f"tag: {tag}"
+    logger.debug(f"🔍 Getting release for {repo_owner}/{repo_name} ({identifier})")
+
+    try:
+        async with github_client_context() as client:
+            if release_id:
+                endpoint = f"/repos/{repo_owner}/{repo_name}/releases/{release_id}"
+            else:
+                endpoint = f"/repos/{repo_owner}/{repo_name}/releases/tags/{tag}"
+
+            response = await client.get(endpoint)
+
+            if response.status == 404:
+                identifier = f"ID {release_id}" if release_id else f"tag '{tag}'"
+                return f"❌ Release {identifier} not found in {repo_owner}/{repo_name}"
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to get release: {response.status} - {error_text}"
+
+            release = await response.json()
+
+            output = [f"Release Information for {repo_owner}/{repo_name}:\n"]
+            output.append(f"📦 Tag: {release.get('tag_name')}")
+            output.append(f"📋 Name: {release.get('name') or '(none)'}")
+
+            status = []
+            if release.get("draft"):
+                status.append("draft")
+            if release.get("prerelease"):
+                status.append("pre-release")
+            if status:
+                output.append(f"🏷️  Status: {', '.join(status)}")
+
+            output.append(f"🔗 URL: {release.get('html_url')}")
+            output.append(f"📅 Created: {release.get('created_at')}")
+            output.append(
+                f"📅 Published: {release.get('published_at') or 'Not published'}"
+            )
+
+            author = release.get("author", {})
+            if author:
+                output.append(f"👤 Author: {author.get('login')}")
+
+            body = release.get("body")
+            if body:
+                output.append(f"\n📝 Description:\n{body}")
+
+            assets = release.get("assets", [])
+            if assets:
+                output.append(f"\n📎 Assets ({len(assets)}):")
+                for asset in assets:
+                    output.append(
+                        f"   • {asset.get('name')} ({asset.get('size')} bytes)"
+                    )
+            else:
+                output.append("\n📎 Assets: None")
+
+            return "\n".join(output)
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error getting release: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error getting release: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error getting release: {e}", exc_info=True)
+        return f"❌ Error getting release: {str(e)}"
+
+
+async def github_list_releases(
+    repo_owner: str,
+    repo_name: str,
+    per_page: int = 30,
+    page: int = 1,
+) -> str:
+    """List releases for a repository.
+
+    Args:
+        repo_owner: Repository owner
+        repo_name: Repository name
+        per_page: Number of releases per page (max 100)
+        page: Page number to retrieve
+    """
+    logger.debug(f"🔍 Listing releases for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.get(
+                f"/repos/{repo_owner}/{repo_name}/releases",
+                params={"per_page": per_page, "page": page},
+            )
+
+            if response.status == 404:
+                return f"❌ Repository {repo_owner}/{repo_name} not found"
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to list releases: {response.status} - {error_text}"
+
+            releases = await response.json()
+
+            if not releases:
+                return f"No releases found for {repo_owner}/{repo_name}"
+
+            output = [f"Releases for {repo_owner}/{repo_name}:\n"]
+
+            for release in releases:
+                tag = release.get("tag_name")
+                name = release.get("name") or tag
+                created = release.get("created_at", "")[:10]  # Just the date
+
+                status = []
+                if release.get("draft"):
+                    status.append("draft")
+                if release.get("prerelease"):
+                    status.append("pre-release")
+                status_str = f" [{', '.join(status)}]" if status else ""
+
+                output.append(f"📦 {tag}: {name}{status_str}")
+                output.append(f"   📅 Created: {created}")
+                output.append(f"   🔗 {release.get('html_url')}")
+                output.append("")
+
+            # Add pagination info
+            link_header = response.headers.get("Link", "")
+            if "next" in link_header or page > 1:
+                output.append(f"📄 Page {page} (use page parameter to see more)")
+
+            return "\n".join(output)
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error listing releases: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error listing releases: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error listing releases: {e}", exc_info=True)
+        return f"❌ Error listing releases: {str(e)}"
+
+
+async def github_update_release(
+    repo_owner: str,
+    repo_name: str,
+    release_id: int,
+    tag_name: str | None = None,
+    name: str | None = None,
+    body: str | None = None,
+    draft: bool | None = None,
+    prerelease: bool | None = None,
+    target_commitish: str | None = None,
+) -> str:
+    """Update a GitHub release.
+
+    Args:
+        repo_owner: Repository owner
+        repo_name: Repository name
+        release_id: Release ID to update
+        tag_name: New tag name
+        name: New release title
+        body: New release description
+        draft: Update draft status
+        prerelease: Update pre-release status
+        target_commitish: Update target commitish
+    """
+    logger.debug(f"🚀 Updating release {release_id} for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            # Build payload with only provided fields
+            payload: dict[str, Any] = {}
+            if tag_name is not None:
+                payload["tag_name"] = tag_name
+            if name is not None:
+                payload["name"] = name
+            if body is not None:
+                payload["body"] = body
+            if draft is not None:
+                payload["draft"] = draft
+            if prerelease is not None:
+                payload["prerelease"] = prerelease
+            if target_commitish is not None:
+                payload["target_commitish"] = target_commitish
+
+            if not payload:
+                return "❌ No fields provided to update"
+
+            response = await client.patch(
+                f"/repos/{repo_owner}/{repo_name}/releases/{release_id}",
+                json=payload,
+            )
+
+            if response.status == 404:
+                return f"❌ Release {release_id} not found in {repo_owner}/{repo_name}"
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to update release: {response.status} - {error_text}"
+
+            release = await response.json()
+            release_url = release.get("html_url", "")
+            tag = release.get("tag_name", "")
+
+            return f"✅ Release {tag} (ID: {release_id}) updated successfully\n🔗 URL: {release_url}"
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error updating release: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error updating release: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error updating release: {e}", exc_info=True)
+        return f"❌ Error updating release: {str(e)}"
+
+
+async def github_delete_release(
+    repo_owner: str,
+    repo_name: str,
+    release_id: int,
+) -> str:
+    """Delete a GitHub release.
+
+    Args:
+        repo_owner: Repository owner
+        repo_name: Repository name
+        release_id: Release ID to delete
+    """
+    logger.debug(f"🗑️  Deleting release {release_id} for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.delete(
+                f"/repos/{repo_owner}/{repo_name}/releases/{release_id}"
+            )
+
+            if response.status == 404:
+                return f"❌ Release {release_id} not found in {repo_owner}/{repo_name}"
+            if response.status != 204:
+                error_text = await response.text()
+                return f"❌ Failed to delete release: {response.status} - {error_text}"
+
+            return f"✅ Release {release_id} deleted successfully from {repo_owner}/{repo_name}"
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error deleting release: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error deleting release: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error deleting release: {e}", exc_info=True)
+        return f"❌ Error deleting release: {str(e)}"
+
+
+async def github_upload_release_asset(
+    repo_owner: str,
+    repo_name: str,
+    release_id: int,
+    file_path: str,
+    name: str | None = None,
+    label: str | None = None,
+) -> str:
+    """Upload a file as a release asset.
+
+    Args:
+        repo_owner: Repository owner
+        repo_name: Repository name
+        release_id: Release ID to upload asset to
+        file_path: Local path to file to upload
+        name: Asset name (defaults to filename)
+        label: Asset label/description
+    """
+    logger.debug(
+        f"📤 Uploading asset {file_path} to release {release_id} for {repo_owner}/{repo_name}"
+    )
+
+    try:
+        # Validate file exists
+        path = Path(file_path)
+        if not path.exists():
+            return f"❌ File not found: {file_path}"
+        if not path.is_file():
+            return f"❌ Path is not a file: {file_path}"
+
+        # Read file content
+        try:
+            with open(path, "rb") as f:
+                file_content = f.read()
+        except Exception as read_error:
+            return f"❌ Failed to read file {file_path}: {read_error}"
+
+        # Determine asset name
+        asset_name = name or path.name
+
+        # Determine content type (handle corrupt mimetypes database gracefully)
+        try:
+            content_type = (
+                mimetypes.guess_type(asset_name)[0] or "application/octet-stream"
+            )
+        except Exception:
+            content_type = "application/octet-stream"
+
+        async with github_client_context() as client:
+            # First get the release to get the upload_url
+            release_response = await client.get(
+                f"/repos/{repo_owner}/{repo_name}/releases/{release_id}"
+            )
+
+            if release_response.status == 404:
+                return f"❌ Release {release_id} not found in {repo_owner}/{repo_name}"
+            if release_response.status != 200:
+                error_text = await release_response.text()
+                return f"❌ Failed to get release: {release_response.status} - {error_text}"
+
+            release = await release_response.json()
+            upload_url = release.get("upload_url", "")
+
+            if not upload_url:
+                return f"❌ Release {release_id} has no upload URL"
+
+            # Remove the {?name,label} template from upload_url
+            upload_url = upload_url.split("{")[0]
+
+            # Build query params
+            params = {"name": asset_name}
+            if label:
+                params["label"] = label
+
+            # Upload the asset
+            response = await client.post(
+                upload_url,
+                params=params,
+                data=file_content,
+                headers={"Content-Type": content_type},
+            )
+
+            if response.status == 422:
+                error_data = await response.json()
+                error_msg = error_data.get("message", "Validation failed")
+                return f"❌ Failed to upload asset: {error_msg}"
+            if response.status not in (200, 201):
+                error_text = await response.text()
+                return f"❌ Failed to upload asset: {response.status} - {error_text}"
+
+            asset = await response.json()
+            asset_url = asset.get("browser_download_url", "")
+            asset_id = asset.get("id", "")
+            asset_size = asset.get("size", 0)
+
+            return f"✅ Asset '{asset_name}' uploaded successfully ({asset_size} bytes)\n🔗 URL: {asset_url}\n📋 Asset ID: {asset_id}"
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error uploading asset: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error uploading asset: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error uploading asset: {e}", exc_info=True)
+        return f"❌ Error uploading asset: {str(e)}"
+
+
+async def github_list_release_assets(
+    repo_owner: str,
+    repo_name: str,
+    release_id: int,
+    per_page: int = 30,
+    page: int = 1,
+) -> str:
+    """List assets for a release.
+
+    Args:
+        repo_owner: Repository owner
+        repo_name: Repository name
+        release_id: Release ID
+        per_page: Number of assets per page (max 100)
+        page: Page number to retrieve
+    """
+    logger.debug(
+        f"🔍 Listing assets for release {release_id} in {repo_owner}/{repo_name}"
+    )
+
+    try:
+        async with github_client_context() as client:
+            response = await client.get(
+                f"/repos/{repo_owner}/{repo_name}/releases/{release_id}/assets",
+                params={"per_page": per_page, "page": page},
+            )
+
+            if response.status == 404:
+                return f"❌ Release {release_id} not found in {repo_owner}/{repo_name}"
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to list assets: {response.status} - {error_text}"
+
+            assets = await response.json()
+
+            if not assets:
+                return f"No assets found for release {release_id}"
+
+            output = [f"Assets for Release {release_id} in {repo_owner}/{repo_name}:\n"]
+
+            for asset in assets:
+                name = asset.get("name")
+                size = asset.get("size", 0)
+                downloads = asset.get("download_count", 0)
+                content_type = asset.get("content_type", "unknown")
+                asset_id = asset.get("id")
+
+                # Format size nicely
+                if size < 1024:
+                    size_str = f"{size} B"
+                elif size < 1024 * 1024:
+                    size_str = f"{size / 1024:.1f} KB"
+                else:
+                    size_str = f"{size / (1024 * 1024):.1f} MB"
+
+                output.append(f"📎 {name}")
+                output.append(f"   ID: {asset_id}")
+                output.append(f"   Size: {size_str}")
+                output.append(f"   Type: {content_type}")
+                output.append(f"   Downloads: {downloads}")
+                output.append(f"   URL: {asset.get('browser_download_url')}")
+                output.append("")
+
+            # Add pagination info
+            link_header = response.headers.get("Link", "")
+            if "next" in link_header or page > 1:
+                output.append(f"📄 Page {page} (use page parameter to see more)")
+
+            return "\n".join(output)
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error listing assets: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error listing assets: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error listing assets: {e}", exc_info=True)
+        return f"❌ Error listing assets: {str(e)}"
+
+
+async def github_delete_release_asset(
+    repo_owner: str,
+    repo_name: str,
+    asset_id: int,
+) -> str:
+    """Delete a release asset.
+
+    Args:
+        repo_owner: Repository owner
+        repo_name: Repository name
+        asset_id: Asset ID to delete
+    """
+    logger.debug(f"🗑️  Deleting asset {asset_id} for {repo_owner}/{repo_name}")
+
+    try:
+        async with github_client_context() as client:
+            response = await client.delete(
+                f"/repos/{repo_owner}/{repo_name}/releases/assets/{asset_id}"
+            )
+
+            if response.status == 404:
+                return f"❌ Asset {asset_id} not found in {repo_owner}/{repo_name}"
+            if response.status != 204:
+                error_text = await response.text()
+                return f"❌ Failed to delete asset: {response.status} - {error_text}"
+
+            return f"✅ Asset {asset_id} deleted successfully from {repo_owner}/{repo_name}"
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error deleting asset: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error deleting asset: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error deleting asset: {e}", exc_info=True)
+        return f"❌ Error deleting asset: {str(e)}"
+
+
 async def github_list_workflow_runs(
     repo_owner: str,
     repo_name: str,
@@ -2804,7 +3394,7 @@ async def github_list_workflow_runs(
     try:
         async with github_client_context() as client:
             # Build query parameters with validation
-            params = {
+            params: dict[str, str | int | bool] = {
                 "per_page": min(max(per_page, 1), 100),  # Enforce GitHub API limits
                 "page": max(page, 1),
             }

--- a/src/mcp_server_git/github/models.py
+++ b/src/mcp_server_git/github/models.py
@@ -4,7 +4,6 @@ import re
 
 from pydantic import BaseModel, field_validator, model_validator
 
-
 # ============================================================================
 # Validation Constants
 # ============================================================================

--- a/src/mcp_server_git/github/models.py
+++ b/src/mcp_server_git/github/models.py
@@ -2,7 +2,7 @@
 
 import re
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, field_validator, model_validator
 
 
 # ============================================================================
@@ -684,3 +684,128 @@ class GitHubGetSecurityAnalysis(BaseModel):
 
     repo_owner: str
     repo_name: str
+
+
+# ============================================================================
+# GitHub Release Management Models (Issue #57)
+# ============================================================================
+
+
+class GitHubCreateRelease(BaseModel):
+    """Model for creating a new GitHub release.
+
+    Creates a release with optional release notes, draft mode, and prerelease flags.
+    Can optionally generate release notes automatically from commit history.
+    """
+
+    repo_owner: str
+    repo_name: str
+    tag_name: str
+    target_commitish: str | None = None  # defaults to default branch
+    name: str | None = None  # release title, defaults to tag_name
+    body: str | None = None  # release notes
+    draft: bool = False
+    prerelease: bool = False
+    generate_release_notes: bool = False
+
+
+class GitHubGetRelease(BaseModel):
+    """Model for fetching a specific release by ID or tag.
+
+    Either release_id or tag must be provided (mutually exclusive).
+    Returns full release details including assets, author, and timestamps.
+    """
+
+    repo_owner: str
+    repo_name: str
+    release_id: int | None = None  # mutually exclusive with tag
+    tag: str | None = None  # mutually exclusive with release_id
+
+    @model_validator(mode="after")
+    def validate_exclusive_params(self) -> "GitHubGetRelease":
+        """Ensure either release_id or tag is provided, but not both."""
+        if self.release_id is None and self.tag is None:
+            raise ValueError("Either release_id or tag must be provided")
+        if self.release_id is not None and self.tag is not None:
+            raise ValueError("Cannot specify both release_id and tag")
+        return self
+
+
+class GitHubListReleases(BaseModel):
+    """Model for listing repository releases.
+
+    Returns a paginated list of releases ordered by creation date (newest first).
+    """
+
+    repo_owner: str
+    repo_name: str
+    per_page: int = 30
+    page: int = 1
+
+
+class GitHubUpdateRelease(BaseModel):
+    """Model for updating an existing release.
+
+    All fields except repo_owner, repo_name, and release_id are optional.
+    Only provided fields will be updated.
+    """
+
+    repo_owner: str
+    repo_name: str
+    release_id: int
+    tag_name: str | None = None
+    target_commitish: str | None = None
+    name: str | None = None
+    body: str | None = None
+    draft: bool | None = None
+    prerelease: bool | None = None
+
+
+class GitHubDeleteRelease(BaseModel):
+    """Model for deleting a release.
+
+    Note: This does not delete the associated Git tag.
+    """
+
+    repo_owner: str
+    repo_name: str
+    release_id: int
+
+
+class GitHubUploadReleaseAsset(BaseModel):
+    """Model for uploading an asset to a release.
+
+    Uploads a file from the local filesystem to a GitHub release.
+    Asset name defaults to the filename if not provided.
+    """
+
+    repo_owner: str
+    repo_name: str
+    release_id: int
+    file_path: str  # local path to file
+    name: str | None = None  # asset name, defaults to filename
+    label: str | None = None  # description
+
+
+class GitHubListReleaseAssets(BaseModel):
+    """Model for listing assets of a release.
+
+    Returns paginated list of release assets with download URLs and metadata.
+    """
+
+    repo_owner: str
+    repo_name: str
+    release_id: int
+    per_page: int = 30
+    page: int = 1
+
+
+class GitHubDeleteReleaseAsset(BaseModel):
+    """Model for deleting a release asset.
+
+    Removes an asset from a release by asset ID.
+    """
+
+    repo_owner: str
+    repo_name: str
+    asset_id: int

--- a/src/mcp_server_git/lean/__main__.py
+++ b/src/mcp_server_git/lean/__main__.py
@@ -14,7 +14,6 @@ from dotenv import load_dotenv
 # Import services from the main server
 from ..services.git_service import GitService
 from ..services.github_service import GitHubService
-
 from .interface import create_git_lean_interface
 
 logger = logging.getLogger(__name__)

--- a/src/mcp_server_git/lean/tool_registry.py
+++ b/src/mcp_server_git/lean/tool_registry.py
@@ -64,6 +64,8 @@ def register_all_tools(
 def _register_git_tools(interface: Any, git_service: Any):
     """Register all Git domain tools."""
     # Import models for schema generation
+    # Import operations and Repo for path conversion
+    from ..git import operations as git_ops
     from ..git.models import (
         GitAbort,
         GitAdd,
@@ -87,9 +89,6 @@ def _register_git_tools(interface: Any, git_service: Any):
         GitShow,
         GitStatus,
     )
-
-    # Import operations and Repo for path conversion
-    from ..git import operations as git_ops
     from ..utils.git_import import Repo
 
     # Create wrapper functions that convert repo_path to Repo object
@@ -377,10 +376,10 @@ def _register_github_tools(interface: Any, github_service: Any):
         GitHubGetVulnerabilityAlerts,
         GitHubGetWorkflowPermissions,
         GitHubGetWorkflowRun,
-        GitHubListReleaseAssets,
-        GitHubListReleases,
         GitHubListIssues,
         GitHubListPullRequests,
+        GitHubListReleaseAssets,
+        GitHubListReleases,
         GitHubListWorkflowRuns,
         GitHubSearchIssues,
         GitHubUpdateActionsPermissions,

--- a/src/mcp_server_git/lean/tool_registry.py
+++ b/src/mcp_server_git/lean/tool_registry.py
@@ -1,11 +1,11 @@
 """
 Tool Registry for Git Lean MCP Interface.
 
-Registers all 68 tools across git, github, and azure domains with complete metadata.
+Registers all 76 tools across git, github, and azure domains with complete metadata.
 
 Tool Distribution:
 - Git tools (25): Core git operations
-- GitHub tools (39): PR, issues, workflows, repo settings, actions, branch protection, security
+- GitHub tools (47): PR, issues, workflows, repo settings, actions, branch protection, security, releases
 - Azure tools (4): Build logs and status
 
 New in Issue #41:
@@ -349,7 +349,10 @@ def _register_github_tools(interface: Any, github_service: Any):
         GitHubBulkUpdateIssues,
         GitHubCreateIssue,
         GitHubCreateIssueFromTemplate,
+        GitHubCreateRelease,
         GitHubDeleteBranchProtection,
+        GitHubDeleteRelease,
+        GitHubDeleteReleaseAsset,
         GitHubDisableAutomatedSecurityFixes,
         GitHubDisableVulnerabilityAlerts,
         GitHubEditPRDescription,
@@ -364,11 +367,14 @@ def _register_github_tools(interface: Any, github_service: Any):
         GitHubGetPRDetails,
         GitHubGetPRFiles,
         GitHubGetPRStatus,
+        GitHubGetRelease,
         GitHubGetRepoSettings,
         GitHubGetSecurityAnalysis,
         GitHubGetVulnerabilityAlerts,
         GitHubGetWorkflowPermissions,
         GitHubGetWorkflowRun,
+        GitHubListReleaseAssets,
+        GitHubListReleases,
         GitHubListIssues,
         GitHubListPullRequests,
         GitHubListWorkflowRuns,
@@ -376,8 +382,10 @@ def _register_github_tools(interface: Any, github_service: Any):
         GitHubUpdateActionsPermissions,
         GitHubUpdateBranchProtection,
         GitHubUpdateIssue,
+        GitHubUpdateRelease,
         GitHubUpdateRepoSettings,
         GitHubUpdateWorkflowPermissions,
+        GitHubUploadReleaseAsset,
     )
 
     github_tools = [
@@ -750,6 +758,71 @@ def _register_github_tools(interface: Any, github_service: Any):
             schema=GitHubGetSecurityAnalysis.model_json_schema(),
             domain="github",
             complexity="comprehensive",
+        ),
+        # Release Management Tools
+        ToolDefinition(
+            name="github_create_release",
+            implementation=github_ops.github_create_release,
+            description="Create a new GitHub release with tag, title, and notes",
+            schema=GitHubCreateRelease.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_get_release",
+            implementation=github_ops.github_get_release,
+            description="Get release information by ID or tag name",
+            schema=GitHubGetRelease.model_json_schema(),
+            domain="github",
+            complexity="core",
+        ),
+        ToolDefinition(
+            name="github_list_releases",
+            implementation=github_ops.github_list_releases,
+            description="List releases for a repository with pagination",
+            schema=GitHubListReleases.model_json_schema(),
+            domain="github",
+            complexity="core",
+        ),
+        ToolDefinition(
+            name="github_update_release",
+            implementation=github_ops.github_update_release,
+            description="Update an existing release's properties",
+            schema=GitHubUpdateRelease.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_delete_release",
+            implementation=github_ops.github_delete_release,
+            description="Delete a GitHub release (does not delete the git tag)",
+            schema=GitHubDeleteRelease.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_upload_release_asset",
+            implementation=github_ops.github_upload_release_asset,
+            description="Upload a file as an asset to a GitHub release",
+            schema=GitHubUploadReleaseAsset.model_json_schema(),
+            domain="github",
+            complexity="advanced",
+        ),
+        ToolDefinition(
+            name="github_list_release_assets",
+            implementation=github_ops.github_list_release_assets,
+            description="List assets attached to a release",
+            schema=GitHubListReleaseAssets.model_json_schema(),
+            domain="github",
+            complexity="core",
+        ),
+        ToolDefinition(
+            name="github_delete_release_asset",
+            implementation=github_ops.github_delete_release_asset,
+            description="Delete an asset from a release",
+            schema=GitHubDeleteReleaseAsset.model_json_schema(),
+            domain="github",
+            complexity="focused",
         ),
     ]
 

--- a/src/mcp_server_git/lean/tool_registry.py
+++ b/src/mcp_server_git/lean/tool_registry.py
@@ -1,12 +1,16 @@
 """
 Tool Registry for Git Lean MCP Interface.
 
-Registers all 76 tools across git, github, and azure domains with complete metadata.
+Registers all 77 tools across git, github, and azure domains with complete metadata.
 
 Tool Distribution:
-- Git tools (25): Core git operations
+- Git tools (26): Core git operations
 - GitHub tools (47): PR, issues, workflows, repo settings, actions, branch protection, security, releases
 - Azure tools (4): Build logs and status
+
+New in Issue #57:
+- Releases: create_release, get_release, list_releases, update_release, delete_release,
+           upload_release_asset, list_release_assets, delete_release_asset
 
 New in Issue #41:
 - Repository Settings: get_repo_settings, update_repo_settings

--- a/src/mcp_server_git/repository_binding.py
+++ b/src/mcp_server_git/repository_binding.py
@@ -153,10 +153,10 @@ class RepositoryBindingManager:
 
             try:
                 Repo(repository_path)
-            except git.InvalidGitRepositoryError:
+            except git.InvalidGitRepositoryError as err:
                 raise RepositoryBindingError(
                     f"Invalid git repository: {repository_path}"
-                )
+                ) from err
 
             # Verify remote URL if requested
             if verify_remote:
@@ -254,11 +254,11 @@ class RepositoryBindingManager:
                 raise RepositoryBindingError(
                     f"Operation path {operation_path} is outside bound repository {bound_path}. "
                     f"This prevents cross-repository contamination."
-                )
+                ) from e
             else:
                 raise RepositoryBindingError(
                     f"Cannot determine path relationship between {operation_path} and {bound_path}: {e}"
-                )
+                ) from e
 
     async def validate_remote_integrity(self) -> None:
         """
@@ -296,15 +296,15 @@ class RepositoryBindingManager:
                         f"'{DEFAULT_REMOTE_NAME}' remote has no URLs in {repo_path}"
                     )
                 return urls[0]
-            except AttributeError:
+            except AttributeError as err:
                 # origin remote doesn't exist
                 raise RepositoryBindingError(
                     f"No '{DEFAULT_REMOTE_NAME}' remote found in {repo_path}"
-                )
+                ) from err
         except Exception as e:
             raise RepositoryBindingError(
                 f"Failed to get remote URL from {repo_path}: {e}"
-            )
+            ) from e
 
     def get_binding_info(self) -> dict:
         """Get current binding information."""

--- a/tests/lean/test_token_limiter.py
+++ b/tests/lean/test_token_limiter.py
@@ -5,8 +5,8 @@ import json
 import pytest
 
 from mcp_server_git.lean.token_limiter import (
-    ContentType,
     ContentTruncator,
+    ContentType,
     MCPTokenLimiter,
     TokenEstimator,
     TruncationConfig,

--- a/tests/test_e2e_server.py
+++ b/tests/test_e2e_server.py
@@ -154,7 +154,7 @@ async def mcp_server():
 
             try:
                 await asyncio.wait_for(process.wait(), timeout=5.0)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 # Force kill if it doesn't terminate
                 try:
                     process.kill()
@@ -163,7 +163,7 @@ async def mcp_server():
                     pass
                 try:
                     await asyncio.wait_for(process.wait(), timeout=3.0)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     pass  # Give up, let it be cleaned up by OS
 
         # Ensure all streams are properly closed

--- a/tests/test_environment_loading.py
+++ b/tests/test_environment_loading.py
@@ -5,11 +5,11 @@ from unittest.mock import patch
 
 import pytest
 
-# Import from current modular architecture
-from mcp_server_git.github.client import get_github_client
-
 # Note: load_environment_variables is now handled by dotenv in main()
 from dotenv import load_dotenv
+
+# Import from current modular architecture
+from mcp_server_git.github.client import get_github_client
 
 
 class TestEnvironmentLoading:
@@ -17,8 +17,8 @@ class TestEnvironmentLoading:
 
     def load_environment_variables(self, repository=None):
         """Helper method that mimics the old load_environment_variables function using dotenv."""
-        from pathlib import Path
         import os
+        from pathlib import Path
 
         # Store the original environment state
         env_overrides = {}
@@ -39,7 +39,7 @@ class TestEnvironmentLoading:
         if claude_code_path:
             claude_env = claude_code_path / ".env"
             if claude_env.exists():
-                with open(claude_env, "r") as f:
+                with open(claude_env) as f:
                     for line in f:
                         line = line.strip()
                         if "=" in line and not line.startswith("#"):
@@ -50,7 +50,7 @@ class TestEnvironmentLoading:
         if repository:
             repo_env = Path(repository) / ".env"
             if repo_env.exists():
-                with open(repo_env, "r") as f:
+                with open(repo_env) as f:
                     for line in f:
                         line = line.strip()
                         if "=" in line and not line.startswith("#"):
@@ -61,7 +61,7 @@ class TestEnvironmentLoading:
         current_env = Path.cwd() / ".env"
         if current_env.exists():
             # Parse the .env file manually to get override values
-            with open(current_env, "r") as f:
+            with open(current_env) as f:
                 for line in f:
                     line = line.strip()
                     if "=" in line and not line.startswith("#"):

--- a/tests/test_llm_compliant_server_e2e.py
+++ b/tests/test_llm_compliant_server_e2e.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 import pytest
+
 from .conftest import _run_git_isolated
 
 
@@ -184,7 +185,7 @@ async def llm_compliant_server():
             except ProcessLookupError:
                 # Process already exited, which is fine
                 pass
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 # Force kill if it doesn't terminate
                 try:
                     if process.returncode is None:
@@ -192,7 +193,7 @@ async def llm_compliant_server():
                 except ProcessLookupError:
                     pass  # Already dead
                     await asyncio.wait_for(process.wait(), timeout=3.0)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     pass  # Give up, let it be cleaned up by OS
 
         # Ensure all streams are properly closed before fixture cleanup

--- a/tests/unit/applications/test_server_application_token_middleware_integration.py
+++ b/tests/unit/applications/test_server_application_token_middleware_integration.py
@@ -11,9 +11,10 @@ These tests specifically validate Task 2 implementation:
 Focus: Testing the integration work completed in Task 2 without requiring full server startup.
 """
 
-import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from mcp_server_git.applications.server_application import (
     ServerApplication,

--- a/tests/unit/applications/test_server_tool_integration.py
+++ b/tests/unit/applications/test_server_tool_integration.py
@@ -1,12 +1,13 @@
 """Unit tests for server application tool integration."""
 
-import pytest
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from mcp_server_git.applications.server_application import (
-    GitTools,
-    GitHubTools,
     AzureTools,
+    GitHubTools,
+    GitTools,
     ServerApplication,
 )
 
@@ -58,7 +59,7 @@ class TestServerToolIntegration:
 
         # Verify the method exists and is callable
         assert hasattr(app, "_execute_tool_operation")
-        assert callable(getattr(app, "_execute_tool_operation"))
+        assert callable(app._execute_tool_operation)
 
     def test_github_tools_registered(self):
         """Test that GitHub tools are properly defined in GitHubTools enum."""

--- a/tests/unit/git/test_git_diff_validation.py
+++ b/tests/unit/git/test_git_diff_validation.py
@@ -11,13 +11,14 @@ Critical for TDD Compliance:
     implementation must be fixed to pass these tests.
 """
 
-import pytest
 from unittest.mock import Mock, patch
 
+import pytest
+
 from mcp_server_git.git.operations import (
+    _apply_diff_size_limiting,
     _validate_commit_range,
     _validate_diff_parameters,
-    _apply_diff_size_limiting,
     git_diff,
     git_diff_staged,
     git_diff_unstaged,

--- a/tests/unit/git/test_git_init.py
+++ b/tests/unit/git/test_git_init.py
@@ -1,8 +1,9 @@
 """Tests for git_init operation on non-initialized directories"""
 
-import tempfile
 import shutil
+import tempfile
 from pathlib import Path
+
 import pytest
 
 

--- a/tests/unit/github/test_github_releases.py
+++ b/tests/unit/github/test_github_releases.py
@@ -1,0 +1,1165 @@
+"""
+Unit tests for GitHub release management functions.
+
+Tests the GitHub release management functionality including:
+- Creating releases with various configurations
+- Retrieving releases by ID or tag
+- Listing releases with pagination
+- Updating releases with different field combinations
+- Deleting releases
+- Uploading release assets
+- Listing release assets
+- Deleting release assets
+- Pydantic model validators for GitHubGetRelease
+- Authentication and connection error handling
+- API error responses (404, 422, etc.)
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, mock_open, patch
+
+import pytest
+from pydantic import ValidationError
+
+from src.mcp_server_git.github.api import (
+    github_create_release,
+    github_delete_release,
+    github_delete_release_asset,
+    github_get_release,
+    github_list_release_assets,
+    github_list_releases,
+    github_update_release,
+    github_upload_release_asset,
+)
+from src.mcp_server_git.github.models import GitHubGetRelease
+
+
+class TestGitHubCreateRelease:
+    """Test github_create_release function."""
+
+    @pytest.mark.asyncio
+    async def test_create_release_success(self):
+        """Test successfully creating a release with basic parameters."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 201
+        mock_response.json = AsyncMock(
+            return_value={
+                "id": 12345,
+                "tag_name": "v1.0.0",
+                "name": "Version 1.0.0",
+                "html_url": "https://github.com/owner/repo/releases/tag/v1.0.0",
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_release(
+                repo_owner="owner",
+                repo_name="repo",
+                tag_name="v1.0.0",
+                name="Version 1.0.0",
+                body="Release notes here",
+            )
+
+            assert "✅ Release v1.0.0 created successfully" in result
+            assert "https://github.com/owner/repo/releases/tag/v1.0.0" in result
+            assert "12345" in result
+            mock_client.post.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_create_release_draft(self):
+        """Test creating a draft release."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 201
+        mock_response.json = AsyncMock(
+            return_value={
+                "id": 12345,
+                "tag_name": "v2.0.0",
+                "html_url": "https://github.com/owner/repo/releases/tag/v2.0.0",
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_release(
+                repo_owner="owner",
+                repo_name="repo",
+                tag_name="v2.0.0",
+                draft=True,
+            )
+
+            assert "✅ Release v2.0.0 created successfully" in result
+            assert "(draft)" in result
+
+    @pytest.mark.asyncio
+    async def test_create_release_prerelease(self):
+        """Test creating a pre-release."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 201
+        mock_response.json = AsyncMock(
+            return_value={
+                "id": 12345,
+                "tag_name": "v3.0.0-beta",
+                "html_url": "https://github.com/owner/repo/releases/tag/v3.0.0-beta",
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_release(
+                repo_owner="owner",
+                repo_name="repo",
+                tag_name="v3.0.0-beta",
+                prerelease=True,
+            )
+
+            assert "✅ Release v3.0.0-beta created successfully" in result
+            assert "(pre-release)" in result
+
+    @pytest.mark.asyncio
+    async def test_create_release_draft_and_prerelease(self):
+        """Test creating a draft pre-release."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 201
+        mock_response.json = AsyncMock(
+            return_value={
+                "id": 12345,
+                "tag_name": "v4.0.0-rc",
+                "html_url": "https://github.com/owner/repo/releases/tag/v4.0.0-rc",
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_release(
+                repo_owner="owner",
+                repo_name="repo",
+                tag_name="v4.0.0-rc",
+                draft=True,
+                prerelease=True,
+            )
+
+            assert "✅ Release v4.0.0-rc created successfully" in result
+            assert "(draft, pre-release)" in result
+
+    @pytest.mark.asyncio
+    async def test_create_release_repo_not_found_404(self):
+        """Test that 404 error is handled for non-existent repository."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_release(
+                repo_owner="nonexistent",
+                repo_name="fake-repo",
+                tag_name="v1.0.0",
+            )
+
+            assert "❌ Repository nonexistent/fake-repo not found" in result
+
+    @pytest.mark.asyncio
+    async def test_create_release_validation_error_422(self):
+        """Test that 422 validation error is handled properly."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 422
+        mock_response.json = AsyncMock(
+            return_value={
+                "message": "Validation Failed: Tag already exists",
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_release(
+                repo_owner="owner",
+                repo_name="repo",
+                tag_name="v1.0.0",
+            )
+
+            assert "❌ Failed to create release" in result
+            assert "Tag already exists" in result
+
+    @pytest.mark.asyncio
+    async def test_create_release_auth_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_create_release(
+                repo_owner="owner",
+                repo_name="repo",
+                tag_name="v1.0.0",
+            )
+
+            assert "❌ GitHub token not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_create_release_connection_error(self):
+        """Test that connection errors are handled gracefully."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_create_release(
+                repo_owner="owner",
+                repo_name="repo",
+                tag_name="v1.0.0",
+            )
+
+            assert "❌ Network connection failed" in result
+            assert "Network timeout" in result
+
+
+class TestGitHubGetRelease:
+    """Test github_get_release function."""
+
+    @pytest.mark.asyncio
+    async def test_get_release_by_id_success(self):
+        """Test successfully retrieving a release by ID."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "id": 12345,
+                "tag_name": "v1.0.0",
+                "name": "Version 1.0.0",
+                "body": "Release notes here",
+                "draft": False,
+                "prerelease": False,
+                "html_url": "https://github.com/owner/repo/releases/tag/v1.0.0",
+                "created_at": "2024-01-01T00:00:00Z",
+                "published_at": "2024-01-01T01:00:00Z",
+                "author": {"login": "testuser"},
+                "assets": [
+                    {"name": "app.zip", "size": 1024},
+                    {"name": "app.tar.gz", "size": 2048},
+                ],
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+            )
+
+            assert "Release Information for owner/repo" in result
+            assert "📦 Tag: v1.0.0" in result
+            assert "📋 Name: Version 1.0.0" in result
+            assert "Release notes here" in result
+            assert "👤 Author: testuser" in result
+            assert "📎 Assets (2)" in result
+            assert "app.zip" in result
+            assert "app.tar.gz" in result
+
+    @pytest.mark.asyncio
+    async def test_get_release_by_tag_success(self):
+        """Test successfully retrieving a release by tag."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "id": 12345,
+                "tag_name": "v2.0.0",
+                "name": "Version 2.0.0",
+                "body": None,
+                "draft": False,
+                "prerelease": False,
+                "html_url": "https://github.com/owner/repo/releases/tag/v2.0.0",
+                "created_at": "2024-02-01T00:00:00Z",
+                "published_at": "2024-02-01T01:00:00Z",
+                "author": {"login": "testuser"},
+                "assets": [],
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_release(
+                repo_owner="owner",
+                repo_name="repo",
+                tag="v2.0.0",
+            )
+
+            assert "Release Information for owner/repo" in result
+            assert "📦 Tag: v2.0.0" in result
+            assert "📎 Assets: None" in result
+
+    @pytest.mark.asyncio
+    async def test_get_release_draft_status(self):
+        """Test that draft status is displayed correctly."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "id": 12345,
+                "tag_name": "v3.0.0",
+                "name": "Version 3.0.0",
+                "draft": True,
+                "prerelease": False,
+                "html_url": "https://github.com/owner/repo/releases/tag/v3.0.0",
+                "created_at": "2024-03-01T00:00:00Z",
+                "published_at": None,
+                "author": {"login": "testuser"},
+                "assets": [],
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+            )
+
+            assert "🏷️  Status: draft" in result
+            assert "📅 Published: Not published" in result
+
+    @pytest.mark.asyncio
+    async def test_get_release_prerelease_status(self):
+        """Test that pre-release status is displayed correctly."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "id": 12345,
+                "tag_name": "v4.0.0-beta",
+                "name": "Version 4.0.0 Beta",
+                "draft": False,
+                "prerelease": True,
+                "html_url": "https://github.com/owner/repo/releases/tag/v4.0.0-beta",
+                "created_at": "2024-04-01T00:00:00Z",
+                "published_at": "2024-04-01T01:00:00Z",
+                "author": {"login": "testuser"},
+                "assets": [],
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_release(
+                repo_owner="owner",
+                repo_name="repo",
+                tag="v4.0.0-beta",
+            )
+
+            assert "🏷️  Status: pre-release" in result
+
+    @pytest.mark.asyncio
+    async def test_get_release_not_found_404(self):
+        """Test that 404 error is handled for non-existent release."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=99999,
+            )
+
+            assert "❌ Release ID 99999 not found" in result
+
+    @pytest.mark.asyncio
+    async def test_get_release_auth_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_get_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+            )
+
+            assert "❌ GitHub token not configured" in result
+
+
+class TestGitHubListReleases:
+    """Test github_list_releases function."""
+
+    @pytest.mark.asyncio
+    async def test_list_releases_success(self):
+        """Test successfully listing releases."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.headers = {"Link": ""}
+        mock_response.json = AsyncMock(
+            return_value=[
+                {
+                    "tag_name": "v1.0.0",
+                    "name": "Version 1.0.0",
+                    "draft": False,
+                    "prerelease": False,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "html_url": "https://github.com/owner/repo/releases/tag/v1.0.0",
+                },
+                {
+                    "tag_name": "v0.9.0",
+                    "name": None,
+                    "draft": False,
+                    "prerelease": True,
+                    "created_at": "2023-12-01T00:00:00Z",
+                    "html_url": "https://github.com/owner/repo/releases/tag/v0.9.0",
+                },
+            ]
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_list_releases(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "Releases for owner/repo" in result
+            assert "📦 v1.0.0: Version 1.0.0" in result
+            assert "📦 v0.9.0: v0.9.0" in result
+            assert "[pre-release]" in result
+            assert "2024-01-01" in result
+            assert "2023-12-01" in result
+
+    @pytest.mark.asyncio
+    async def test_list_releases_empty(self):
+        """Test listing releases when none exist."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=[])
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_list_releases(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "No releases found for owner/repo" in result
+
+    @pytest.mark.asyncio
+    async def test_list_releases_with_pagination(self):
+        """Test listing releases with pagination info."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.headers = {
+            "Link": '<https://api.github.com/repos/owner/repo/releases?page=3>; rel="next"'
+        }
+        mock_response.json = AsyncMock(
+            return_value=[
+                {
+                    "tag_name": "v1.0.0",
+                    "name": "Version 1.0.0",
+                    "draft": False,
+                    "prerelease": False,
+                    "created_at": "2024-01-01T00:00:00Z",
+                    "html_url": "https://github.com/owner/repo/releases/tag/v1.0.0",
+                }
+            ]
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_list_releases(
+                repo_owner="owner",
+                repo_name="repo",
+                page=2,
+            )
+
+            assert "📄 Page 2 (use page parameter to see more)" in result
+
+    @pytest.mark.asyncio
+    async def test_list_releases_auth_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_list_releases(
+                repo_owner="owner",
+                repo_name="repo",
+            )
+
+            assert "❌ GitHub token not configured" in result
+
+
+class TestGitHubUpdateRelease:
+    """Test github_update_release function."""
+
+    @pytest.mark.asyncio
+    async def test_update_release_success(self):
+        """Test successfully updating a release."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "tag_name": "v1.0.0",
+                "name": "Updated Release Title",
+                "html_url": "https://github.com/owner/repo/releases/tag/v1.0.0",
+            }
+        )
+        mock_client.patch = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+                name="Updated Release Title",
+                body="Updated release notes",
+            )
+
+            assert "✅ Release v1.0.0 (ID: 12345) updated successfully" in result
+            assert "https://github.com/owner/repo/releases/tag/v1.0.0" in result
+
+    @pytest.mark.asyncio
+    async def test_update_release_publish_draft(self):
+        """Test publishing a draft release."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "tag_name": "v2.0.0",
+                "name": "Version 2.0.0",
+                "html_url": "https://github.com/owner/repo/releases/tag/v2.0.0",
+            }
+        )
+        mock_client.patch = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+                draft=False,
+            )
+
+            assert "✅ Release v2.0.0 (ID: 12345) updated successfully" in result
+
+    @pytest.mark.asyncio
+    async def test_update_release_no_fields(self):
+        """Test that providing no update fields returns warning."""
+        mock_client = MagicMock()
+        mock_client.patch = AsyncMock()
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+            )
+
+            assert "❌ No fields provided to update" in result
+            mock_client.patch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_update_release_not_found_404(self):
+        """Test that 404 error is handled for non-existent release."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.patch = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=99999,
+                name="New Name",
+            )
+
+            assert "❌ Release 99999 not found" in result
+
+    @pytest.mark.asyncio
+    async def test_update_release_auth_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_update_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+                name="New Name",
+            )
+
+            assert "❌ GitHub token not configured" in result
+
+
+class TestGitHubDeleteRelease:
+    """Test github_delete_release function."""
+
+    @pytest.mark.asyncio
+    async def test_delete_release_success(self):
+        """Test successfully deleting a release."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 204
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_delete_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+            )
+
+            assert "✅ Release 12345 deleted successfully" in result
+            assert "owner/repo" in result
+            mock_client.delete.assert_called_once_with(
+                "/repos/owner/repo/releases/12345"
+            )
+
+    @pytest.mark.asyncio
+    async def test_delete_release_not_found_404(self):
+        """Test that 404 error is handled for non-existent release."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_delete_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=99999,
+            )
+
+            assert "❌ Release 99999 not found" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_release_auth_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_delete_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+            )
+
+            assert "❌ GitHub token not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_release_connection_error(self):
+        """Test that connection errors are handled gracefully."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_delete_release(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+            )
+
+            assert "❌ Network connection failed" in result
+            assert "Network timeout" in result
+
+
+class TestGitHubUploadReleaseAsset:
+    """Test github_upload_release_asset function."""
+
+    @pytest.mark.asyncio
+    async def test_upload_asset_success(self):
+        """Test successfully uploading a release asset."""
+        mock_client = MagicMock()
+
+        # Mock the release response
+        release_response = AsyncMock()
+        release_response.status = 200
+        release_response.json = AsyncMock(
+            return_value={
+                "upload_url": "https://uploads.github.com/repos/owner/repo/releases/12345/assets{?name,label}"
+            }
+        )
+
+        # Mock the upload response
+        upload_response = AsyncMock()
+        upload_response.status = 201
+        upload_response.json = AsyncMock(
+            return_value={
+                "id": 67890,
+                "name": "app.zip",
+                "size": 1024,
+                "browser_download_url": "https://github.com/owner/repo/releases/download/v1.0.0/app.zip",
+            }
+        )
+
+        async def mock_get_post(url, **kwargs):
+            if "releases/12345/assets" in url or "releases/12345" in url:
+                if kwargs.get("data"):
+                    return upload_response
+                return release_response
+            return release_response
+
+        mock_client.get = AsyncMock(return_value=release_response)
+        mock_client.post = AsyncMock(side_effect=mock_get_post)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context, patch("builtins.open", mock_open(read_data=b"file content")), patch(
+            "pathlib.Path.exists", return_value=True
+        ), patch(
+            "pathlib.Path.is_file", return_value=True
+        ):
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_upload_release_asset(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+                file_path="/tmp/app.zip",
+                name="app.zip",
+                label="Application archive",
+            )
+
+            assert "✅ Asset 'app.zip' uploaded successfully" in result
+            assert "1024 bytes" in result
+            assert "67890" in result
+
+    @pytest.mark.asyncio
+    async def test_upload_asset_file_not_found(self):
+        """Test that file not found error is handled."""
+        with patch("pathlib.Path.exists", return_value=False):
+            result = await github_upload_release_asset(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+                file_path="/tmp/nonexistent.zip",
+            )
+
+            assert "❌ File not found: /tmp/nonexistent.zip" in result
+
+    @pytest.mark.asyncio
+    async def test_upload_asset_release_not_found(self):
+        """Test that 404 error is handled for non-existent release."""
+        mock_client = MagicMock()
+
+        release_response = AsyncMock()
+        release_response.status = 404
+        mock_client.get = AsyncMock(return_value=release_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context, patch("builtins.open", mock_open(read_data=b"file content")), patch(
+            "pathlib.Path.exists", return_value=True
+        ), patch(
+            "pathlib.Path.is_file", return_value=True
+        ):
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_upload_release_asset(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=99999,
+                file_path="/tmp/app.zip",
+            )
+
+            assert "❌ Release 99999 not found" in result
+
+    @pytest.mark.asyncio
+    async def test_upload_asset_auth_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context, patch(
+            "builtins.open", mock_open(read_data=b"file content")
+        ), patch(
+            "pathlib.Path.exists", return_value=True
+        ), patch(
+            "pathlib.Path.is_file", return_value=True
+        ):
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_upload_release_asset(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+                file_path="/tmp/app.zip",
+            )
+
+            assert "❌ GitHub token not configured" in result
+
+
+class TestGitHubListReleaseAssets:
+    """Test github_list_release_assets function."""
+
+    @pytest.mark.asyncio
+    async def test_list_assets_success(self):
+        """Test successfully listing release assets."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.headers = {"Link": ""}
+        mock_response.json = AsyncMock(
+            return_value=[
+                {
+                    "id": 1,
+                    "name": "app.zip",
+                    "size": 1024,
+                    "download_count": 42,
+                    "content_type": "application/zip",
+                    "browser_download_url": "https://github.com/owner/repo/releases/download/v1.0.0/app.zip",
+                },
+                {
+                    "id": 2,
+                    "name": "app.tar.gz",
+                    "size": 2048000,
+                    "download_count": 10,
+                    "content_type": "application/gzip",
+                    "browser_download_url": "https://github.com/owner/repo/releases/download/v1.0.0/app.tar.gz",
+                },
+            ]
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_list_release_assets(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+            )
+
+            assert "Assets for Release 12345" in result
+            assert "📎 app.zip" in result
+            assert "1.0 KB" in result
+            assert "Downloads: 42" in result
+            assert "📎 app.tar.gz" in result
+            assert "2.0 MB" in result
+            assert "Downloads: 10" in result
+
+    @pytest.mark.asyncio
+    async def test_list_assets_empty(self):
+        """Test listing assets when none exist."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=[])
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_list_release_assets(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+            )
+
+            assert "No assets found for release 12345" in result
+
+    @pytest.mark.asyncio
+    async def test_list_assets_not_found_404(self):
+        """Test that 404 error is handled for non-existent release."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_list_release_assets(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=99999,
+            )
+
+            assert "❌ Release 99999 not found" in result
+
+
+class TestGitHubDeleteReleaseAsset:
+    """Test github_delete_release_asset function."""
+
+    @pytest.mark.asyncio
+    async def test_delete_asset_success(self):
+        """Test successfully deleting a release asset."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 204
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_delete_release_asset(
+                repo_owner="owner",
+                repo_name="repo",
+                asset_id=67890,
+            )
+
+            assert "✅ Asset 67890 deleted successfully" in result
+            assert "owner/repo" in result
+            mock_client.delete.assert_called_once_with(
+                "/repos/owner/repo/releases/assets/67890"
+            )
+
+    @pytest.mark.asyncio
+    async def test_delete_asset_not_found_404(self):
+        """Test that 404 error is handled for non-existent asset."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.delete = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_delete_release_asset(
+                repo_owner="owner",
+                repo_name="repo",
+                asset_id=99999,
+            )
+
+            assert "❌ Asset 99999 not found" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_asset_auth_error(self):
+        """Test that authentication errors are handled properly."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_delete_release_asset(
+                repo_owner="owner",
+                repo_name="repo",
+                asset_id=67890,
+            )
+
+            assert "❌ GitHub token not configured" in result
+
+    @pytest.mark.asyncio
+    async def test_delete_asset_connection_error(self):
+        """Test that connection errors are handled gracefully."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network timeout"
+            )
+
+            result = await github_delete_release_asset(
+                repo_owner="owner",
+                repo_name="repo",
+                asset_id=67890,
+            )
+
+            assert "❌ Network connection failed" in result
+            assert "Network timeout" in result
+
+
+class TestGitHubGetReleaseModel:
+    """Test Pydantic model validators for GitHubGetRelease."""
+
+    def test_valid_with_release_id(self):
+        """Test that providing release_id is valid."""
+        model = GitHubGetRelease(
+            repo_owner="owner",
+            repo_name="repo",
+            release_id=12345,
+        )
+        assert model.release_id == 12345
+        assert model.tag is None
+
+    def test_valid_with_tag(self):
+        """Test that providing tag is valid."""
+        model = GitHubGetRelease(
+            repo_owner="owner",
+            repo_name="repo",
+            tag="v1.0.0",
+        )
+        assert model.tag == "v1.0.0"
+        assert model.release_id is None
+
+    def test_invalid_neither_provided(self):
+        """Test that providing neither release_id nor tag raises ValidationError.
+
+        Note: The validator is on release_id field, so we need to explicitly
+        set release_id to None to trigger the validation.
+        """
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubGetRelease(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=None,
+                tag=None,
+            )
+        assert "Either release_id or tag must be provided" in str(exc_info.value)
+
+    def test_invalid_both_provided(self):
+        """Test that providing both release_id and tag raises ValidationError."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubGetRelease(
+                repo_owner="owner",
+                repo_name="repo",
+                release_id=12345,
+                tag="v1.0.0",
+            )
+        assert "Cannot specify both release_id and tag" in str(exc_info.value)

--- a/tests/unit/github/test_github_releases.py
+++ b/tests/unit/github/test_github_releases.py
@@ -840,12 +840,13 @@ class TestGitHubUploadReleaseAsset:
         mock_client.get = AsyncMock(return_value=release_response)
         mock_client.post = AsyncMock(side_effect=mock_get_post)
 
-        with patch(
-            "src.mcp_server_git.github.api.github_client_context"
-        ) as mock_context, patch("builtins.open", mock_open(read_data=b"file content")), patch(
-            "pathlib.Path.exists", return_value=True
-        ), patch(
-            "pathlib.Path.is_file", return_value=True
+        with (
+            patch(
+                "src.mcp_server_git.github.api.github_client_context"
+            ) as mock_context,
+            patch("builtins.open", mock_open(read_data=b"file content")),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
         ):
             mock_context.return_value.__aenter__.return_value = mock_client
 
@@ -884,12 +885,13 @@ class TestGitHubUploadReleaseAsset:
         release_response.status = 404
         mock_client.get = AsyncMock(return_value=release_response)
 
-        with patch(
-            "src.mcp_server_git.github.api.github_client_context"
-        ) as mock_context, patch("builtins.open", mock_open(read_data=b"file content")), patch(
-            "pathlib.Path.exists", return_value=True
-        ), patch(
-            "pathlib.Path.is_file", return_value=True
+        with (
+            patch(
+                "src.mcp_server_git.github.api.github_client_context"
+            ) as mock_context,
+            patch("builtins.open", mock_open(read_data=b"file content")),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
         ):
             mock_context.return_value.__aenter__.return_value = mock_client
 
@@ -905,14 +907,13 @@ class TestGitHubUploadReleaseAsset:
     @pytest.mark.asyncio
     async def test_upload_asset_auth_error(self):
         """Test that authentication errors are handled properly."""
-        with patch(
-            "src.mcp_server_git.github.api.github_client_context"
-        ) as mock_context, patch(
-            "builtins.open", mock_open(read_data=b"file content")
-        ), patch(
-            "pathlib.Path.exists", return_value=True
-        ), patch(
-            "pathlib.Path.is_file", return_value=True
+        with (
+            patch(
+                "src.mcp_server_git.github.api.github_client_context"
+            ) as mock_context,
+            patch("builtins.open", mock_open(read_data=b"file content")),
+            patch("pathlib.Path.exists", return_value=True),
+            patch("pathlib.Path.is_file", return_value=True),
         ):
             mock_context.return_value.__aenter__.side_effect = ValueError(
                 "GitHub token not configured"


### PR DESCRIPTION
## Summary
Add 8 new GitHub API tools for release management, addressing the gap identified in issue #57 where release automation workflows required fallback to `gh` CLI.

### New Tools
- `github_create_release` - Create releases with draft/prerelease/auto-notes support
- `github_get_release` - Get release by ID or tag name (mutually exclusive)
- `github_list_releases` - List releases with pagination
- `github_update_release` - Update release properties
- `github_delete_release` - Delete releases (preserves git tags)
- `github_upload_release_asset` - Upload files as release assets
- `github_list_release_assets` - List assets for a release
- `github_delete_release_asset` - Delete release assets

### Implementation Details
- Pydantic models with mutual exclusivity validation (`model_validator` for release_id vs tag)
- Graceful mimetypes error handling (handles corrupt system DB)
- 42 comprehensive unit tests covering success, errors, and edge cases
- Tool registry updated: 77 total tools (26 git + 47 github + 4 azure)

## Test Plan
- [x] All 42 new release tests pass
- [x] All 208 GitHub API tests pass
- [x] Type checking passes (pyright)
- [x] Lint/format checks pass (ruff)

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)