### PR TITLE
feat: HTTP transport with SSE support and stash tools

### DIFF
--- a/mcp-git-http.service
+++ b/mcp-git-http.service
@@ -1,0 +1,47 @@
+# User-level systemd service for mcp-git HTTP server
+# Install to: ~/.config/systemd/user/mcp-git-http.service
+#
+# Installation:
+#   mkdir -p ~/.config/systemd/user
+#   cp mcp-git-http.service ~/.config/systemd/user/mcp-git-http.service
+#   systemctl --user daemon-reload
+#   systemctl --user enable mcp-git-http
+#   systemctl --user start mcp-git-http
+#
+# Commands:
+#   systemctl --user status mcp-git-http
+#   systemctl --user stop mcp-git-http
+#   systemctl --user restart mcp-git-http
+#   journalctl --user -u mcp-git-http -f
+
+[Unit]
+Description=MCP Git HTTP Server (User)
+Documentation=https://github.com/MementoRC/mcp-git
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/ClaudeCode/Servers/git/worktrees/feat-issues-impl
+
+# Environment
+Environment=MCP_GIT_HTTP_PORT=4100
+Environment=LOG_LEVEL=INFO
+Environment=PYTHONPATH=%h/ClaudeCode/Servers/git/worktrees/feat-issues-impl/src
+
+# Use pixi to run the server
+ExecStart=%h/.conda/envs/ClaudeCode/bin/pixi run pixi-git-server-http --port 4100
+ExecReload=/bin/kill -HUP $MAINPID
+
+# Restart configuration
+Restart=on-failure
+RestartSec=5
+StartLimitBurst=3
+StartLimitIntervalSec=60
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=mcp-git-http
+
+[Install]
+WantedBy=default.target

--- a/mcp-git-http.service
+++ b/mcp-git-http.service
@@ -28,8 +28,9 @@ Environment=MCP_GIT_HTTP_PORT=4100
 Environment=LOG_LEVEL=INFO
 Environment=PYTHONPATH=%h/ClaudeCode/Servers/git/worktrees/feat-issues-impl/src
 
-# Use pixi to run the server
-ExecStart=%h/.conda/envs/ClaudeCode/bin/pixi run pixi-git-server-http --port 4100
+# Use pixi to run the server with default repo for MCP client compatibility
+# The --default-repo enables auto-session mode so MCP clients work without explicit session management
+ExecStart=%h/.conda/envs/ClaudeCode/bin/pixi run pixi-git-server-http --default-repo %h/ClaudeCode/Servers/git/worktrees/feat-issues-impl
 ExecReload=/bin/kill -HUP $MAINPID
 
 # Restart configuration

--- a/pixi.lock
+++ b/pixi.lock
@@ -11,6 +11,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohttp-3.13.3-pyhf64b827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
@@ -40,11 +41,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fakeredis-2.33.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.128.8-h9b0ccdf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.21-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.128.8-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastmcp-2.14.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.7.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
@@ -53,6 +60,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-sse-0.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -132,6 +140,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.12.0-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydocket-0.16.3-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
@@ -165,6 +174,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.19.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.10-h4196e79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.4.1-py312h7900ff3_0.conda
@@ -187,6 +197,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.40.0-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.40.0-h4cd5af1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.22.1-py312h4c3975b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.1.1-py312h0ccc70a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-16.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xclip-0.13-hb9d3cd8_4.conda
@@ -213,6 +226,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohttp-3.13.3-pyhf64b827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
@@ -236,10 +250,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fakeredis-2.33.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.128.8-h9b0ccdf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.21-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.128.8-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastmcp-2.14.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.7.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
@@ -248,6 +268,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-sse-0.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -259,6 +280,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.0.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-path-0.3.4-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
@@ -276,6 +298,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.51.2-hf4e2dac_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-15.2.0-h934c35e_16.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.41.3-h5347b49_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.51.0-hb03c661_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-h8a09558_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxcrypt-4.4.36-hd590300_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.1-hb9d3cd8_2.conda
@@ -283,6 +306,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/luajit-2.1.1744318430-h73b1eb8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lupa-2.6-py312lua54h1289d80_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markupsafe-3.0.3-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mcp-1.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhcf101f3_1.conda
@@ -309,6 +333,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.12.0-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydocket-0.16.3-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
@@ -328,6 +353,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.19.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.4.1-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/setuptools-80.9.0-pyhff2d567_0.conda
@@ -348,6 +374,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.40.0-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.40.0-h4cd5af1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.22.1-py312h4c3975b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.1.1-py312h0ccc70a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-16.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xclip-0.13-hb9d3cd8_4.conda
@@ -375,6 +404,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohttp-3.13.3-pyhf64b827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
@@ -408,13 +438,19 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dparse-0.6.4-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/faker-40.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fakeredis-2.33.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.128.8-h9b0ccdf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.21-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.128.8-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastmcp-2.14.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.7.0-pyhf298e5d_0.conda
@@ -424,6 +460,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-sse-0.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -513,6 +550,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.12.0-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydocket-0.16.3-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
@@ -551,6 +589,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.19.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py312h5253ce2_1.conda
@@ -582,8 +621,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312hd9148b4_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.40.0-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.40.0-h4cd5af1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.22.1-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vulture-2.14-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.1.1-py312h0ccc70a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-16.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
@@ -611,6 +653,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohttp-3.13.3-pyhf64b827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
@@ -638,11 +681,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fakeredis-2.33.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.128.8-h9b0ccdf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.21-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.128.8-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastmcp-2.14.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.7.0-pyhf298e5d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/gitdb-4.0.12-pyhd8ed1ab_0.conda
@@ -651,6 +700,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-sse-0.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -663,6 +713,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.context-6.0.2-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jaraco.functools-4.4.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jeepney-0.9.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/jinja2-3.1.6-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-4.25.1-pyhe01879c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-path-0.3.4-pyh29332c3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/jsonschema-specifications-2025.9.1-pyhcf101f3_0.conda
@@ -694,6 +745,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/luajit-2.1.1744318430-h73b1eb8_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/lupa-2.6-py312lua54h1289d80_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/markdown-it-py-4.0.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/markupsafe-3.0.3-pyh7db6752_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mcp-1.25.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/mdurl-0.1.2-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/more-itertools-10.8.0-pyhcf101f3_1.conda
@@ -726,6 +778,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.12.0-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydocket-0.16.3-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
@@ -752,6 +805,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.19.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruff-0.14.10-h4196e79_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/secretstorage-3.4.1-py312h7900ff3_0.conda
@@ -773,6 +827,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.40.0-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.40.0-h4cd5af1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.22.1-py312h4c3975b_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.1.1-py312h0ccc70a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-16.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/xclip-0.13-hb9d3cd8_4.conda
@@ -799,6 +856,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohttp-3.13.3-pyhf64b827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
@@ -830,12 +888,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dparse-0.6.4-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fakeredis-2.33.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.128.8-h9b0ccdf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.21-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.128.8-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastmcp-2.14.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.7.0-pyhf298e5d_0.conda
@@ -845,6 +909,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-sse-0.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -930,6 +995,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.12.0-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydocket-0.16.3-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
@@ -957,6 +1023,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/requests-2.32.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.19.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py312h5253ce2_1.conda
@@ -987,8 +1054,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312hd9148b4_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.40.0-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.40.0-h4cd5af1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.22.1-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vulture-2.14-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.1.1-py312h0ccc70a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-16.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
@@ -1017,6 +1087,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiohttp-3.13.3-pyhf64b827_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/aiosignal-1.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/anyio-4.12.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/async-timeout-5.0.1-pyhcf101f3_2.conda
@@ -1050,12 +1121,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/deprecated-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/diskcache-5.6.3-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/distlib-0.4.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/docutils-0.22.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/dparse-0.6.4-pyhff2d567_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/execnet-2.1.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fakeredis-2.33.0-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.128.8-h9b0ccdf_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.21-pyhcf101f3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.128.8-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/fastmcp-2.14.2-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/filelock-3.20.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/frozenlist-1.7.0-pyhf298e5d_0.conda
@@ -1065,6 +1142,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/h2-4.3.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hpack-4.1.0-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpcore-1.0.9-pyh29332c3_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-sse-0.4.3-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/hyperframe-6.1.0-pyhd8ed1ab_0.conda
@@ -1152,6 +1230,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/pycparser-2.22-pyh29332c3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-2.12.5-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydantic-core-2.41.5-py312h868fb18_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.0-pyhcf101f3_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.12.0-pyh3cfb1c2_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/pydocket-0.16.3-py312h7900ff3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/pygments-2.19.2-pyhd8ed1ab_0.conda
@@ -1186,6 +1265,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/rfc3986-2.0.0-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-14.2.0-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/rich-rst-1.3.2-pyhd8ed1ab_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.19.4-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ruamel.yaml-0.19.1-pyhcf101f3_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ruamel.yaml.clib-0.2.15-py312h5253ce2_1.conda
@@ -1217,8 +1297,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ukkonen-1.0.1-py312hd9148b4_6.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/urllib3-2.6.2-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-0.40.0-pyhc90fa1f_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.40.0-h4cd5af1_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.22.1-py312h4c3975b_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/vulture-2.14-pyhd8ed1ab_1.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.1.1-py312h0ccc70a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-16.0-py312h5253ce2_1.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/wheel-0.45.1-pyhd8ed1ab_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/wrapt-1.17.3-py312h4c3975b_1.conda
@@ -1305,6 +1388,16 @@ packages:
   license_family: APACHE
   size: 13688
   timestamp: 1751626573984
+- conda: https://conda.anaconda.org/conda-forge/noarch/annotated-doc-0.0.4-pyhcf101f3_0.conda
+  sha256: cc9fbc50d4ee7ee04e49ee119243e6f1765750f0fd0b4d270d5ef35461b643b1
+  md5: 52be5139047efadaeeb19c6a5103f92a
+  depends:
+  - python >=3.10
+  - python
+  license: MIT
+  license_family: MIT
+  size: 14222
+  timestamp: 1762868213144
 - conda: https://conda.anaconda.org/conda-forge/noarch/annotated-types-0.7.0-pyhd8ed1ab_1.conda
   sha256: e0ea1ba78fbb64f17062601edda82097fcf815012cf52bb704150a2668110d48
   md5: 2934f256a8acfe48f6ebb4fce6cde29c
@@ -1671,6 +1764,25 @@ packages:
   license_family: APACHE
   size: 275642
   timestamp: 1752823081585
+- conda: https://conda.anaconda.org/conda-forge/noarch/dnspython-2.8.0-pyhcf101f3_0.conda
+  sha256: ef1e7b8405997ed3d6e2b6722bd7088d4a8adf215e7c88335582e65651fb4e05
+  md5: d73fdc05f10693b518f52c994d748c19
+  depends:
+  - python >=3.10,<4.0.0
+  - sniffio
+  - python
+  constrains:
+  - aioquic >=1.2.0
+  - cryptography >=45
+  - httpcore >=1.0.0
+  - httpx >=0.28.0
+  - h2 >=4.2.0
+  - idna >=3.10
+  - trio >=0.30
+  - wmi >=1.5.1
+  license: ISC
+  size: 196500
+  timestamp: 1757292856922
 - conda: https://conda.anaconda.org/conda-forge/noarch/docstring_parser-0.17.0-pyhd8ed1ab_0.conda
   sha256: 3069a555097f084d3b7bc8f9efbb42f9907ecbfa24d310c63df9814a8df491af
   md5: ce49d3e5a7d20be2ba57a2c670bdd82e
@@ -1699,6 +1811,24 @@ packages:
   license_family: MIT
   size: 22268
   timestamp: 1731180466651
+- conda: https://conda.anaconda.org/conda-forge/noarch/email-validator-2.3.0-pyhd8ed1ab_0.conda
+  sha256: c37320864c35ef996b0e02e289df6ee89582d6c8e233e18dc9983375803c46bb
+  md5: 3bc0ac31178387e8ed34094d9481bfe8
+  depends:
+  - dnspython >=2.0.0
+  - idna >=2.0.0
+  - python >=3.10
+  license: Unlicense
+  size: 46767
+  timestamp: 1756221480106
+- conda: https://conda.anaconda.org/conda-forge/noarch/email_validator-2.3.0-hd8ed1ab_0.conda
+  sha256: 6a518e00d040fcad016fb2dde29672aa3476cd9ae33ea5b7b257222e66037d89
+  md5: 2452e434747a6b742adc5045f2182a8e
+  depends:
+  - email-validator >=2.3.0,<2.3.1.0a0
+  license: Unlicense
+  size: 7077
+  timestamp: 1756221480651
 - conda: https://conda.anaconda.org/conda-forge/noarch/exceptiongroup-1.3.1-pyhd8ed1ab_0.conda
   sha256: ee6cf346d017d954255bbcbdb424cddea4d14e4ed7e9813e429db1d795d01144
   md5: 8e662bd460bda79b1ea39194e3c4c9ab
@@ -1741,6 +1871,60 @@ packages:
   license_family: BSD
   size: 97212
   timestamp: 1765921480665
+- conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-0.128.8-h9b0ccdf_0.conda
+  sha256: 38b90c4418d0fa084fe55d9c620d02869e496a0dec0a11604b4c902b34ca6520
+  md5: d3e8f99973ec8bc47df9994c79ce5002
+  depends:
+  - fastapi-core ==0.128.8 pyhcf101f3_0
+  - email_validator
+  - fastapi-cli
+  - httpx
+  - jinja2
+  - pydantic-settings
+  - pydantic-extra-types
+  - python-multipart
+  - uvicorn-standard
+  license: MIT
+  license_family: MIT
+  size: 4849
+  timestamp: 1770853253343
+- conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-cli-0.0.21-pyhcf101f3_0.conda
+  sha256: cfaa276cea0f630e3053c8c2b2c19716edf2f5ac52ede4aafcf87dc674ee5897
+  md5: a604f77cc79c83c567b9a26acc8917a1
+  depends:
+  - python >=3.10
+  - rich-toolkit >=0.14.8
+  - tomli >=2.0.0
+  - typer >=0.15.1
+  - uvicorn-standard >=0.15.0
+  - python
+  license: MIT
+  size: 19107
+  timestamp: 1770860157174
+- conda: https://conda.anaconda.org/conda-forge/noarch/fastapi-core-0.128.8-pyhcf101f3_0.conda
+  sha256: e7c09dab5f5f77751e72c0b00b4430c204721bf2b1afff9a62b27ada475b8bef
+  md5: 470faa86927635e1a5cd5cfaae7a2884
+  depends:
+  - python >=3.10
+  - annotated-doc >=0.0.2
+  - starlette >=0.40.0,<1.0.0
+  - typing_extensions >=4.8.0
+  - typing-inspection >=0.4.2
+  - pydantic >=2.7.0
+  - python
+  constrains:
+  - email_validator >=2.0.0
+  - fastapi-cli >=0.0.8
+  - httpx >=0.23.0,<1.0.0
+  - jinja2 >=3.1.5
+  - pydantic-extra-types >=2.0.0
+  - pydantic-settings >=2.0.0
+  - python-multipart >=0.0.18
+  - uvicorn-standard >=0.12.0
+  license: MIT
+  license_family: MIT
+  size: 85536
+  timestamp: 1770853253340
 - conda: https://conda.anaconda.org/conda-forge/noarch/fastmcp-2.14.2-pyhcf101f3_0.conda
   sha256: 5b975581c15c011afac2c70226b67e8f20e49afa0a36da27cef1e16127d82c47
   md5: 4abec894529a2ea4c118fea949300d74
@@ -1860,6 +2044,18 @@ packages:
   license_family: BSD
   size: 49483
   timestamp: 1745602916758
+- conda: https://conda.anaconda.org/conda-forge/linux-64/httptools-0.7.1-py312h4c3975b_1.conda
+  sha256: 3579b3765e301ee7106bdf5f506f45ad46cc1568207c0c691aa7b82737ca2e82
+  md5: 931af0f1dd27b0072f2865dd55640735
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT
+  license_family: MIT
+  size: 101089
+  timestamp: 1762504091918
 - conda: https://conda.anaconda.org/conda-forge/noarch/httpx-0.28.1-pyhd8ed1ab_0.conda
   sha256: cd0f1de3697b252df95f98383e9edb1d00386bfdd03fdf607fa42fe5fcb09950
   md5: d6989ead454181f4f9bc987d3dc4e285
@@ -2922,6 +3118,25 @@ packages:
   license_family: MIT
   size: 1935221
   timestamp: 1762989004359
+- conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-extra-types-2.11.0-pyhcf101f3_1.conda
+  sha256: 6a25f3b7a92833534eb9d09e3b4ba00195fbf459ec608d15dc9e31f81b67e972
+  md5: 83984e3edee8f7312c0aa860682ee145
+  depends:
+  - python >=3.10
+  - pydantic >=2.5.2
+  - python
+  constrains:
+  - phonenumbers >=8,<9
+  - pycountry >=23
+  - semver >=3.0.2,<4
+  - python-ulid >=1,<4
+  - pendulum >=3.0.0,<4.0.0
+  - pytz >=2024.1
+  - tzdata >=2024a
+  license: MIT
+  license_family: MIT
+  size: 68665
+  timestamp: 1770023146886
 - conda: https://conda.anaconda.org/conda-forge/noarch/pydantic-settings-2.12.0-pyh3cfb1c2_0.conda
   sha256: 17d552dd19501909d626ff50cd23753d56e03ab670ce9096f1c4068e1eb90f2a
   md5: 0a3042ce18b785982c64a8567cc3e512
@@ -3385,6 +3600,18 @@ packages:
   license_family: MIT
   size: 18299
   timestamp: 1760519277784
+- conda: https://conda.anaconda.org/conda-forge/noarch/rich-toolkit-0.19.4-pyhcf101f3_0.conda
+  sha256: 0edab1aab1fba55f44e83dce4440d3506af8e06e0fd9509a4a62b727478e3253
+  md5: 0011605b057af14c5d86fe26ec6f7d3d
+  depends:
+  - python >=3.10
+  - rich >=13.7.1
+  - click >=8.1.7
+  - typing_extensions >=4.12.2
+  - python
+  license: MIT
+  size: 32478
+  timestamp: 1770904484792
 - conda: https://conda.anaconda.org/conda-forge/linux-64/rpds-py-0.30.0-py312h868fb18_0.conda
   sha256: 62f46e85caaba30b459da7dfcf3e5488ca24fd11675c33ce4367163ab191a42c
   md5: 3ffc5a3572db8751c2f15bacf6a0e937
@@ -3754,6 +3981,34 @@ packages:
   license_family: BSD
   size: 54972
   timestamp: 1766332899903
+- conda: https://conda.anaconda.org/conda-forge/noarch/uvicorn-standard-0.40.0-h4cd5af1_0.conda
+  sha256: 0476363e52d50f7c6075d06f309a54a9dc9b8828c00b4ed572b78d5f1374fccb
+  md5: 8c7fcf5c22f9342caf554be590f6fee9
+  depends:
+  - __unix
+  - uvicorn ==0.40.0 pyhc90fa1f_0
+  - websockets >=10.4
+  - httptools >=0.6.3
+  - watchfiles >=0.13
+  - python-dotenv >=0.13
+  - pyyaml >=5.1
+  - uvloop >=0.14.0,!=0.15.0,!=0.15.1
+  license: BSD-3-Clause
+  license_family: BSD
+  size: 4119
+  timestamp: 1766332899904
+- conda: https://conda.anaconda.org/conda-forge/linux-64/uvloop-0.22.1-py312h4c3975b_1.conda
+  sha256: 15714d471fcba83c76930f49c4de0ebb5589f9b90d9eab52b1e7fc1478474891
+  md5: bdfc3f5345f9a16c63ba18e50c292e08
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - libgcc >=14
+  - libuv >=1.51.0,<2.0a0
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  license: MIT OR Apache-2.0
+  size: 596425
+  timestamp: 1762472840090
 - conda: https://conda.anaconda.org/conda-forge/noarch/virtualenv-20.35.4-pyhd8ed1ab_0.conda
   sha256: 77193c99c6626c58446168d3700f9643d8c0dab1f6deb6b9dd039e6872781bfb
   md5: cfccfd4e8d9de82ed75c8e2c91cab375
@@ -3777,6 +4032,21 @@ packages:
   license_family: MIT
   size: 31151
   timestamp: 1735032545327
+- conda: https://conda.anaconda.org/conda-forge/linux-64/watchfiles-1.1.1-py312h0ccc70a_0.conda
+  sha256: 5cc839dafe34e5f7b612e1d4d97bb11546eae8b1842e5b7870b3c6adbe9097e8
+  md5: d8ecac58c1cb180296a1dd7de058dbc5
+  depends:
+  - __glibc >=2.17,<3.0.a0
+  - anyio >=3.0.0
+  - libgcc >=14
+  - python >=3.12,<3.13.0a0
+  - python_abi 3.12.* *_cp312
+  constrains:
+  - __glibc >=2.17
+  license: MIT
+  license_family: MIT
+  size: 419919
+  timestamp: 1760456820374
 - conda: https://conda.anaconda.org/conda-forge/linux-64/websockets-16.0-py312h5253ce2_1.conda
   sha256: dd598cab9175a9ab11c8a1798c49ccabe923263d12aababa84a296cb18206464
   md5: e35ffb48178b20ee1a43fbe7abc93746

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 [project.scripts]
 mcp-server-git = "mcp_server_git:main"
 mcp-git-lean = "mcp_server_git.lean:main"
+mcp-git-http = "mcp_server_git.http_lean_server:main"
 
 [build-system]
 requires = ["hatchling"]
@@ -99,6 +100,11 @@ psutil = ">=5.9.0"
 pydantic = ">=2.0.0"
 python-dotenv = ">=1.0.0"
 lupa = ">=2.6,<3"
+
+# HTTP transport dependencies
+fastapi = ">=0.115.0"
+uvicorn = ">=0.34.0"
+sse-starlette = ">=2.2.0"
 
 # No PyPI dependencies - everything from conda-forge
 
@@ -254,6 +260,10 @@ pixi-git-server-debug = { cmd = "python -m mcp_server_git -vv --enable-file-logg
 # Lean interface (3-meta-tool pattern, 95% context reduction)
 pixi-git-server-lean = { cmd = "python -m mcp_server_git.lean", env = { PYTHONPATH = "src", CLAUDECODE = "0" } }
 pixi-git-server-lean-debug = { cmd = "python -m mcp_server_git.lean -vv --enable-file-logging", env = { PYTHONPATH = "src", LOG_LEVEL = "DEBUG", CLAUDECODE = "0" } }
+
+# HTTP lean interface (FastAPI + SSE transport)
+pixi-git-server-http = { cmd = "python -m mcp_server_git.http_lean_server --port 4100", env = { PYTHONPATH = "src", CLAUDECODE = "0" } }
+pixi-git-server-http-debug = { cmd = "python -m mcp_server_git.http_lean_server -vv --port 4100", env = { PYTHONPATH = "src", LOG_LEVEL = "DEBUG", CLAUDECODE = "0" } }
 
 # Auto-install and run MCP server (for ClaudeCode integration)
 mcp-server-git = { cmd = "python -m mcp_server_git", env = { PYTHONPATH = "src", CLAUDECODE = "0" } }

--- a/src/mcp_server_git/http_lean_server.py
+++ b/src/mcp_server_git/http_lean_server.py
@@ -15,6 +15,7 @@ Key features:
 
 import logging
 import sys
+from pathlib import Path
 
 import click
 from dotenv import load_dotenv
@@ -52,6 +53,12 @@ logger = logging.getLogger(__name__)
     help="Session timeout in seconds (default: 3600 = 1 hour)",
 )
 @click.option(
+    "--default-repo",
+    type=click.Path(exists=True, file_okay=False, dir_okay=True, resolve_path=True),
+    default=None,
+    help="Default repository for auto-session mode (enables MCP client compatibility)",
+)
+@click.option(
     "-v",
     "--verbose",
     count=True,
@@ -62,6 +69,7 @@ def main(
     port: int,
     api_key: str | None,
     session_timeout: int,
+    default_repo: str | None,
     verbose: int,
 ) -> None:
     """
@@ -113,6 +121,7 @@ def main(
         port=port,
         api_key=api_key,
         session_timeout=float(session_timeout),
+        default_repo=Path(default_repo) if default_repo else None,
     )
 
     logger.info(f"HTTP Server configured: {host}:{port}")
@@ -121,6 +130,8 @@ def main(
     else:
         logger.info("API key authentication disabled")
     logger.info(f"Session timeout: {session_timeout} seconds")
+    if default_repo:
+        logger.info(f"Default repository: {default_repo} (auto-session mode enabled)")
 
     logger.info("Starting HTTP Lean Server...")
 

--- a/src/mcp_server_git/http_lean_server.py
+++ b/src/mcp_server_git/http_lean_server.py
@@ -1,0 +1,132 @@
+"""
+CLI entry point for HTTP Lean Server.
+
+Provides a command-line interface to start the HTTP transport layer for the
+MCP Git lean interface, exposing the 3 meta-tools (discover_tools, get_tool_spec,
+execute_tool) over HTTP with session management and security features.
+
+Key features:
+- JSON-RPC 2.0 tool execution over HTTP
+- Session management with repository isolation
+- Optional API key authentication
+- Configurable session timeout
+- Verbosity-based logging control
+"""
+
+import logging
+import sys
+
+import click
+from dotenv import load_dotenv
+
+from .services.git_service import GitService
+from .services.github_service import GitHubService
+from .transport.http_server import HTTPGitServer
+from .lean.null_azure_service import NullAzureService
+from .lean.interface import create_git_lean_interface
+
+logger = logging.getLogger(__name__)
+
+
+@click.command()
+@click.option(
+    "--host",
+    default="127.0.0.1",
+    help="Host address to bind to (default: 127.0.0.1)",
+)
+@click.option(
+    "--port",
+    type=int,
+    default=4100,
+    help="Port to listen on (default: 4100)",
+)
+@click.option(
+    "--api-key",
+    default=None,
+    help="Optional API key for authentication",
+)
+@click.option(
+    "--session-timeout",
+    type=int,
+    default=3600,
+    help="Session timeout in seconds (default: 3600 = 1 hour)",
+)
+@click.option(
+    "-v",
+    "--verbose",
+    count=True,
+    help="Increase verbosity (-v for INFO, -vv for DEBUG)",
+)
+def main(
+    host: str,
+    port: int,
+    api_key: str | None,
+    session_timeout: int,
+    verbose: int,
+) -> None:
+    """
+    HTTP Lean Server - MCP Git functionality over HTTP with lean interface.
+
+    Starts an HTTP server that exposes the 3 meta-tools (discover_tools,
+    get_tool_spec, execute_tool) for 95% context reduction, with session
+    management and optional API key security.
+    """
+    # Set up logging level based on verbosity
+    logging_level = logging.WARNING
+    if verbose == 1:
+        logging_level = logging.INFO
+    elif verbose >= 2:
+        logging_level = logging.DEBUG
+
+    # Configure logging
+    logging.basicConfig(
+        level=logging_level,
+        format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
+        stream=sys.stderr,
+    )
+
+    # Load environment variables
+    load_dotenv()
+
+    logger.info("Initializing HTTP Lean Server...")
+
+    # Initialize services
+    git_service = GitService()
+    github_service = GitHubService()
+    azure_service = NullAzureService()
+
+    # Create lean interface (this prepares the interface but we use it
+    # to validate that all services are properly initialized)
+    _app = create_git_lean_interface(
+        git_service=git_service,
+        github_service=github_service,
+        azure_service=azure_service,
+    )
+
+    logger.info("Lean interface initialized successfully")
+    logger.info("3 meta-tools available: discover_tools, get_tool_spec, execute_tool")
+    logger.info("51 tools registered across git, github, and azure domains")
+
+    # Create and configure HTTP server
+    server = HTTPGitServer(
+        host=host,
+        port=port,
+        api_key=api_key,
+        session_timeout=float(session_timeout),
+    )
+
+    logger.info(f"HTTP Server configured: {host}:{port}")
+    if api_key:
+        logger.info("API key authentication enabled")
+    else:
+        logger.info("API key authentication disabled")
+    logger.info(f"Session timeout: {session_timeout} seconds")
+
+    logger.info("Starting HTTP Lean Server...")
+
+    # Run the HTTP server
+    server.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/mcp_server_git/lean/interface.py
+++ b/src/mcp_server_git/lean/interface.py
@@ -569,6 +569,54 @@ class GitLeanInterface:
                 "error": str(e),
             }
 
+    def discover_tools(self, pattern: str = "") -> dict[str, Any]:
+        """Discover available tools (direct method for HTTP transport)."""
+        tools = []
+
+        for name, tool_def in self.tool_registry.items():
+            if pattern and pattern.strip() and pattern.lower() not in name.lower():
+                continue
+
+            tools.append(
+                {
+                    "name": name,
+                    "description": tool_def.description,
+                    "domain": tool_def.domain,
+                    "complexity": tool_def.complexity,
+                }
+            )
+
+        return {
+            "available_tools": tools,
+            "total_tools": len(self.tool_registry),
+            "filtered_count": len(tools),
+            "domains": {
+                "git": len([t for t in self.tool_registry.values() if t.domain == "git"]),
+                "github": len([t for t in self.tool_registry.values() if t.domain == "github"]),
+                "azure": len([t for t in self.tool_registry.values() if t.domain == "azure"]),
+            },
+            "context_saving": f"~{len(self.tool_registry) * 0.5}K tokens saved vs traditional MCP",
+        }
+
+    def get_tool_spec(self, tool_name: str) -> dict[str, Any]:
+        """Get tool specification (direct method for HTTP transport)."""
+        if tool_name not in self.tool_registry:
+            return {
+                "error": f"Tool '{tool_name}' not found",
+                "available_tools": list(self.tool_registry.keys()),
+            }
+
+        tool_def = self.tool_registry[tool_name]
+        return {
+            "name": tool_name,
+            "description": tool_def.description,
+            "domain": tool_def.domain,
+            "complexity": tool_def.complexity,
+            "schema": tool_def.schema,
+            "examples": tool_def.examples,
+            "usage_note": f"Execute with: execute_tool('{tool_name}', parameters)",
+        }
+
     def health_check(self) -> dict[str, Any]:
         """Perform health check on the lean MCP interface."""
         return {

--- a/src/mcp_server_git/lean/interface.py
+++ b/src/mcp_server_git/lean/interface.py
@@ -82,6 +82,7 @@ class GitLeanInterface:
         self.git_service = git_service
         self.github_service = github_service
         self.azure_service = azure_service
+        self.app_name = app_name
         self.app = FastMCP(app_name, version=version)
         self.token_limiter = token_limiter or MCPTokenLimiter()
 
@@ -519,6 +520,54 @@ class GitLeanInterface:
     def get_app(self) -> FastMCP:
         """Get the FastMCP application instance."""
         return self.app
+
+    async def execute_tool_direct(
+        self, tool_name: str, parameters: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Execute a tool directly without going through FastMCP protocol.
+
+        Used by HTTP transport for direct programmatic tool invocation.
+
+        Args:
+            tool_name: Name of the tool to execute
+            parameters: Tool parameters
+
+        Returns:
+            Dictionary containing:
+            - tool: Tool name
+            - status: "success" or "error"
+            - result: Tool execution result (on success)
+            - error: Error message (on failure)
+        """
+        if tool_name not in self.tool_registry:
+            return {
+                "error": f"Tool '{tool_name}' not found",
+                "available_tools": list(self.tool_registry.keys()),
+            }
+
+        tool_def = self.tool_registry[tool_name]
+
+        try:
+            # Validate path parameters
+            self._validate_path_parameters(parameters)
+
+            # Execute tool
+            if inspect.iscoroutinefunction(tool_def.implementation):
+                result = await tool_def.implementation(**parameters)
+            else:
+                result = tool_def.implementation(**parameters)
+
+            return {
+                "tool": tool_name,
+                "status": "success",
+                "result": result,
+            }
+        except Exception as e:
+            return {
+                "tool": tool_name,
+                "status": "error",
+                "error": str(e),
+            }
 
     def health_check(self) -> dict[str, Any]:
         """Perform health check on the lean MCP interface."""

--- a/src/mcp_server_git/lean/interface.py
+++ b/src/mcp_server_git/lean/interface.py
@@ -591,9 +591,15 @@ class GitLeanInterface:
             "total_tools": len(self.tool_registry),
             "filtered_count": len(tools),
             "domains": {
-                "git": len([t for t in self.tool_registry.values() if t.domain == "git"]),
-                "github": len([t for t in self.tool_registry.values() if t.domain == "github"]),
-                "azure": len([t for t in self.tool_registry.values() if t.domain == "azure"]),
+                "git": len(
+                    [t for t in self.tool_registry.values() if t.domain == "git"]
+                ),
+                "github": len(
+                    [t for t in self.tool_registry.values() if t.domain == "github"]
+                ),
+                "azure": len(
+                    [t for t in self.tool_registry.values() if t.domain == "azure"]
+                ),
             },
             "context_saving": f"~{len(self.tool_registry) * 0.5}K tokens saved vs traditional MCP",
         }

--- a/src/mcp_server_git/lean/tool_registry.py
+++ b/src/mcp_server_git/lean/tool_registry.py
@@ -337,6 +337,61 @@ def _register_git_tools(interface: Any, git_service: Any):
             domain="git",
             complexity="core",
         ),
+        # Stash operations
+        ToolDefinition(
+            name="git_stash_list",
+            implementation=wrap_repo_op(git_ops.git_stash_list),
+            description="List all stashes in the repository",
+            schema={"type": "object", "properties": {"repo_path": {"type": "string"}}, "required": ["repo_path"]},
+            domain="git",
+            complexity="core",
+        ),
+        ToolDefinition(
+            name="git_stash_push",
+            implementation=wrap_repo_op(git_ops.git_stash_push),
+            description="Create a new stash with optional message",
+            schema={
+                "type": "object",
+                "properties": {
+                    "repo_path": {"type": "string"},
+                    "message": {"type": "string", "description": "Optional stash message"},
+                    "include_untracked": {"type": "boolean", "default": False, "description": "Include untracked files"},
+                },
+                "required": ["repo_path"],
+            },
+            domain="git",
+            complexity="core",
+        ),
+        ToolDefinition(
+            name="git_stash_pop",
+            implementation=wrap_repo_op(git_ops.git_stash_pop),
+            description="Apply and remove a stash (defaults to latest)",
+            schema={
+                "type": "object",
+                "properties": {
+                    "repo_path": {"type": "string"},
+                    "stash_id": {"type": "string", "description": "Stash ID (e.g., stash@{0}), defaults to latest"},
+                },
+                "required": ["repo_path"],
+            },
+            domain="git",
+            complexity="core",
+        ),
+        ToolDefinition(
+            name="git_stash_drop",
+            implementation=wrap_repo_op(git_ops.git_stash_drop),
+            description="Remove a stash without applying it",
+            schema={
+                "type": "object",
+                "properties": {
+                    "repo_path": {"type": "string"},
+                    "stash_id": {"type": "string", "description": "Stash ID (e.g., stash@{0}), defaults to latest"},
+                },
+                "required": ["repo_path"],
+            },
+            domain="git",
+            complexity="core",
+        ),
     ]
 
     for tool in git_tools:

--- a/src/mcp_server_git/lean/tool_registry.py
+++ b/src/mcp_server_git/lean/tool_registry.py
@@ -342,7 +342,11 @@ def _register_git_tools(interface: Any, git_service: Any):
             name="git_stash_list",
             implementation=wrap_repo_op(git_ops.git_stash_list),
             description="List all stashes in the repository",
-            schema={"type": "object", "properties": {"repo_path": {"type": "string"}}, "required": ["repo_path"]},
+            schema={
+                "type": "object",
+                "properties": {"repo_path": {"type": "string"}},
+                "required": ["repo_path"],
+            },
             domain="git",
             complexity="core",
         ),
@@ -354,8 +358,15 @@ def _register_git_tools(interface: Any, git_service: Any):
                 "type": "object",
                 "properties": {
                     "repo_path": {"type": "string"},
-                    "message": {"type": "string", "description": "Optional stash message"},
-                    "include_untracked": {"type": "boolean", "default": False, "description": "Include untracked files"},
+                    "message": {
+                        "type": "string",
+                        "description": "Optional stash message",
+                    },
+                    "include_untracked": {
+                        "type": "boolean",
+                        "default": False,
+                        "description": "Include untracked files",
+                    },
                 },
                 "required": ["repo_path"],
             },
@@ -370,7 +381,10 @@ def _register_git_tools(interface: Any, git_service: Any):
                 "type": "object",
                 "properties": {
                     "repo_path": {"type": "string"},
-                    "stash_id": {"type": "string", "description": "Stash ID (e.g., stash@{0}), defaults to latest"},
+                    "stash_id": {
+                        "type": "string",
+                        "description": "Stash ID (e.g., stash@{0}), defaults to latest",
+                    },
                 },
                 "required": ["repo_path"],
             },
@@ -385,7 +399,10 @@ def _register_git_tools(interface: Any, git_service: Any):
                 "type": "object",
                 "properties": {
                     "repo_path": {"type": "string"},
-                    "stash_id": {"type": "string", "description": "Stash ID (e.g., stash@{0}), defaults to latest"},
+                    "stash_id": {
+                        "type": "string",
+                        "description": "Stash ID (e.g., stash@{0}), defaults to latest",
+                    },
                 },
                 "required": ["repo_path"],
             },

--- a/src/mcp_server_git/repository_binding.py
+++ b/src/mcp_server_git/repository_binding.py
@@ -270,6 +270,10 @@ class RepositoryBindingManager:
         if self._state == RepositoryBindingState.UNBOUND or not self._binding:
             return
 
+        # Skip validation if no expected remote URL was set (e.g., default sessions)
+        if self._binding.expected_remote_url is None:
+            return
+
         current_remote = await self._get_current_remote_url(
             self._binding.repository_path
         )

--- a/src/mcp_server_git/session.py
+++ b/src/mcp_server_git/session.py
@@ -566,6 +566,15 @@ class SessionManager:
         except Exception as e:
             logger.error(f"Failed to restore sessions: {e}")
 
+    async def __aenter__(self) -> "SessionManager":
+        """Support async context manager protocol."""
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> bool:
+        """Ensure cleanup on context exit."""
+        await self.shutdown()
+        return False
+
     async def shutdown(self):
         """
         Gracefully close all sessions and stop heartbeat manager.

--- a/src/mcp_server_git/transport/__init__.py
+++ b/src/mcp_server_git/transport/__init__.py
@@ -1,0 +1,29 @@
+"""
+HTTP Transport for MCP Git Server.
+
+This module provides HTTP transport support for the mcp-git server,
+enabling shared server instances across multiple Claude Code sessions
+while maintaining strict git repository isolation.
+
+Architecture:
+- HTTPGitServer: FastAPI-based HTTP server with MCP protocol support
+- HTTPSessionManager: Session-repository binding and isolation
+- Security middleware: Localhost-only restriction and API key authentication
+
+Each HTTP session gets:
+1. Dedicated MCPGitServerCore instance
+2. Dedicated RepositoryBindingManager instance
+3. Bound to exactly one repository at session creation
+"""
+
+from .http_server import HTTPGitServer
+from .http_session_manager import HTTPSessionManager, SessionContext
+from .security import APIKeyMiddleware, LocalhostOnlyMiddleware
+
+__all__ = [
+    "HTTPGitServer",
+    "HTTPSessionManager",
+    "SessionContext",
+    "LocalhostOnlyMiddleware",
+    "APIKeyMiddleware",
+]

--- a/src/mcp_server_git/transport/http_server.py
+++ b/src/mcp_server_git/transport/http_server.py
@@ -182,11 +182,9 @@ class HTTPGitServer:
 
             # Shutdown
             logger.info("MCP Git HTTP Server shutting down")
-            # Cleanup all sessions
-            session_ids = list(self.session_manager._sessions.keys())
-            for session_id in session_ids:
-                await self.session_manager.close_session(session_id)
-            logger.info(f"Cleaned up {len(session_ids)} sessions on shutdown")
+            # Cleanup all sessions via encapsulated method
+            count = await self.session_manager.close_all_sessions()
+            logger.info(f"Cleaned up {count} sessions on shutdown")
 
         self.app = FastAPI(
             title="MCP Git HTTP Server",
@@ -342,9 +340,9 @@ class HTTPGitServer:
 
             # Handle initialize - creates new MCP session
             if method == "initialize":
-                # Create a new session with default repo if configured
+                new_session_id = f"mcp-{secrets.token_urlsafe(8)}"
+                # Create session with default repo if configured
                 if self.default_repo:
-                    new_session_id = f"mcp-{secrets.token_urlsafe(8)}"
                     try:
                         await self.session_manager.create_session(
                             repo_path=self.default_repo,
@@ -352,10 +350,18 @@ class HTTPGitServer:
                             session_id=new_session_id,
                         )
                     except Exception as e:
-                        logger.warning(f"Session creation failed, using default: {e}")
-                        new_session_id = self.DEFAULT_SESSION_ID
-                else:
-                    new_session_id = f"mcp-{secrets.token_urlsafe(8)}"
+                        logger.error(f"Session creation failed for {self.default_repo}: {e}")
+                        return JSONResponse(
+                            status_code=500,
+                            content={
+                                "jsonrpc": "2.0",
+                                "id": req_id,
+                                "error": {
+                                    "code": -32603,
+                                    "message": f"Failed to initialize session: {e}",
+                                },
+                            },
+                        )
 
                 response = JSONResponse(content={
                     "jsonrpc": "2.0",

--- a/src/mcp_server_git/transport/http_server.py
+++ b/src/mcp_server_git/transport/http_server.py
@@ -492,9 +492,8 @@ class HTTPGitServer:
             if method == "tools/call":
                 # Use default session if none provided
                 if not mcp_session_id:
-                    if (
-                        self.default_repo
-                        and self.DEFAULT_SESSION_ID in self.session_manager._sessions
+                    if self.default_repo and self.session_manager.has_session(
+                        self.DEFAULT_SESSION_ID
                     ):
                         mcp_session_id = self.DEFAULT_SESSION_ID
                     else:

--- a/src/mcp_server_git/transport/http_server.py
+++ b/src/mcp_server_git/transport/http_server.py
@@ -17,14 +17,17 @@ Architecture:
                         └─> API Key middleware (optional)
 """
 
+import asyncio
 import logging
 import secrets
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Optional
 
 import uvicorn
-from fastapi import FastAPI, Header, HTTPException, status
+from fastapi import FastAPI, Header, HTTPException, Request, status
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from .http_session_manager import HTTPSessionManager
@@ -86,7 +89,7 @@ class JSONRPCRequest(BaseModel):
 
     jsonrpc: str = Field(default="2.0", description="JSON-RPC version")
     method: str = Field(..., description="Method name (e.g., 'tools/call')")
-    params: dict[str, Any] = Field(..., description="Method parameters")
+    params: Optional[dict[str, Any]] = Field(default=None, description="Method parameters")
     id: Optional[int | str] = Field(None, description="Request ID")
 
 
@@ -309,37 +312,36 @@ class HTTPGitServer:
 
         @self.app.post("/mcp")
         async def handle_mcp_request(
-            request: JSONRPCRequest,
+            request: Request,
             mcp_session_id: Optional[str] = Header(None, alias="MCP-Session-Id"),
         ):
             """
             Handle MCP JSON-RPC 2.0 requests.
 
-            Supports MCP protocol methods:
-            - initialize: Create new session, returns session ID in header
-            - notifications/initialized: Acknowledge initialization
-            - tools/list: List available tools (3 meta-tools)
-            - tools/call: Execute a tool
-
-            Args:
-                request: JSON-RPC 2.0 request with method and params
-                mcp_session_id: Optional session identifier from header
-
-            Returns:
-                JSON-RPC 2.0 response with result or error
+            Follows session-intelligence reference implementation pattern:
+            - Raw JSON parsing (no Pydantic validation)
+            - Session created on initialize, validated thereafter
+            - 3-meta-tool pattern for tool execution
             """
-            from fastapi.responses import JSONResponse
+            # Parse raw JSON (session-intelligence pattern)
+            try:
+                body = await request.json()
+            except Exception:
+                return JSONResponse(
+                    status_code=400,
+                    content={
+                        "jsonrpc": "2.0",
+                        "id": None,
+                        "error": {"code": -32700, "message": "Parse error"},
+                    },
+                )
 
-            # Validate JSON-RPC version
-            if request.jsonrpc != "2.0":
-                return JSONResponse(content={
-                    "jsonrpc": "2.0",
-                    "id": request.id,
-                    "error": {"code": -32600, "message": "Invalid Request - only JSON-RPC 2.0 supported"},
-                })
+            method = body.get("method")
+            params = body.get("params", {})
+            req_id = body.get("id")
 
             # Handle initialize - creates new MCP session
-            if request.method == "initialize":
+            if method == "initialize":
                 # Create a new session with default repo if configured
                 if self.default_repo:
                     new_session_id = f"mcp-{secrets.token_urlsafe(8)}"
@@ -357,7 +359,7 @@ class HTTPGitServer:
 
                 response = JSONResponse(content={
                     "jsonrpc": "2.0",
-                    "id": request.id,
+                    "id": req_id,
                     "result": {
                         "protocolVersion": "2024-11-05",
                         "capabilities": {
@@ -371,18 +373,18 @@ class HTTPGitServer:
                 return response
 
             # Handle notifications/initialized - just acknowledge
-            if request.method == "notifications/initialized":
+            if method == "notifications/initialized":
                 return JSONResponse(content={
                     "jsonrpc": "2.0",
-                    "id": request.id,
+                    "id": req_id,
                     "result": {},
                 })
 
             # Handle tools/list - return the 3 meta-tools
-            if request.method == "tools/list":
+            if method == "tools/list":
                 return JSONResponse(content={
                     "jsonrpc": "2.0",
-                    "id": request.id,
+                    "id": req_id,
                     "result": {
                         "tools": [
                             {
@@ -419,7 +421,7 @@ class HTTPGitServer:
                 })
 
             # For tools/call, we need a session
-            if request.method == "tools/call":
+            if method == "tools/call":
                 # Use default session if none provided
                 if not mcp_session_id:
                     if self.default_repo and self.DEFAULT_SESSION_ID in self.session_manager._sessions:
@@ -427,34 +429,69 @@ class HTTPGitServer:
                     else:
                         return JSONResponse(content={
                             "jsonrpc": "2.0",
-                            "id": request.id,
+                            "id": req_id,
                             "error": {"code": -32000, "message": "MCP-Session-Id header required"},
                         })
 
                 # Extract tool name and arguments
                 try:
-                    tool_name = request.params.get("name")
-                    arguments = request.params.get("arguments", {})
+                    call_params = params or {}
+                    tool_name = call_params.get("name")
+                    arguments = call_params.get("arguments", {})
 
                     if not tool_name:
                         return JSONResponse(content={
                             "jsonrpc": "2.0",
-                            "id": request.id,
+                            "id": req_id,
                             "error": {"code": -32602, "message": "Invalid params - 'name' required"},
                         })
 
-                    # Execute tool via session manager
-                    result = await self.session_manager.execute_tool(
-                        session_id=mcp_session_id,
-                        tool_name=tool_name,
-                        args=arguments,
-                    )
+                    # Handle 3-meta-tool pattern
+                    if tool_name == "discover_tools":
+                        pattern = arguments.get("pattern", "")
+                        result = await self.session_manager.discover_tools(
+                            session_id=mcp_session_id,
+                            pattern=pattern,
+                        )
+                    elif tool_name == "get_tool_spec":
+                        target_tool = arguments.get("tool_name")
+                        if not target_tool:
+                            return JSONResponse(content={
+                                "jsonrpc": "2.0",
+                                "id": req_id,
+                                "error": {"code": -32602, "message": "tool_name required"},
+                            })
+                        result = await self.session_manager.get_tool_spec(
+                            session_id=mcp_session_id,
+                            tool_name=target_tool,
+                        )
+                    elif tool_name == "execute_tool":
+                        target_tool = arguments.get("tool_name")
+                        tool_params = arguments.get("parameters", {})
+                        if not target_tool:
+                            return JSONResponse(content={
+                                "jsonrpc": "2.0",
+                                "id": req_id,
+                                "error": {"code": -32602, "message": "tool_name required"},
+                            })
+                        result = await self.session_manager.execute_tool(
+                            session_id=mcp_session_id,
+                            tool_name=target_tool,
+                            args=tool_params,
+                        )
+                    else:
+                        # Direct tool execution (legacy/fallback)
+                        result = await self.session_manager.execute_tool(
+                            session_id=mcp_session_id,
+                            tool_name=tool_name,
+                            args=arguments,
+                        )
 
                     logger.debug(f"Tool executed: {tool_name} for session {mcp_session_id}")
 
                     return JSONResponse(content={
                         "jsonrpc": "2.0",
-                        "id": request.id,
+                        "id": req_id,
                         "result": {"content": [{"type": "text", "text": str(result)}]},
                     })
 
@@ -462,7 +499,7 @@ class HTTPGitServer:
                     logger.error(f"Tool execution error: {e}")
                     return JSONResponse(content={
                         "jsonrpc": "2.0",
-                        "id": request.id,
+                        "id": req_id,
                         "error": {"code": -32000, "message": str(e)},
                     })
 
@@ -470,16 +507,51 @@ class HTTPGitServer:
                     logger.error(f"Tool execution failed: {e}", exc_info=True)
                     return JSONResponse(content={
                         "jsonrpc": "2.0",
-                        "id": request.id,
+                        "id": req_id,
                         "error": {"code": -32603, "message": f"Internal error: {str(e)}"},
                     })
 
             # Unknown method
             return JSONResponse(content={
                 "jsonrpc": "2.0",
-                "id": request.id,
-                "error": {"code": -32601, "message": f"Method not found: {request.method}"},
+                "id": req_id,
+                "error": {"code": -32601, "message": f"Method not found: {method}"},
             })
+
+        @self.app.get("/mcp")
+        async def handle_mcp_sse(
+            mcp_session_id: Optional[str] = Header(None, alias="MCP-Session-Id"),
+        ) -> StreamingResponse:
+            """
+            Server-Sent Events endpoint for MCP notifications.
+
+            SSE transport requires both:
+            - POST /mcp for client-to-server requests
+            - GET /mcp for server-to-client notifications (this endpoint)
+
+            Returns:
+                StreamingResponse with text/event-stream content type
+            """
+            async def event_generator() -> AsyncGenerator[str, None]:
+                """Generate SSE events."""
+                try:
+                    # Keep connection alive with periodic heartbeats
+                    while True:
+                        # Send heartbeat comment every 30 seconds
+                        yield ": heartbeat\n\n"
+                        await asyncio.sleep(30)
+                except asyncio.CancelledError:
+                    pass
+
+            return StreamingResponse(
+                event_generator(),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "Connection": "keep-alive",
+                    "X-Accel-Buffering": "no",
+                },
+            )
 
         @self.app.get("/health", response_model=HealthResponse)
         async def health_check():

--- a/src/mcp_server_git/transport/http_server.py
+++ b/src/mcp_server_git/transport/http_server.py
@@ -18,6 +18,7 @@ Architecture:
 """
 
 import logging
+import secrets
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Optional
@@ -306,17 +307,19 @@ class HTTPGitServer:
 
             return SessionStatusResponse(**session_info)
 
-        @self.app.post("/mcp", response_model=JSONRPCResponse)
-        async def execute_mcp_tool(
+        @self.app.post("/mcp")
+        async def handle_mcp_request(
             request: JSONRPCRequest,
             mcp_session_id: Optional[str] = Header(None, alias="MCP-Session-Id"),
         ):
             """
-            Execute an MCP tool via JSON-RPC 2.0.
+            Handle MCP JSON-RPC 2.0 requests.
 
-            This endpoint accepts JSON-RPC 2.0 formatted requests for tool execution.
-            The session ID can be provided via the MCP-Session-Id header.
-            If no session ID is provided and a default session exists, uses the default.
+            Supports MCP protocol methods:
+            - initialize: Create new session, returns session ID in header
+            - notifications/initialized: Acknowledge initialization
+            - tools/list: List available tools (3 meta-tools)
+            - tools/call: Execute a tool
 
             Args:
                 request: JSON-RPC 2.0 request with method and params
@@ -324,102 +327,159 @@ class HTTPGitServer:
 
             Returns:
                 JSON-RPC 2.0 response with result or error
-
-            Raises:
-                HTTPException 400: If request is invalid
-                HTTPException 404: If session not found
             """
-            # Use default session if none provided
-            if not mcp_session_id:
-                if self.default_repo and self.DEFAULT_SESSION_ID in self.session_manager._sessions:
-                    mcp_session_id = self.DEFAULT_SESSION_ID
-                else:
-                    return JSONRPCResponse(
-                        jsonrpc="2.0",
-                        error={
-                            "code": -32000,
-                            "message": "MCP-Session-Id header required (no default session configured)",
-                        },
-                        id=request.id,
-                    )
+            from fastapi.responses import JSONResponse
 
             # Validate JSON-RPC version
             if request.jsonrpc != "2.0":
-                return JSONRPCResponse(
-                    jsonrpc="2.0",
-                    error={
-                        "code": -32600,
-                        "message": "Invalid Request - only JSON-RPC 2.0 supported",
-                    },
-                    id=request.id,
-                )
+                return JSONResponse(content={
+                    "jsonrpc": "2.0",
+                    "id": request.id,
+                    "error": {"code": -32600, "message": "Invalid Request - only JSON-RPC 2.0 supported"},
+                })
 
-            # Validate method
-            if request.method != "tools/call":
-                return JSONRPCResponse(
-                    jsonrpc="2.0",
-                    error={
-                        "code": -32601,
-                        "message": f"Method not found: {request.method}",
-                    },
-                    id=request.id,
-                )
+            # Handle initialize - creates new MCP session
+            if request.method == "initialize":
+                # Create a new session with default repo if configured
+                if self.default_repo:
+                    new_session_id = f"mcp-{secrets.token_urlsafe(8)}"
+                    try:
+                        await self.session_manager.create_session(
+                            repo_path=self.default_repo,
+                            expected_remote_url=None,
+                            session_id=new_session_id,
+                        )
+                    except Exception as e:
+                        logger.warning(f"Session creation failed, using default: {e}")
+                        new_session_id = self.DEFAULT_SESSION_ID
+                else:
+                    new_session_id = f"mcp-{secrets.token_urlsafe(8)}"
 
-            # Extract tool name and arguments
-            try:
-                tool_name = request.params.get("name")
-                arguments = request.params.get("arguments", {})
-
-                if not tool_name:
-                    return JSONRPCResponse(
-                        jsonrpc="2.0",
-                        error={
-                            "code": -32602,
-                            "message": "Invalid params - 'name' required",
+                response = JSONResponse(content={
+                    "jsonrpc": "2.0",
+                    "id": request.id,
+                    "result": {
+                        "protocolVersion": "2024-11-05",
+                        "capabilities": {
+                            "tools": {"listChanged": True},
                         },
-                        id=request.id,
+                        "serverInfo": {"name": "mcp-git", "version": "1.0.0"},
+                    },
+                })
+                response.headers["MCP-Session-Id"] = new_session_id
+                response.headers["MCP-Protocol-Version"] = "2024-11-05"
+                return response
+
+            # Handle notifications/initialized - just acknowledge
+            if request.method == "notifications/initialized":
+                return JSONResponse(content={
+                    "jsonrpc": "2.0",
+                    "id": request.id,
+                    "result": {},
+                })
+
+            # Handle tools/list - return the 3 meta-tools
+            if request.method == "tools/list":
+                return JSONResponse(content={
+                    "jsonrpc": "2.0",
+                    "id": request.id,
+                    "result": {
+                        "tools": [
+                            {
+                                "name": "discover_tools",
+                                "description": "Discover available Git, GitHub, and Azure DevOps tools. USE WHEN: finding tools by pattern",
+                                "inputSchema": {
+                                    "type": "object",
+                                    "properties": {"pattern": {"type": "string", "default": ""}},
+                                },
+                            },
+                            {
+                                "name": "get_tool_spec",
+                                "description": "Get full specification for specific tool including schema and examples.",
+                                "inputSchema": {
+                                    "type": "object",
+                                    "properties": {"tool_name": {"type": "string"}},
+                                    "required": ["tool_name"],
+                                },
+                            },
+                            {
+                                "name": "execute_tool",
+                                "description": "Execute Git, GitHub, or Azure DevOps operation.",
+                                "inputSchema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "tool_name": {"type": "string"},
+                                        "parameters": {"type": "object"},
+                                    },
+                                    "required": ["tool_name", "parameters"],
+                                },
+                            },
+                        ]
+                    },
+                })
+
+            # For tools/call, we need a session
+            if request.method == "tools/call":
+                # Use default session if none provided
+                if not mcp_session_id:
+                    if self.default_repo and self.DEFAULT_SESSION_ID in self.session_manager._sessions:
+                        mcp_session_id = self.DEFAULT_SESSION_ID
+                    else:
+                        return JSONResponse(content={
+                            "jsonrpc": "2.0",
+                            "id": request.id,
+                            "error": {"code": -32000, "message": "MCP-Session-Id header required"},
+                        })
+
+                # Extract tool name and arguments
+                try:
+                    tool_name = request.params.get("name")
+                    arguments = request.params.get("arguments", {})
+
+                    if not tool_name:
+                        return JSONResponse(content={
+                            "jsonrpc": "2.0",
+                            "id": request.id,
+                            "error": {"code": -32602, "message": "Invalid params - 'name' required"},
+                        })
+
+                    # Execute tool via session manager
+                    result = await self.session_manager.execute_tool(
+                        session_id=mcp_session_id,
+                        tool_name=tool_name,
+                        args=arguments,
                     )
 
-                # Execute tool via session manager
-                result = await self.session_manager.execute_tool(
-                    session_id=mcp_session_id,
-                    tool_name=tool_name,
-                    args=arguments,
-                )
+                    logger.debug(f"Tool executed: {tool_name} for session {mcp_session_id}")
 
-                logger.debug(
-                    f"Tool executed: {tool_name} for session {mcp_session_id}"
-                )
+                    return JSONResponse(content={
+                        "jsonrpc": "2.0",
+                        "id": request.id,
+                        "result": {"content": [{"type": "text", "text": str(result)}]},
+                    })
 
-                return JSONRPCResponse(
-                    jsonrpc="2.0",
-                    result=result,
-                    id=request.id,
-                )
+                except ValueError as e:
+                    logger.error(f"Tool execution error: {e}")
+                    return JSONResponse(content={
+                        "jsonrpc": "2.0",
+                        "id": request.id,
+                        "error": {"code": -32000, "message": str(e)},
+                    })
 
-            except ValueError as e:
-                # Session not found or validation error
-                logger.error(f"Tool execution error: {e}")
-                return JSONRPCResponse(
-                    jsonrpc="2.0",
-                    error={
-                        "code": -32000,
-                        "message": str(e),
-                    },
-                    id=request.id,
-                )
+                except Exception as e:
+                    logger.error(f"Tool execution failed: {e}", exc_info=True)
+                    return JSONResponse(content={
+                        "jsonrpc": "2.0",
+                        "id": request.id,
+                        "error": {"code": -32603, "message": f"Internal error: {str(e)}"},
+                    })
 
-            except Exception as e:
-                # Internal error
-                logger.error(f"Tool execution failed: {e}", exc_info=True)
-                return JSONRPCResponse(
-                    jsonrpc="2.0",
-                    error={
-                        "code": -32603,
-                        "message": f"Internal error: {str(e)}",
-                    },
-                    id=request.id,
-                )
+            # Unknown method
+            return JSONResponse(content={
+                "jsonrpc": "2.0",
+                "id": request.id,
+                "error": {"code": -32601, "message": f"Method not found: {request.method}"},
+            })
 
         @self.app.get("/health", response_model=HealthResponse)
         async def health_check():

--- a/src/mcp_server_git/transport/http_server.py
+++ b/src/mcp_server_git/transport/http_server.py
@@ -18,6 +18,7 @@ Architecture:
 """
 
 import asyncio
+import json
 import logging
 import secrets
 from collections.abc import AsyncGenerator
@@ -331,6 +332,20 @@ class HTTPGitServer:
             method = body.get("method")
             params = body.get("params", {})
             req_id = body.get("id")
+            jsonrpc_version = body.get("jsonrpc")
+
+            # Validate JSON-RPC version
+            if jsonrpc_version != "2.0":
+                return JSONResponse(
+                    content={
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "error": {
+                            "code": -32600,
+                            "message": "Invalid Request - jsonrpc must be '2.0'",
+                        },
+                    }
+                )
 
             # Handle initialize - creates new MCP session
             if method == "initialize":
@@ -529,7 +544,9 @@ class HTTPGitServer:
                             "jsonrpc": "2.0",
                             "id": req_id,
                             "result": {
-                                "content": [{"type": "text", "text": str(result)}]
+                                "content": [
+                                    {"type": "text", "text": json.dumps(result)}
+                                ]
                             },
                         }
                     )

--- a/src/mcp_server_git/transport/http_server.py
+++ b/src/mcp_server_git/transport/http_server.py
@@ -1,0 +1,412 @@
+"""
+FastAPI HTTP Server for MCP Git Server.
+
+This module implements the HTTP transport layer for the MCP Git server, providing
+RESTful endpoints for session management and MCP tool execution over HTTP.
+
+Key features:
+- Session management with isolated repository contexts
+- JSON-RPC 2.0 tool execution
+- Security middleware (localhost-only + optional API key)
+- Health monitoring and session cleanup
+- Automatic session timeout handling
+
+Architecture:
+    HTTP Client → FastAPI → SessionManager → Services → Git/GitHub Operations
+                        ├─> Localhost-only middleware
+                        └─> API Key middleware (optional)
+"""
+
+import logging
+from contextlib import asynccontextmanager
+from pathlib import Path
+from typing import Any, Optional
+
+import uvicorn
+from fastapi import FastAPI, Header, HTTPException, status
+from pydantic import BaseModel, Field
+
+from .http_session_manager import HTTPSessionManager
+from .security import APIKeyMiddleware, LocalhostOnlyMiddleware
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["HTTPGitServer"]
+
+
+# Pydantic models for request/response validation
+
+
+class CreateSessionRequest(BaseModel):
+    """Request model for creating a new session."""
+
+    repository_path: str = Field(
+        ..., description="Absolute path to the git repository"
+    )
+    expected_remote_url: str = Field(
+        ..., description="Expected remote URL for validation"
+    )
+
+
+class CreateSessionResponse(BaseModel):
+    """Response model for session creation."""
+
+    session_id: str = Field(..., description="Unique session identifier")
+    status: str = Field(default="bound", description="Session status")
+    repository_path: str = Field(..., description="Bound repository path")
+
+
+class SessionStatusResponse(BaseModel):
+    """Response model for session status."""
+
+    session_id: str
+    created_at: float
+    last_activity: float
+    age: float
+    idle_time: float
+    binding_info: dict[str, Any]
+
+
+class CloseSessionResponse(BaseModel):
+    """Response model for session closure."""
+
+    status: str = Field(default="closed", description="Closure status")
+
+
+class HealthResponse(BaseModel):
+    """Response model for health check."""
+
+    status: str = Field(default="healthy", description="Server health status")
+    active_sessions: int = Field(..., description="Number of active sessions")
+
+
+class JSONRPCRequest(BaseModel):
+    """JSON-RPC 2.0 request model."""
+
+    jsonrpc: str = Field(default="2.0", description="JSON-RPC version")
+    method: str = Field(..., description="Method name (e.g., 'tools/call')")
+    params: dict[str, Any] = Field(..., description="Method parameters")
+    id: Optional[int | str] = Field(None, description="Request ID")
+
+
+class JSONRPCResponse(BaseModel):
+    """JSON-RPC 2.0 response model."""
+
+    jsonrpc: str = Field(default="2.0", description="JSON-RPC version")
+    result: Optional[dict[str, Any]] = Field(None, description="Result data")
+    error: Optional[dict[str, Any]] = Field(None, description="Error data")
+    id: Optional[int | str] = Field(None, description="Request ID")
+
+
+class HTTPGitServer:
+    """
+    FastAPI HTTP server for MCP Git operations.
+
+    Provides HTTP endpoints for:
+    - Session lifecycle management (create, close, status)
+    - MCP tool execution via JSON-RPC 2.0
+    - Health monitoring
+    - Automatic session cleanup
+
+    Security:
+    - Localhost-only access by default
+    - Optional API key authentication
+    - Per-session repository isolation
+    """
+
+    def __init__(
+        self,
+        host: str = "127.0.0.1",
+        port: int = 8765,
+        api_key: Optional[str] = None,
+        session_timeout: float = 3600.0,
+    ):
+        """
+        Initialize HTTP Git server.
+
+        Args:
+            host: Host address to bind to (default: 127.0.0.1)
+            port: Port to listen on (default: 8765)
+            api_key: Optional API key for authentication
+            session_timeout: Session timeout in seconds (default: 3600 = 1 hour)
+        """
+        self.host = host
+        self.port = port
+        self.api_key = api_key
+        self.session_manager = HTTPSessionManager(session_timeout=session_timeout)
+
+        # Create FastAPI app with lifespan context manager
+        @asynccontextmanager
+        async def lifespan(app: FastAPI):
+            """Lifespan context manager for startup/shutdown."""
+            # Startup
+            logger.info(
+                f"MCP Git HTTP Server starting on {self.host}:{self.port}"
+            )
+            if self.api_key:
+                logger.info("API key authentication enabled")
+            else:
+                logger.info("API key authentication disabled")
+
+            yield
+
+            # Shutdown
+            logger.info("MCP Git HTTP Server shutting down")
+            # Cleanup all sessions
+            session_ids = list(self.session_manager._sessions.keys())
+            for session_id in session_ids:
+                await self.session_manager.close_session(session_id)
+            logger.info(f"Cleaned up {len(session_ids)} sessions on shutdown")
+
+        self.app = FastAPI(
+            title="MCP Git HTTP Server",
+            description="HTTP transport for MCP Git operations",
+            version="1.0.0",
+            lifespan=lifespan,
+        )
+
+        # Apply security middleware
+        self.app.add_middleware(LocalhostOnlyMiddleware)
+        if self.api_key:
+            self.app.add_middleware(APIKeyMiddleware, api_key=self.api_key)
+
+        # Register endpoints
+        self._register_endpoints()
+
+    def _register_endpoints(self):
+        """Register all HTTP endpoints."""
+
+        @self.app.post(
+            "/mcp/session/create",
+            response_model=CreateSessionResponse,
+            status_code=status.HTTP_201_CREATED,
+        )
+        async def create_session(request: CreateSessionRequest):
+            """
+            Create a new MCP session with repository binding.
+
+            This endpoint creates an isolated session context with its own
+            service instances and binds it to a specific repository.
+
+            Args:
+                request: Session creation request with repository path and expected remote URL
+
+            Returns:
+                Session information including session_id and status
+
+            Raises:
+                HTTPException 400: If repository binding fails
+                HTTPException 422: If request validation fails
+            """
+            try:
+                session_context = await self.session_manager.create_session(
+                    repo_path=Path(request.repository_path),
+                    expected_remote_url=request.expected_remote_url,
+                )
+
+                logger.info(f"Session created: {session_context.session_id}")
+
+                return CreateSessionResponse(
+                    session_id=session_context.session_id,
+                    status="bound",
+                    repository_path=str(
+                        session_context.repository_binding.repository_path
+                        if session_context.repository_binding
+                        else request.repository_path
+                    ),
+                )
+
+            except Exception as e:
+                logger.error(f"Failed to create session: {e}", exc_info=True)
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Failed to create session: {str(e)}",
+                )
+
+        @self.app.delete(
+            "/mcp/session/{session_id}",
+            response_model=CloseSessionResponse,
+        )
+        async def close_session(session_id: str):
+            """
+            Close an existing MCP session.
+
+            This endpoint unbinds the repository and releases all session resources.
+
+            Args:
+                session_id: The session identifier to close
+
+            Returns:
+                Closure status
+
+            Raises:
+                HTTPException 404: If session not found
+            """
+            success = await self.session_manager.close_session(session_id)
+
+            if not success:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Session not found: {session_id}",
+                )
+
+            logger.info(f"Session closed: {session_id}")
+            return CloseSessionResponse(status="closed")
+
+        @self.app.get(
+            "/mcp/session/{session_id}/status",
+            response_model=SessionStatusResponse,
+        )
+        async def get_session_status(session_id: str):
+            """
+            Get status information for a session.
+
+            Args:
+                session_id: The session identifier
+
+            Returns:
+                Session status information including activity timestamps
+
+            Raises:
+                HTTPException 404: If session not found
+            """
+            session_info = await self.session_manager.get_session_info(session_id)
+
+            if not session_info:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail=f"Session not found: {session_id}",
+                )
+
+            return SessionStatusResponse(**session_info)
+
+        @self.app.post("/mcp", response_model=JSONRPCResponse)
+        async def execute_mcp_tool(
+            request: JSONRPCRequest,
+            mcp_session_id: str = Header(..., alias="MCP-Session-Id"),
+        ):
+            """
+            Execute an MCP tool via JSON-RPC 2.0.
+
+            This endpoint accepts JSON-RPC 2.0 formatted requests for tool execution.
+            The session ID must be provided via the MCP-Session-Id header.
+
+            Args:
+                request: JSON-RPC 2.0 request with method and params
+                mcp_session_id: Session identifier from header
+
+            Returns:
+                JSON-RPC 2.0 response with result or error
+
+            Raises:
+                HTTPException 400: If request is invalid
+                HTTPException 404: If session not found
+            """
+            # Validate JSON-RPC version
+            if request.jsonrpc != "2.0":
+                return JSONRPCResponse(
+                    jsonrpc="2.0",
+                    error={
+                        "code": -32600,
+                        "message": "Invalid Request - only JSON-RPC 2.0 supported",
+                    },
+                    id=request.id,
+                )
+
+            # Validate method
+            if request.method != "tools/call":
+                return JSONRPCResponse(
+                    jsonrpc="2.0",
+                    error={
+                        "code": -32601,
+                        "message": f"Method not found: {request.method}",
+                    },
+                    id=request.id,
+                )
+
+            # Extract tool name and arguments
+            try:
+                tool_name = request.params.get("name")
+                arguments = request.params.get("arguments", {})
+
+                if not tool_name:
+                    return JSONRPCResponse(
+                        jsonrpc="2.0",
+                        error={
+                            "code": -32602,
+                            "message": "Invalid params - 'name' required",
+                        },
+                        id=request.id,
+                    )
+
+                # Execute tool via session manager
+                result = await self.session_manager.execute_tool(
+                    session_id=mcp_session_id,
+                    tool_name=tool_name,
+                    args=arguments,
+                )
+
+                logger.debug(
+                    f"Tool executed: {tool_name} for session {mcp_session_id}"
+                )
+
+                return JSONRPCResponse(
+                    jsonrpc="2.0",
+                    result=result,
+                    id=request.id,
+                )
+
+            except ValueError as e:
+                # Session not found or validation error
+                logger.error(f"Tool execution error: {e}")
+                return JSONRPCResponse(
+                    jsonrpc="2.0",
+                    error={
+                        "code": -32000,
+                        "message": str(e),
+                    },
+                    id=request.id,
+                )
+
+            except Exception as e:
+                # Internal error
+                logger.error(f"Tool execution failed: {e}", exc_info=True)
+                return JSONRPCResponse(
+                    jsonrpc="2.0",
+                    error={
+                        "code": -32603,
+                        "message": f"Internal error: {str(e)}",
+                    },
+                    id=request.id,
+                )
+
+        @self.app.get("/health", response_model=HealthResponse)
+        async def health_check():
+            """
+            Health check endpoint.
+
+            Returns:
+                Server health status and active session count
+            """
+            active_sessions = len(self.session_manager._sessions)
+
+            return HealthResponse(
+                status="healthy",
+                active_sessions=active_sessions,
+            )
+
+    def run(self):
+        """
+        Run the HTTP server.
+
+        This starts the uvicorn server with the configured host and port.
+        The server will run until interrupted (e.g., Ctrl+C).
+        """
+        logger.info(f"Starting HTTP server on {self.host}:{self.port}")
+
+        uvicorn.run(
+            self.app,
+            host=self.host,
+            port=self.port,
+            log_level="info",
+        )

--- a/src/mcp_server_git/transport/http_server.py
+++ b/src/mcp_server_git/transport/http_server.py
@@ -44,9 +44,7 @@ __all__ = ["HTTPGitServer"]
 class CreateSessionRequest(BaseModel):
     """Request model for creating a new session."""
 
-    repository_path: str = Field(
-        ..., description="Absolute path to the git repository"
-    )
+    repository_path: str = Field(..., description="Absolute path to the git repository")
     expected_remote_url: str = Field(
         ..., description="Expected remote URL for validation"
     )
@@ -89,7 +87,9 @@ class JSONRPCRequest(BaseModel):
 
     jsonrpc: str = Field(default="2.0", description="JSON-RPC version")
     method: str = Field(..., description="Method name (e.g., 'tools/call')")
-    params: Optional[dict[str, Any]] = Field(default=None, description="Method parameters")
+    params: Optional[dict[str, Any]] = Field(
+        default=None, description="Method parameters"
+    )
     id: Optional[int | str] = Field(None, description="Request ID")
 
 
@@ -154,9 +154,7 @@ class HTTPGitServer:
         async def lifespan(app: FastAPI):
             """Lifespan context manager for startup/shutdown."""
             # Startup
-            logger.info(
-                f"MCP Git HTTP Server starting on {self.host}:{self.port}"
-            )
+            logger.info(f"MCP Git HTTP Server starting on {self.host}:{self.port}")
             if self.api_key:
                 logger.info("API key authentication enabled")
             else:
@@ -170,13 +168,9 @@ class HTTPGitServer:
                         expected_remote_url=None,  # Skip URL validation for default session
                         session_id=self.DEFAULT_SESSION_ID,
                     )
-                    logger.info(
-                        f"Default session created for: {self.default_repo}"
-                    )
+                    logger.info(f"Default session created for: {self.default_repo}")
                 except Exception as e:
-                    logger.warning(
-                        f"Failed to create default session: {e}"
-                    )
+                    logger.warning(f"Failed to create default session: {e}")
 
             yield
 
@@ -350,7 +344,9 @@ class HTTPGitServer:
                             session_id=new_session_id,
                         )
                     except Exception as e:
-                        logger.error(f"Session creation failed for {self.default_repo}: {e}")
+                        logger.error(
+                            f"Session creation failed for {self.default_repo}: {e}"
+                        )
                         return JSONResponse(
                             status_code=500,
                             content={
@@ -363,81 +359,97 @@ class HTTPGitServer:
                             },
                         )
 
-                response = JSONResponse(content={
-                    "jsonrpc": "2.0",
-                    "id": req_id,
-                    "result": {
-                        "protocolVersion": "2024-11-05",
-                        "capabilities": {
-                            "tools": {"listChanged": True},
+                response = JSONResponse(
+                    content={
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "result": {
+                            "protocolVersion": "2024-11-05",
+                            "capabilities": {
+                                "tools": {"listChanged": True},
+                            },
+                            "serverInfo": {"name": "mcp-git", "version": "1.0.0"},
                         },
-                        "serverInfo": {"name": "mcp-git", "version": "1.0.0"},
-                    },
-                })
+                    }
+                )
                 response.headers["MCP-Session-Id"] = new_session_id
                 response.headers["MCP-Protocol-Version"] = "2024-11-05"
                 return response
 
             # Handle notifications/initialized - just acknowledge
             if method == "notifications/initialized":
-                return JSONResponse(content={
-                    "jsonrpc": "2.0",
-                    "id": req_id,
-                    "result": {},
-                })
+                return JSONResponse(
+                    content={
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "result": {},
+                    }
+                )
 
             # Handle tools/list - return the 3 meta-tools
             if method == "tools/list":
-                return JSONResponse(content={
-                    "jsonrpc": "2.0",
-                    "id": req_id,
-                    "result": {
-                        "tools": [
-                            {
-                                "name": "discover_tools",
-                                "description": "Discover available Git, GitHub, and Azure DevOps tools. USE WHEN: finding tools by pattern",
-                                "inputSchema": {
-                                    "type": "object",
-                                    "properties": {"pattern": {"type": "string", "default": ""}},
-                                },
-                            },
-                            {
-                                "name": "get_tool_spec",
-                                "description": "Get full specification for specific tool including schema and examples.",
-                                "inputSchema": {
-                                    "type": "object",
-                                    "properties": {"tool_name": {"type": "string"}},
-                                    "required": ["tool_name"],
-                                },
-                            },
-                            {
-                                "name": "execute_tool",
-                                "description": "Execute Git, GitHub, or Azure DevOps operation.",
-                                "inputSchema": {
-                                    "type": "object",
-                                    "properties": {
-                                        "tool_name": {"type": "string"},
-                                        "parameters": {"type": "object"},
+                return JSONResponse(
+                    content={
+                        "jsonrpc": "2.0",
+                        "id": req_id,
+                        "result": {
+                            "tools": [
+                                {
+                                    "name": "discover_tools",
+                                    "description": "Discover available Git, GitHub, and Azure DevOps tools. USE WHEN: finding tools by pattern",
+                                    "inputSchema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "pattern": {"type": "string", "default": ""}
+                                        },
                                     },
-                                    "required": ["tool_name", "parameters"],
                                 },
-                            },
-                        ]
-                    },
-                })
+                                {
+                                    "name": "get_tool_spec",
+                                    "description": "Get full specification for specific tool including schema and examples.",
+                                    "inputSchema": {
+                                        "type": "object",
+                                        "properties": {"tool_name": {"type": "string"}},
+                                        "required": ["tool_name"],
+                                    },
+                                },
+                                {
+                                    "name": "execute_tool",
+                                    "description": "Execute Git, GitHub, or Azure DevOps operation.",
+                                    "inputSchema": {
+                                        "type": "object",
+                                        "properties": {
+                                            "tool_name": {"type": "string"},
+                                            "parameters": {"type": "object"},
+                                        },
+                                        "required": ["tool_name", "parameters"],
+                                    },
+                                },
+                            ]
+                        },
+                    }
+                )
 
             # For tools/call, we need a session
             if method == "tools/call":
                 # Use default session if none provided
                 if not mcp_session_id:
-                    if self.default_repo and self.DEFAULT_SESSION_ID in self.session_manager._sessions:
+                    if (
+                        self.default_repo
+                        and self.DEFAULT_SESSION_ID in self.session_manager._sessions
+                    ):
                         mcp_session_id = self.DEFAULT_SESSION_ID
                     else:
-                        return JSONResponse(content={
-                            "jsonrpc": "2.0",
-                            "id": req_id,
-                            "error": {"code": -32000, "message": "MCP-Session-Id header required"},
-                        })
+                        return JSONResponse(
+                            content={
+                                "jsonrpc": "2.0",
+                                "id": req_id,
+                                "error": {
+                                    "code": -32000,
+                                    "message": "MCP-Session-Id header required",
+                                },
+                            }
+                        )
 
                 # Extract tool name and arguments
                 try:
@@ -446,11 +458,16 @@ class HTTPGitServer:
                     arguments = call_params.get("arguments", {})
 
                     if not tool_name:
-                        return JSONResponse(content={
-                            "jsonrpc": "2.0",
-                            "id": req_id,
-                            "error": {"code": -32602, "message": "Invalid params - 'name' required"},
-                        })
+                        return JSONResponse(
+                            content={
+                                "jsonrpc": "2.0",
+                                "id": req_id,
+                                "error": {
+                                    "code": -32602,
+                                    "message": "Invalid params - 'name' required",
+                                },
+                            }
+                        )
 
                     # Handle 3-meta-tool pattern
                     if tool_name == "discover_tools":
@@ -462,11 +479,16 @@ class HTTPGitServer:
                     elif tool_name == "get_tool_spec":
                         target_tool = arguments.get("tool_name")
                         if not target_tool:
-                            return JSONResponse(content={
-                                "jsonrpc": "2.0",
-                                "id": req_id,
-                                "error": {"code": -32602, "message": "tool_name required"},
-                            })
+                            return JSONResponse(
+                                content={
+                                    "jsonrpc": "2.0",
+                                    "id": req_id,
+                                    "error": {
+                                        "code": -32602,
+                                        "message": "tool_name required",
+                                    },
+                                }
+                            )
                         result = await self.session_manager.get_tool_spec(
                             session_id=mcp_session_id,
                             tool_name=target_tool,
@@ -475,11 +497,16 @@ class HTTPGitServer:
                         target_tool = arguments.get("tool_name")
                         tool_params = arguments.get("parameters", {})
                         if not target_tool:
-                            return JSONResponse(content={
-                                "jsonrpc": "2.0",
-                                "id": req_id,
-                                "error": {"code": -32602, "message": "tool_name required"},
-                            })
+                            return JSONResponse(
+                                content={
+                                    "jsonrpc": "2.0",
+                                    "id": req_id,
+                                    "error": {
+                                        "code": -32602,
+                                        "message": "tool_name required",
+                                    },
+                                }
+                            )
                         result = await self.session_manager.execute_tool(
                             session_id=mcp_session_id,
                             tool_name=target_tool,
@@ -493,36 +520,51 @@ class HTTPGitServer:
                             args=arguments,
                         )
 
-                    logger.debug(f"Tool executed: {tool_name} for session {mcp_session_id}")
+                    logger.debug(
+                        f"Tool executed: {tool_name} for session {mcp_session_id}"
+                    )
 
-                    return JSONResponse(content={
-                        "jsonrpc": "2.0",
-                        "id": req_id,
-                        "result": {"content": [{"type": "text", "text": str(result)}]},
-                    })
+                    return JSONResponse(
+                        content={
+                            "jsonrpc": "2.0",
+                            "id": req_id,
+                            "result": {
+                                "content": [{"type": "text", "text": str(result)}]
+                            },
+                        }
+                    )
 
                 except ValueError as e:
                     logger.error(f"Tool execution error: {e}")
-                    return JSONResponse(content={
-                        "jsonrpc": "2.0",
-                        "id": req_id,
-                        "error": {"code": -32000, "message": str(e)},
-                    })
+                    return JSONResponse(
+                        content={
+                            "jsonrpc": "2.0",
+                            "id": req_id,
+                            "error": {"code": -32000, "message": str(e)},
+                        }
+                    )
 
                 except Exception as e:
                     logger.error(f"Tool execution failed: {e}", exc_info=True)
-                    return JSONResponse(content={
-                        "jsonrpc": "2.0",
-                        "id": req_id,
-                        "error": {"code": -32603, "message": f"Internal error: {str(e)}"},
-                    })
+                    return JSONResponse(
+                        content={
+                            "jsonrpc": "2.0",
+                            "id": req_id,
+                            "error": {
+                                "code": -32603,
+                                "message": f"Internal error: {str(e)}",
+                            },
+                        }
+                    )
 
             # Unknown method
-            return JSONResponse(content={
-                "jsonrpc": "2.0",
-                "id": req_id,
-                "error": {"code": -32601, "message": f"Method not found: {method}"},
-            })
+            return JSONResponse(
+                content={
+                    "jsonrpc": "2.0",
+                    "id": req_id,
+                    "error": {"code": -32601, "message": f"Method not found: {method}"},
+                }
+            )
 
         @self.app.get("/mcp")
         async def handle_mcp_sse(
@@ -538,6 +580,7 @@ class HTTPGitServer:
             Returns:
                 StreamingResponse with text/event-stream content type
             """
+
             async def event_generator() -> AsyncGenerator[str, None]:
                 """Generate SSE events."""
                 try:

--- a/src/mcp_server_git/transport/http_server.py
+++ b/src/mcp_server_git/transport/http_server.py
@@ -31,6 +31,7 @@ from fastapi import FastAPI, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
+from ..repository_binding import RemoteContaminationError, RepositoryBindingError
 from .http_session_manager import HTTPSessionManager
 from .security import APIKeyMiddleware, LocalhostOnlyMiddleware
 
@@ -358,6 +359,47 @@ class HTTPGitServer:
                             expected_remote_url=None,
                             session_id=new_session_id,
                         )
+                    except FileNotFoundError as e:
+                        logger.error(
+                            f"Repository path not found: {self.default_repo}: {e}"
+                        )
+                        return JSONResponse(
+                            content={
+                                "jsonrpc": "2.0",
+                                "id": req_id,
+                                "error": {
+                                    "code": -32602,
+                                    "message": f"Invalid repository path: {self.default_repo}",
+                                    "data": {"error_type": "path_not_found"},
+                                },
+                            },
+                        )
+                    except RemoteContaminationError as e:
+                        logger.error(f"Remote URL mismatch: {e}")
+                        return JSONResponse(
+                            content={
+                                "jsonrpc": "2.0",
+                                "id": req_id,
+                                "error": {
+                                    "code": -32602,
+                                    "message": f"Remote URL validation failed: {e}",
+                                    "data": {"error_type": "remote_mismatch"},
+                                },
+                            },
+                        )
+                    except RepositoryBindingError as e:
+                        logger.error(f"Repository binding failed: {e}")
+                        return JSONResponse(
+                            content={
+                                "jsonrpc": "2.0",
+                                "id": req_id,
+                                "error": {
+                                    "code": -32602,
+                                    "message": f"Repository binding failed: {e}",
+                                    "data": {"error_type": "binding_error"},
+                                },
+                            },
+                        )
                     except Exception as e:
                         logger.error(
                             f"Session creation failed for {self.default_repo}: {e}"
@@ -369,7 +411,8 @@ class HTTPGitServer:
                                 "id": req_id,
                                 "error": {
                                     "code": -32603,
-                                    "message": f"Failed to initialize session: {e}",
+                                    "message": f"Internal error during session initialization: {e}",
+                                    "data": {"error_type": "internal_error"},
                                 },
                             },
                         )
@@ -599,7 +642,14 @@ class HTTPGitServer:
             """
 
             async def event_generator() -> AsyncGenerator[str, None]:
-                """Generate SSE events."""
+                """Generate SSE events.
+
+                TODO: Expand to send actual MCP notifications:
+                - Tool execution progress events
+                - Repository state change notifications
+                - Session health updates
+                Currently only sends heartbeats for connection keepalive.
+                """
                 try:
                     # Keep connection alive with periodic heartbeats
                     while True:
@@ -627,11 +677,9 @@ class HTTPGitServer:
             Returns:
                 Server health status and active session count
             """
-            active_sessions = len(self.session_manager._sessions)
-
             return HealthResponse(
                 status="healthy",
-                active_sessions=active_sessions,
+                active_sessions=self.session_manager.get_session_count(),
             )
 
     def run(self):

--- a/src/mcp_server_git/transport/http_server.py
+++ b/src/mcp_server_git/transport/http_server.py
@@ -112,7 +112,14 @@ class HTTPGitServer:
     - Localhost-only access by default
     - Optional API key authentication
     - Per-session repository isolation
+
+    Auto-session mode:
+    - When default_repo is specified, creates a default session at startup
+    - MCP clients can omit MCP-Session-Id header and use default session
+    - Enables compatibility with standard MCP clients
     """
+
+    DEFAULT_SESSION_ID = "default"
 
     def __init__(
         self,
@@ -120,6 +127,7 @@ class HTTPGitServer:
         port: int = 8765,
         api_key: Optional[str] = None,
         session_timeout: float = 3600.0,
+        default_repo: Optional[Path] = None,
     ):
         """
         Initialize HTTP Git server.
@@ -129,10 +137,12 @@ class HTTPGitServer:
             port: Port to listen on (default: 8765)
             api_key: Optional API key for authentication
             session_timeout: Session timeout in seconds (default: 3600 = 1 hour)
+            default_repo: Optional default repository for auto-session mode
         """
         self.host = host
         self.port = port
         self.api_key = api_key
+        self.default_repo = default_repo
         self.session_manager = HTTPSessionManager(session_timeout=session_timeout)
 
         # Create FastAPI app with lifespan context manager
@@ -147,6 +157,22 @@ class HTTPGitServer:
                 logger.info("API key authentication enabled")
             else:
                 logger.info("API key authentication disabled")
+
+            # Create default session if default_repo is specified
+            if self.default_repo:
+                try:
+                    await self.session_manager.create_session(
+                        repo_path=self.default_repo,
+                        expected_remote_url=None,  # Skip URL validation for default session
+                        session_id=self.DEFAULT_SESSION_ID,
+                    )
+                    logger.info(
+                        f"Default session created for: {self.default_repo}"
+                    )
+                except Exception as e:
+                    logger.warning(
+                        f"Failed to create default session: {e}"
+                    )
 
             yield
 
@@ -283,17 +309,18 @@ class HTTPGitServer:
         @self.app.post("/mcp", response_model=JSONRPCResponse)
         async def execute_mcp_tool(
             request: JSONRPCRequest,
-            mcp_session_id: str = Header(..., alias="MCP-Session-Id"),
+            mcp_session_id: Optional[str] = Header(None, alias="MCP-Session-Id"),
         ):
             """
             Execute an MCP tool via JSON-RPC 2.0.
 
             This endpoint accepts JSON-RPC 2.0 formatted requests for tool execution.
-            The session ID must be provided via the MCP-Session-Id header.
+            The session ID can be provided via the MCP-Session-Id header.
+            If no session ID is provided and a default session exists, uses the default.
 
             Args:
                 request: JSON-RPC 2.0 request with method and params
-                mcp_session_id: Session identifier from header
+                mcp_session_id: Optional session identifier from header
 
             Returns:
                 JSON-RPC 2.0 response with result or error
@@ -302,6 +329,20 @@ class HTTPGitServer:
                 HTTPException 400: If request is invalid
                 HTTPException 404: If session not found
             """
+            # Use default session if none provided
+            if not mcp_session_id:
+                if self.default_repo and self.DEFAULT_SESSION_ID in self.session_manager._sessions:
+                    mcp_session_id = self.DEFAULT_SESSION_ID
+                else:
+                    return JSONRPCResponse(
+                        jsonrpc="2.0",
+                        error={
+                            "code": -32000,
+                            "message": "MCP-Session-Id header required (no default session configured)",
+                        },
+                        id=request.id,
+                    )
+
             # Validate JSON-RPC version
             if request.jsonrpc != "2.0":
                 return JSONRPCResponse(

--- a/src/mcp_server_git/transport/http_session_manager.py
+++ b/src/mcp_server_git/transport/http_session_manager.py
@@ -99,21 +99,23 @@ class HTTPSessionManager:
     async def create_session(
         self,
         repo_path: Path,
-        expected_remote_url: str,
+        expected_remote_url: str | None = None,
+        session_id: str | None = None,
     ) -> SessionContext:
         """
         Create a new HTTP session with isolated context.
 
         Each session gets:
-        - Unique session ID with "mcp-" prefix
+        - Unique session ID with "mcp-" prefix (or custom ID if provided)
         - New GitService instance
         - New GitHubService instance
         - New RepositoryBindingManager
-        - Repository binding with remote validation
+        - Repository binding with optional remote validation
 
         Args:
             repo_path: Path to git repository
-            expected_remote_url: Expected remote URL for validation
+            expected_remote_url: Expected remote URL for validation (optional for default sessions)
+            session_id: Custom session ID (optional, auto-generated if not provided)
 
         Returns:
             SessionContext with bound repository
@@ -123,8 +125,9 @@ class HTTPSessionManager:
             RemoteContaminationError: If remote URL doesn't match
         """
         async with self._lock:
-            # Generate unique session ID
-            session_id = f"mcp-{secrets.token_urlsafe(16)}"
+            # Use provided session ID or generate a unique one
+            if session_id is None:
+                session_id = f"mcp-{secrets.token_urlsafe(16)}"
 
             # Create isolated service instances
             git_service = GitService()
@@ -135,11 +138,11 @@ class HTTPSessionManager:
                 server_name=f"http-session-{session_id}"
             )
 
-            # Bind repository with remote validation
+            # Bind repository with optional remote validation
             repository_binding = await binding_manager.bind_repository(
                 repository_path=repo_path,
                 expected_remote_url=expected_remote_url,
-                verify_remote=True,
+                verify_remote=expected_remote_url is not None,
             )
 
             # Create session context
@@ -157,9 +160,10 @@ class HTTPSessionManager:
             # Store session
             self._sessions[session_id] = session_context
 
+            remote_info = f"with remote {expected_remote_url}" if expected_remote_url else "(no remote validation)"
             logger.info(
                 f"Session created: {session_id} for repository {repo_path} "
-                f"with remote {expected_remote_url}"
+                f"{remote_info}"
             )
 
             return session_context

--- a/src/mcp_server_git/transport/http_session_manager.py
+++ b/src/mcp_server_git/transport/http_session_manager.py
@@ -366,6 +366,18 @@ class HTTPSessionManager:
         """
         return len(self._sessions)
 
+    def has_session(self, session_id: str) -> bool:
+        """
+        Check if a session exists.
+
+        Args:
+            session_id: Session identifier to check
+
+        Returns:
+            True if session exists, False otherwise
+        """
+        return session_id in self._sessions
+
     async def close_all_sessions(self) -> int:
         """
         Close all active sessions.

--- a/src/mcp_server_git/transport/http_session_manager.py
+++ b/src/mcp_server_git/transport/http_session_manager.py
@@ -355,6 +355,27 @@ class HTTPSessionManager:
 
             return session_infos
 
+    async def close_all_sessions(self) -> int:
+        """
+        Close all active sessions.
+
+        Returns:
+            Number of sessions closed
+        """
+        async with self._lock:
+            session_ids = list(self._sessions.keys())
+            count = 0
+
+            for session_id in session_ids:
+                session = self._sessions.get(session_id)
+                if session:
+                    await session.binding_manager.unbind_repository(force=True)
+                    del self._sessions[session_id]
+                    count += 1
+                    logger.info(f"Session closed during shutdown: {session_id}")
+
+            return count
+
     async def discover_tools(
         self,
         session_id: str,

--- a/src/mcp_server_git/transport/http_session_manager.py
+++ b/src/mcp_server_git/transport/http_session_manager.py
@@ -92,9 +92,7 @@ class HTTPSessionManager:
         self.session_timeout = session_timeout
         self._sessions: dict[str, SessionContext] = {}
         self._lock = asyncio.Lock()
-        logger.info(
-            f"HTTPSessionManager initialized with {session_timeout}s timeout"
-        )
+        logger.info(f"HTTPSessionManager initialized with {session_timeout}s timeout")
 
     async def create_session(
         self,
@@ -160,7 +158,11 @@ class HTTPSessionManager:
             # Store session
             self._sessions[session_id] = session_context
 
-            remote_info = f"with remote {expected_remote_url}" if expected_remote_url else "(no remote validation)"
+            remote_info = (
+                f"with remote {expected_remote_url}"
+                if expected_remote_url
+                else "(no remote validation)"
+            )
             logger.info(
                 f"Session created: {session_id} for repository {repo_path} "
                 f"{remote_info}"
@@ -249,9 +251,7 @@ class HTTPSessionManager:
         # Validate repository binding integrity
         if session.repository_binding:
             if not session.repository_binding.verify_integrity():
-                logger.error(
-                    f"Binding integrity check failed for session {session_id}"
-                )
+                logger.error(f"Binding integrity check failed for session {session_id}")
                 raise ValueError(
                     "Repository binding corrupted - potential tampering detected"
                 )
@@ -344,14 +344,16 @@ class HTTPSessionManager:
             current_time = time.time()
 
             for session in self._sessions.values():
-                session_infos.append({
-                    "session_id": session.session_id,
-                    "created_at": session.created_at,
-                    "last_activity": session.last_activity,
-                    "age": current_time - session.created_at,
-                    "idle_time": current_time - session.last_activity,
-                    "binding_info": session.binding_manager.get_binding_info(),
-                })
+                session_infos.append(
+                    {
+                        "session_id": session.session_id,
+                        "created_at": session.created_at,
+                        "last_activity": session.last_activity,
+                        "age": current_time - session.created_at,
+                        "idle_time": current_time - session.last_activity,
+                        "binding_info": session.binding_manager.get_binding_info(),
+                    }
+                )
 
             return session_infos
 

--- a/src/mcp_server_git/transport/http_session_manager.py
+++ b/src/mcp_server_git/transport/http_session_manager.py
@@ -1,0 +1,352 @@
+"""
+HTTP Session Manager for MCP Git Server.
+
+This module implements HTTP session management with repository isolation to prevent
+cross-session contamination. Each HTTP session gets its own isolated context with
+dedicated service instances and repository binding.
+
+Key features:
+- Isolated session contexts with unique session IDs
+- Per-session GitService and GitHubService instances
+- Repository binding with remote URL validation
+- Session timeout and automatic cleanup
+- Thread-safe session management with asyncio locks
+- Remote contamination detection during tool execution
+
+Architecture:
+    HTTP Request → SessionManager → SessionContext → Services → Git/GitHub Operations
+                                   └─> RepositoryBinding (validation)
+"""
+
+import asyncio
+import logging
+import secrets
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ..lean.interface import GitLeanInterface
+from ..repository_binding import (
+    RepositoryBinding,
+    RepositoryBindingManager,
+)
+from ..services.git_service import GitService
+from ..services.github_service import GitHubService
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "SessionContext",
+    "HTTPSessionManager",
+]
+
+
+@dataclass
+class SessionContext:
+    """
+    Isolated session context for HTTP sessions.
+
+    Each session gets its own service instances and repository binding to prevent
+    cross-session contamination.
+    """
+
+    session_id: str
+    binding_manager: RepositoryBindingManager
+    repository_binding: RepositoryBinding | None
+    created_at: float
+    last_activity: float
+    git_service: GitService
+    github_service: GitHubService
+    lean_interface: GitLeanInterface = field(init=False)
+
+    def __post_init__(self):
+        """Initialize the lean interface for this session."""
+        # Create lean interface with session's service instances
+        # Note: azure_service is optional and can be None for now
+        self.lean_interface = GitLeanInterface(
+            git_service=self.git_service,
+            github_service=self.github_service,
+            azure_service=None,  # Azure service not required for basic operations
+            app_name=f"mcp-git-session-{self.session_id}",
+        )
+
+
+class HTTPSessionManager:
+    """
+    Manages HTTP sessions with repository isolation.
+
+    Provides session lifecycle management including:
+    - Session creation with isolated service instances
+    - Repository binding with remote validation
+    - Tool execution with contamination detection
+    - Session cleanup and timeout handling
+    """
+
+    def __init__(self, session_timeout: float = 3600.0):
+        """
+        Initialize HTTP session manager.
+
+        Args:
+            session_timeout: Session timeout in seconds (default: 1 hour)
+        """
+        self.session_timeout = session_timeout
+        self._sessions: dict[str, SessionContext] = {}
+        self._lock = asyncio.Lock()
+        logger.info(
+            f"HTTPSessionManager initialized with {session_timeout}s timeout"
+        )
+
+    async def create_session(
+        self,
+        repo_path: Path,
+        expected_remote_url: str,
+    ) -> SessionContext:
+        """
+        Create a new HTTP session with isolated context.
+
+        Each session gets:
+        - Unique session ID with "mcp-" prefix
+        - New GitService instance
+        - New GitHubService instance
+        - New RepositoryBindingManager
+        - Repository binding with remote validation
+
+        Args:
+            repo_path: Path to git repository
+            expected_remote_url: Expected remote URL for validation
+
+        Returns:
+            SessionContext with bound repository
+
+        Raises:
+            RepositoryBindingError: If repository binding fails
+            RemoteContaminationError: If remote URL doesn't match
+        """
+        async with self._lock:
+            # Generate unique session ID
+            session_id = f"mcp-{secrets.token_urlsafe(16)}"
+
+            # Create isolated service instances
+            git_service = GitService()
+            github_service = GitHubService()
+
+            # Create binding manager for this session
+            binding_manager = RepositoryBindingManager(
+                server_name=f"http-session-{session_id}"
+            )
+
+            # Bind repository with remote validation
+            repository_binding = await binding_manager.bind_repository(
+                repository_path=repo_path,
+                expected_remote_url=expected_remote_url,
+                verify_remote=True,
+            )
+
+            # Create session context
+            current_time = time.time()
+            session_context = SessionContext(
+                session_id=session_id,
+                binding_manager=binding_manager,
+                repository_binding=repository_binding,
+                created_at=current_time,
+                last_activity=current_time,
+                git_service=git_service,
+                github_service=github_service,
+            )
+
+            # Store session
+            self._sessions[session_id] = session_context
+
+            logger.info(
+                f"Session created: {session_id} for repository {repo_path} "
+                f"with remote {expected_remote_url}"
+            )
+
+            return session_context
+
+    async def get_session(self, session_id: str) -> SessionContext | None:
+        """
+        Get session context by ID.
+
+        Updates last activity timestamp if session exists.
+
+        Args:
+            session_id: Session identifier
+
+        Returns:
+            SessionContext if found, None otherwise
+        """
+        async with self._lock:
+            session = self._sessions.get(session_id)
+            if session:
+                session.last_activity = time.time()
+                logger.debug(f"Session accessed: {session_id}")
+            else:
+                logger.warning(f"Session not found: {session_id}")
+            return session
+
+    async def close_session(self, session_id: str) -> bool:
+        """
+        Close session and unbind repository.
+
+        Args:
+            session_id: Session identifier
+
+        Returns:
+            True if session was closed, False if not found
+        """
+        async with self._lock:
+            session = self._sessions.get(session_id)
+            if not session:
+                logger.warning(f"Cannot close non-existent session: {session_id}")
+                return False
+
+            # Unbind repository
+            await session.binding_manager.unbind_repository()
+
+            # Remove from sessions
+            del self._sessions[session_id]
+
+            logger.info(f"Session closed: {session_id}")
+            return True
+
+    async def execute_tool(
+        self,
+        session_id: str,
+        tool_name: str,
+        args: dict,
+    ) -> dict:
+        """
+        Execute tool with session context and contamination detection.
+
+        Validates:
+        1. Session exists
+        2. Repository binding integrity
+        3. Remote URL hasn't been contaminated
+
+        Args:
+            session_id: Session identifier
+            tool_name: Tool name to execute
+            args: Tool arguments
+
+        Returns:
+            Tool execution result
+
+        Raises:
+            ValueError: If session not found
+            RemoteContaminationError: If remote contamination detected
+            RepositoryBindingError: If binding validation fails
+        """
+        # Get session (updates last_activity)
+        session = await self.get_session(session_id)
+        if not session:
+            raise ValueError(f"Session not found: {session_id}")
+
+        # Validate repository binding integrity
+        if session.repository_binding:
+            if not session.repository_binding.verify_integrity():
+                logger.error(
+                    f"Binding integrity check failed for session {session_id}"
+                )
+                raise ValueError(
+                    "Repository binding corrupted - potential tampering detected"
+                )
+
+        # Check for remote contamination
+        await session.binding_manager.validate_remote_integrity()
+
+        # Validate operation path if provided in args
+        if "repo_path" in args:
+            operation_path = Path(args["repo_path"])
+            session.binding_manager.validate_operation_path(operation_path)
+
+        # Execute tool via session's lean interface
+        logger.debug(
+            f"Executing tool {tool_name} for session {session_id} with args: {args}"
+        )
+
+        # Use the lean interface's execute_tool_direct method
+        # This will route to the appropriate handler based on tool name
+        result = await session.lean_interface.execute_tool_direct(tool_name, args)
+
+        return result
+
+    async def cleanup_expired_sessions(self) -> int:
+        """
+        Remove sessions older than timeout.
+
+        Returns:
+            Number of sessions cleaned up
+        """
+        async with self._lock:
+            current_time = time.time()
+            expired_sessions = []
+
+            for session_id, session in self._sessions.items():
+                age = current_time - session.last_activity
+                if age > self.session_timeout:
+                    expired_sessions.append(session_id)
+
+            # Clean up expired sessions
+            for session_id in expired_sessions:
+                session = self._sessions[session_id]
+                await session.binding_manager.unbind_repository(force=True)
+                del self._sessions[session_id]
+                logger.info(
+                    f"Expired session cleaned up: {session_id} "
+                    f"(age: {current_time - session.created_at:.1f}s)"
+                )
+
+            if expired_sessions:
+                logger.info(
+                    f"Cleanup completed: {len(expired_sessions)} sessions removed"
+                )
+
+            return len(expired_sessions)
+
+    async def get_session_info(self, session_id: str) -> dict | None:
+        """
+        Get session information.
+
+        Args:
+            session_id: Session identifier
+
+        Returns:
+            Session info dictionary or None if not found
+        """
+        session = await self.get_session(session_id)
+        if not session:
+            return None
+
+        current_time = time.time()
+        return {
+            "session_id": session.session_id,
+            "created_at": session.created_at,
+            "last_activity": session.last_activity,
+            "age": current_time - session.created_at,
+            "idle_time": current_time - session.last_activity,
+            "binding_info": session.binding_manager.get_binding_info(),
+        }
+
+    async def get_all_sessions_info(self) -> list[dict]:
+        """
+        Get information for all active sessions.
+
+        Returns:
+            List of session info dictionaries
+        """
+        async with self._lock:
+            session_infos = []
+            current_time = time.time()
+
+            for session in self._sessions.values():
+                session_infos.append({
+                    "session_id": session.session_id,
+                    "created_at": session.created_at,
+                    "last_activity": session.last_activity,
+                    "age": current_time - session.created_at,
+                    "idle_time": current_time - session.last_activity,
+                    "binding_info": session.binding_manager.get_binding_info(),
+                })
+
+            return session_infos

--- a/src/mcp_server_git/transport/http_session_manager.py
+++ b/src/mcp_server_git/transport/http_session_manager.py
@@ -354,3 +354,45 @@ class HTTPSessionManager:
                 })
 
             return session_infos
+
+    async def discover_tools(
+        self,
+        session_id: str,
+        pattern: str = "",
+    ) -> dict:
+        """
+        Discover available tools via session's lean interface.
+
+        Args:
+            session_id: Session identifier
+            pattern: Optional filter pattern
+
+        Returns:
+            Tool discovery result
+        """
+        session = await self.get_session(session_id)
+        if not session:
+            raise ValueError(f"Session not found: {session_id}")
+
+        return session.lean_interface.discover_tools(pattern)
+
+    async def get_tool_spec(
+        self,
+        session_id: str,
+        tool_name: str,
+    ) -> dict:
+        """
+        Get tool specification via session's lean interface.
+
+        Args:
+            session_id: Session identifier
+            tool_name: Name of tool to get spec for
+
+        Returns:
+            Tool specification
+        """
+        session = await self.get_session(session_id)
+        if not session:
+            raise ValueError(f"Session not found: {session_id}")
+
+        return session.lean_interface.get_tool_spec(tool_name)

--- a/src/mcp_server_git/transport/http_session_manager.py
+++ b/src/mcp_server_git/transport/http_session_manager.py
@@ -357,6 +357,15 @@ class HTTPSessionManager:
 
             return session_infos
 
+    def get_session_count(self) -> int:
+        """
+        Get number of active sessions.
+
+        Returns:
+            Number of active sessions (thread-safe read)
+        """
+        return len(self._sessions)
+
     async def close_all_sessions(self) -> int:
         """
         Close all active sessions.

--- a/src/mcp_server_git/transport/security.py
+++ b/src/mcp_server_git/transport/security.py
@@ -42,14 +42,14 @@ class LocalhostOnlyMiddleware(BaseHTTPMiddleware):
             logger.warning(
                 "Blocked non-localhost request from %s to %s",
                 client_host,
-                request.url.path
+                request.url.path,
             )
             return JSONResponse(
                 status_code=403,
                 content={
                     "error": "Forbidden",
-                    "message": "Access restricted to localhost only"
-                }
+                    "message": "Access restricted to localhost only",
+                },
             )
 
         return await call_next(request)
@@ -100,29 +100,20 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         provided_key = request.headers.get("X-API-Key")
 
         if not provided_key:
-            logger.warning(
-                "Request to %s missing X-API-Key header",
-                request.url.path
-            )
+            logger.warning("Request to %s missing X-API-Key header", request.url.path)
             return JSONResponse(
                 status_code=401,
                 content={
                     "error": "Unauthorized",
-                    "message": "X-API-Key header required"
-                }
+                    "message": "X-API-Key header required",
+                },
             )
 
         if provided_key != self.api_key:
-            logger.warning(
-                "Request to %s with invalid API key",
-                request.url.path
-            )
+            logger.warning("Request to %s with invalid API key", request.url.path)
             return JSONResponse(
                 status_code=401,
-                content={
-                    "error": "Unauthorized",
-                    "message": "Invalid API key"
-                }
+                content={"error": "Unauthorized", "message": "Invalid API key"},
             )
 
         # API key is valid, proceed with request

--- a/src/mcp_server_git/transport/security.py
+++ b/src/mcp_server_git/transport/security.py
@@ -1,0 +1,129 @@
+"""Security middleware for HTTP transport.
+
+This module provides security layers for the HTTP transport:
+- LocalhostOnlyMiddleware: Restricts access to localhost connections only
+- APIKeyMiddleware: Optional API key validation via X-API-Key header
+"""
+
+import logging
+from typing import Optional
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+
+class LocalhostOnlyMiddleware(BaseHTTPMiddleware):
+    """Middleware that restricts access to localhost connections only.
+
+    This middleware checks the client IP address and only allows requests
+    from localhost (127.0.0.1, ::1, or localhost hostname).
+
+    Any requests from other IP addresses will receive a 403 Forbidden response.
+    """
+
+    ALLOWED_HOSTS = {"127.0.0.1", "::1", "localhost", "testclient"}
+
+    async def dispatch(self, request: Request, call_next):
+        """Process the request and validate client IP.
+
+        Args:
+            request: The incoming HTTP request
+            call_next: The next middleware or endpoint handler
+
+        Returns:
+            Response from the next handler if allowed, otherwise 403 Forbidden
+        """
+        client_host = request.client.host if request.client else None
+
+        if client_host not in self.ALLOWED_HOSTS:
+            logger.warning(
+                "Blocked non-localhost request from %s to %s",
+                client_host,
+                request.url.path
+            )
+            return JSONResponse(
+                status_code=403,
+                content={
+                    "error": "Forbidden",
+                    "message": "Access restricted to localhost only"
+                }
+            )
+
+        return await call_next(request)
+
+
+class APIKeyMiddleware(BaseHTTPMiddleware):
+    """Middleware that validates API key via X-API-Key header.
+
+    This middleware provides optional API key authentication. If an API key
+    is configured, all requests must include a matching X-API-Key header.
+    If no API key is configured, all requests are allowed through.
+
+    Args:
+        api_key: The expected API key, or None to skip validation
+    """
+
+    def __init__(self, app, api_key: Optional[str] = None):
+        """Initialize the API key middleware.
+
+        Args:
+            app: The ASGI application
+            api_key: The expected API key, or None to skip validation
+        """
+        super().__init__(app)
+        self.api_key = api_key
+        self.enabled = api_key is not None
+
+        if self.enabled:
+            logger.info("API key authentication enabled")
+        else:
+            logger.info("API key authentication disabled")
+
+    async def dispatch(self, request: Request, call_next):
+        """Process the request and validate API key if enabled.
+
+        Args:
+            request: The incoming HTTP request
+            call_next: The next middleware or endpoint handler
+
+        Returns:
+            Response from the next handler if authorized, otherwise 401 Unauthorized
+        """
+        # Skip validation if API key is not configured
+        if not self.enabled:
+            return await call_next(request)
+
+        # Check for X-API-Key header
+        provided_key = request.headers.get("X-API-Key")
+
+        if not provided_key:
+            logger.warning(
+                "Request to %s missing X-API-Key header",
+                request.url.path
+            )
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "error": "Unauthorized",
+                    "message": "X-API-Key header required"
+                }
+            )
+
+        if provided_key != self.api_key:
+            logger.warning(
+                "Request to %s with invalid API key",
+                request.url.path
+            )
+            return JSONResponse(
+                status_code=401,
+                content={
+                    "error": "Unauthorized",
+                    "message": "Invalid API key"
+                }
+            )
+
+        # API key is valid, proceed with request
+        return await call_next(request)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -11,6 +11,16 @@ def event_loop():
     """Create an instance of the default event loop for the session."""
     loop = asyncio.get_event_loop_policy().new_event_loop()
     yield loop
+
+    # Cancel all pending tasks before closing
+    pending = asyncio.all_tasks(loop)
+    for task in pending:
+        task.cancel()
+
+    # Wait for cancellation to complete
+    if pending:
+        loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+
     loop.close()
 
 

--- a/tests/integration/test_protocol_compliance.py
+++ b/tests/integration/test_protocol_compliance.py
@@ -63,29 +63,29 @@ async def test_notification_interceptor_handles_malformed(malformed_notification
 @pytest.mark.asyncio
 async def test_session_lifecycle_integration():
     """Test session creation, activation, pausing, and closing."""
-    manager = SessionManager(idle_timeout=2, heartbeat_timeout=1)
-    session = await manager.create_session("sess-1", user="alice")
-    assert session.state == SessionState.ACTIVE
-    await session.pause()
-    assert session.state == SessionState.PAUSED
-    await session.resume()
-    assert session.state == SessionState.ACTIVE
-    await session.close(reason="test done")
-    assert session.state == SessionState.CLOSED
+    async with SessionManager(idle_timeout=2, heartbeat_timeout=1) as manager:
+        session = await manager.create_session("sess-1", user="alice")
+        assert session.state == SessionState.ACTIVE
+        await session.pause()
+        assert session.state == SessionState.PAUSED
+        await session.resume()
+        assert session.state == SessionState.ACTIVE
+        await session.close(reason="test done")
+        assert session.state == SessionState.CLOSED
 
 
 @pytest.mark.asyncio
 async def test_session_error_handling():
     """Test error context integration with session command handling."""
-    manager = SessionManager()
-    session = await manager.create_session("sess-err", user="bob")
-    # Simulate a command that raises an error
-    with pytest.raises(RuntimeError):
-        await session.handle_command("bad_command")
-    ctx = session.get_error_context()
-    assert isinstance(ctx, ErrorContext)
-    assert ctx.operation == "bad_command"
-    await session.close()
+    async with SessionManager() as manager:
+        session = await manager.create_session("sess-err", user="bob")
+        # Simulate a command that raises an error
+        with pytest.raises(RuntimeError):
+            await session.handle_command("bad_command")
+        ctx = session.get_error_context()
+        assert isinstance(ctx, ErrorContext)
+        assert ctx.operation == "bad_command"
+        await session.close()
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_stability.py
+++ b/tests/integration/test_stability.py
@@ -10,25 +10,25 @@ from mcp_server_git.session import SessionManager, SessionState
 @pytest.mark.asyncio
 async def test_long_running_session_lifecycle():
     """Test that a session remains active and then times out as expected."""
-    manager = SessionManager(idle_timeout=1.5, heartbeat_timeout=1.0)
-    session = await manager.create_session("longrun", user="eve")
-    assert session.state == SessionState.ACTIVE
-    # Wait for idle timeout to trigger
-    await asyncio.sleep(2.0)
-    assert session.state == SessionState.CLOSED
+    async with SessionManager(idle_timeout=1.5, heartbeat_timeout=1.0) as manager:
+        session = await manager.create_session("longrun", user="eve")
+        assert session.state == SessionState.ACTIVE
+        # Wait for idle timeout to trigger
+        await asyncio.sleep(2.0)
+        assert session.state == SessionState.CLOSED
 
 
 @pytest.mark.asyncio
 async def test_heartbeat_prevents_idle_timeout():
     """Test that heartbeats keep the session alive."""
-    manager = SessionManager(idle_timeout=2.0, heartbeat_timeout=1.0)
-    session = await manager.create_session("heartbeat", user="bob")
-    for _ in range(3):
-        await session.handle_heartbeat()
-        await asyncio.sleep(0.5)
-    # Should still be active
-    assert session.state == SessionState.ACTIVE
-    await session.close()
+    async with SessionManager(idle_timeout=2.0, heartbeat_timeout=1.0) as manager:
+        session = await manager.create_session("heartbeat", user="bob")
+        for _ in range(3):
+            await session.handle_heartbeat()
+            await asyncio.sleep(0.5)
+        # Should still be active
+        assert session.state == SessionState.ACTIVE
+        await session.close()
 
 
 @pytest.mark.asyncio
@@ -48,25 +48,25 @@ async def test_stress_many_notifications(sample_cancelled_notification):
 @pytest.mark.asyncio
 async def test_concurrent_sessions_and_notifications(sample_cancelled_notification):
     """Test concurrent session creation and notification interception."""
-    manager = SessionManager(idle_timeout=2.0, heartbeat_timeout=1.0)
-    interceptor = NotificationInterceptor()
-    raw_message = json.dumps(sample_cancelled_notification)
+    async with SessionManager(idle_timeout=2.0, heartbeat_timeout=1.0) as manager:
+        interceptor = NotificationInterceptor()
+        raw_message = json.dumps(sample_cancelled_notification)
 
-    async def create_and_run_session(sid):
-        session = await manager.create_session(sid)
-        await session.handle_heartbeat()
-        await asyncio.sleep(0.2)
-        await session.close()
+        async def create_and_run_session(sid):
+            session = await manager.create_session(sid)
+            await session.handle_heartbeat()
+            await asyncio.sleep(0.2)
+            await session.close()
 
-    async def send_notifications():
-        for _ in range(100):
-            await interceptor.preprocess_message(raw_message)
+        async def send_notifications():
+            for _ in range(100):
+                await interceptor.preprocess_message(raw_message)
 
-    tasks = [
-        asyncio.create_task(create_and_run_session(f"sess-{i}")) for i in range(10)
-    ] + [asyncio.create_task(send_notifications()) for _ in range(5)]
+        tasks = [
+            asyncio.create_task(create_and_run_session(f"sess-{i}")) for i in range(10)
+        ] + [asyncio.create_task(send_notifications()) for _ in range(5)]
 
-    await asyncio.gather(*tasks)
+        await asyncio.gather(*tasks)
 
 
 @pytest.mark.asyncio

--- a/tests/integration/transport/__init__.py
+++ b/tests/integration/transport/__init__.py
@@ -1,0 +1,1 @@
+"""Integration tests for HTTP transport module."""

--- a/tests/integration/transport/test_http_server.py
+++ b/tests/integration/transport/test_http_server.py
@@ -283,13 +283,21 @@ class TestMCPToolExecution:
         assert data["id"] == 1
         assert "error" not in data or data["error"] is None
 
-        # Result should contain tool information
+        # Result is in MCP content format
         result = data["result"]
-        assert "available_tools" in result or "tools" in result
+        assert "content" in result
+        assert len(result["content"]) > 0
+        assert result["content"][0]["type"] == "text"
+
+        # Parse the JSON text to get actual tool info
+        import json
+
+        tool_result = json.loads(result["content"][0]["text"])
+        assert "available_tools" in tool_result or "tools" in tool_result
 
     @pytest.mark.asyncio
     async def test_mcp_missing_session_header(self, async_client):
-        """Test POST /mcp without MCP-Session-Id header returns error."""
+        """Test POST /mcp without MCP-Session-Id header returns JSON-RPC error."""
         response = await async_client.post(
             "/mcp",
             json={
@@ -303,8 +311,13 @@ class TestMCPToolExecution:
             },
         )
 
-        # FastAPI should return 422 for missing required header
-        assert response.status_code == 422
+        # JSON-RPC error response (not HTTP error)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jsonrpc"] == "2.0"
+        assert "error" in data
+        assert data["error"]["code"] == -32000
+        assert "MCP-Session-Id" in data["error"]["message"]
 
     @pytest.mark.asyncio
     async def test_mcp_invalid_session(self, async_client):

--- a/tests/integration/transport/test_http_server.py
+++ b/tests/integration/transport/test_http_server.py
@@ -36,9 +36,7 @@ def temp_git_repo():
         repo_path.mkdir()
 
         # Initialize git repo
-        subprocess.run(
-            ["git", "init"], cwd=repo_path, check=True, capture_output=True
-        )
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],
             cwd=repo_path,
@@ -523,9 +521,7 @@ class TestConcurrentSessions:
                 binding_info = status_data["binding_info"]
                 # repository_path is inside binding object
                 binding = binding_info.get("binding", {})
-                assert repos[i][0].name in str(
-                    binding.get("repository_path", "")
-                )
+                assert repos[i][0].name in str(binding.get("repository_path", ""))
 
             # Execute tool in each session concurrently
             tool_tasks = [

--- a/tests/integration/transport/test_http_server.py
+++ b/tests/integration/transport/test_http_server.py
@@ -1,0 +1,607 @@
+"""
+Integration tests for HTTP Server.
+
+This module provides comprehensive integration tests for the HTTPGitServer class,
+testing the full HTTP transport layer including FastAPI routes, session management,
+and MCP tool execution.
+
+Test Strategy:
+- Uses httpx.AsyncClient with ASGITransport for async testing
+- Creates real temporary git repositories for realistic testing
+- Tests all HTTP endpoints and error conditions
+- Validates session isolation and concurrent access
+- Tests JSON-RPC 2.0 tool execution
+
+Critical for TDD Compliance:
+    These tests verify the complete HTTP transport implementation and must
+    pass to ensure MCP Git server can be used over HTTP.
+"""
+
+import asyncio
+import subprocess
+import tempfile
+from pathlib import Path
+
+import httpx
+import pytest
+
+from mcp_server_git.transport.http_server import HTTPGitServer
+
+
+@pytest.fixture
+def temp_git_repo():
+    """Create a temporary git repository with a remote."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        repo_path = Path(temp_dir) / "test_repo"
+        repo_path.mkdir()
+
+        # Initialize git repo
+        subprocess.run(
+            ["git", "init"], cwd=repo_path, check=True, capture_output=True
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
+
+        # Add remote
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
+
+        # Create initial commit
+        (repo_path / "README.md").write_text("# Test Repository")
+        subprocess.run(
+            ["git", "add", "README.md"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=repo_path,
+            check=True,
+            capture_output=True,
+        )
+
+        yield repo_path
+
+
+@pytest.fixture
+async def http_server():
+    """Create HTTP server instance for testing."""
+    server = HTTPGitServer(
+        host="127.0.0.1",
+        port=8765,
+        api_key=None,  # No API key for testing
+        session_timeout=60.0,  # Short timeout for testing
+    )
+    yield server
+    # Cleanup: close all sessions
+    session_ids = list(server.session_manager._sessions.keys())
+    for session_id in session_ids:
+        await server.session_manager.close_session(session_id)
+
+
+@pytest.fixture
+async def async_client(http_server):
+    """Create async HTTP client for testing."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=http_server.app),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+class TestHealthEndpoint:
+    """Test health check endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_health_endpoint(self, async_client):
+        """Test GET /health returns healthy status."""
+        response = await async_client.get("/health")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "healthy"
+        assert "active_sessions" in data
+        assert isinstance(data["active_sessions"], int)
+        assert data["active_sessions"] >= 0
+
+
+class TestSessionManagement:
+    """Test session lifecycle management endpoints."""
+
+    @pytest.mark.asyncio
+    async def test_create_session_success(self, async_client, temp_git_repo):
+        """Test POST /mcp/session/create with valid repository."""
+        response = await async_client.post(
+            "/mcp/session/create",
+            json={
+                "repository_path": str(temp_git_repo),
+                "expected_remote_url": "https://github.com/test/repo.git",
+            },
+        )
+
+        assert response.status_code == 201
+        data = response.json()
+        assert "session_id" in data
+        assert data["session_id"].startswith("mcp-")
+        assert data["status"] == "bound"
+        assert data["repository_path"] == str(temp_git_repo)
+
+    @pytest.mark.asyncio
+    async def test_create_session_invalid_repo(self, async_client):
+        """Test POST /mcp/session/create returns error for invalid repository."""
+        response = await async_client.post(
+            "/mcp/session/create",
+            json={
+                "repository_path": "/nonexistent/path",
+                "expected_remote_url": "https://github.com/test/repo.git",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "detail" in data
+        assert "Failed to create session" in data["detail"]
+
+    @pytest.mark.asyncio
+    async def test_create_session_remote_mismatch(self, async_client, temp_git_repo):
+        """Test POST /mcp/session/create returns error for remote URL mismatch."""
+        response = await async_client.post(
+            "/mcp/session/create",
+            json={
+                "repository_path": str(temp_git_repo),
+                "expected_remote_url": "https://github.com/wrong/repo.git",
+            },
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert "detail" in data
+
+    @pytest.mark.asyncio
+    async def test_get_session_status(self, async_client, temp_git_repo):
+        """Test GET /mcp/session/{id}/status returns session info."""
+        # First create a session
+        create_response = await async_client.post(
+            "/mcp/session/create",
+            json={
+                "repository_path": str(temp_git_repo),
+                "expected_remote_url": "https://github.com/test/repo.git",
+            },
+        )
+        assert create_response.status_code == 201
+        session_id = create_response.json()["session_id"]
+
+        # Get session status
+        response = await async_client.get(f"/mcp/session/{session_id}/status")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["session_id"] == session_id
+        assert "created_at" in data
+        assert "last_activity" in data
+        assert "age" in data
+        assert "idle_time" in data
+        assert "binding_info" in data
+        assert isinstance(data["age"], float)
+        assert isinstance(data["idle_time"], float)
+
+    @pytest.mark.asyncio
+    async def test_get_session_not_found(self, async_client):
+        """Test GET /mcp/session/{id}/status returns 404 for non-existent session."""
+        response = await async_client.get("/mcp/session/nonexistent-session/status")
+
+        assert response.status_code == 404
+        data = response.json()
+        assert "detail" in data
+        assert "Session not found" in data["detail"]
+
+    @pytest.mark.asyncio
+    async def test_close_session(self, async_client, temp_git_repo):
+        """Test DELETE /mcp/session/{id} closes session."""
+        # First create a session
+        create_response = await async_client.post(
+            "/mcp/session/create",
+            json={
+                "repository_path": str(temp_git_repo),
+                "expected_remote_url": "https://github.com/test/repo.git",
+            },
+        )
+        assert create_response.status_code == 201
+        session_id = create_response.json()["session_id"]
+
+        # Close the session
+        response = await async_client.delete(f"/mcp/session/{session_id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "closed"
+
+        # Verify session no longer exists
+        status_response = await async_client.get(f"/mcp/session/{session_id}/status")
+        assert status_response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_close_session_not_found(self, async_client):
+        """Test DELETE /mcp/session/{id} returns 404 for non-existent session."""
+        response = await async_client.delete("/mcp/session/nonexistent-session")
+
+        assert response.status_code == 404
+        data = response.json()
+        assert "detail" in data
+        assert "Session not found" in data["detail"]
+
+
+class TestMCPToolExecution:
+    """Test MCP tool execution via JSON-RPC 2.0."""
+
+    @pytest.mark.asyncio
+    async def test_mcp_tool_execution(self, async_client, temp_git_repo):
+        """Test POST /mcp executes discover_tools successfully."""
+        # Create a session first
+        create_response = await async_client.post(
+            "/mcp/session/create",
+            json={
+                "repository_path": str(temp_git_repo),
+                "expected_remote_url": "https://github.com/test/repo.git",
+            },
+        )
+        assert create_response.status_code == 201
+        session_id = create_response.json()["session_id"]
+
+        # Execute discover_tools via JSON-RPC
+        response = await async_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "discover_tools",
+                    "arguments": {"pattern": ""},
+                },
+                "id": 1,
+            },
+            headers={"MCP-Session-Id": session_id},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jsonrpc"] == "2.0"
+        assert "result" in data
+        assert data["id"] == 1
+        assert "error" not in data or data["error"] is None
+
+        # Result should contain tool information
+        result = data["result"]
+        assert "available_tools" in result or "tools" in result
+
+    @pytest.mark.asyncio
+    async def test_mcp_missing_session_header(self, async_client):
+        """Test POST /mcp without MCP-Session-Id header returns error."""
+        response = await async_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "discover_tools",
+                    "arguments": {},
+                },
+                "id": 1,
+            },
+        )
+
+        # FastAPI should return 422 for missing required header
+        assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_mcp_invalid_session(self, async_client):
+        """Test POST /mcp with invalid session returns error."""
+        response = await async_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "discover_tools",
+                    "arguments": {},
+                },
+                "id": 1,
+            },
+            headers={"MCP-Session-Id": "invalid-session"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jsonrpc"] == "2.0"
+        assert "error" in data
+        assert data["error"] is not None
+        assert data["id"] == 1
+
+    @pytest.mark.asyncio
+    async def test_mcp_invalid_jsonrpc_version(self, async_client, temp_git_repo):
+        """Test POST /mcp with invalid JSON-RPC version returns error."""
+        # Create a session first
+        create_response = await async_client.post(
+            "/mcp/session/create",
+            json={
+                "repository_path": str(temp_git_repo),
+                "expected_remote_url": "https://github.com/test/repo.git",
+            },
+        )
+        session_id = create_response.json()["session_id"]
+
+        response = await async_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "1.0",
+                "method": "tools/call",
+                "params": {
+                    "name": "discover_tools",
+                    "arguments": {},
+                },
+                "id": 1,
+            },
+            headers={"MCP-Session-Id": session_id},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jsonrpc"] == "2.0"
+        assert "error" in data
+        assert data["error"]["code"] == -32600
+
+    @pytest.mark.asyncio
+    async def test_mcp_invalid_method(self, async_client, temp_git_repo):
+        """Test POST /mcp with invalid method returns error."""
+        # Create a session first
+        create_response = await async_client.post(
+            "/mcp/session/create",
+            json={
+                "repository_path": str(temp_git_repo),
+                "expected_remote_url": "https://github.com/test/repo.git",
+            },
+        )
+        session_id = create_response.json()["session_id"]
+
+        response = await async_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "invalid/method",
+                "params": {},
+                "id": 1,
+            },
+            headers={"MCP-Session-Id": session_id},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jsonrpc"] == "2.0"
+        assert "error" in data
+        assert data["error"]["code"] == -32601
+
+    @pytest.mark.asyncio
+    async def test_mcp_missing_tool_name(self, async_client, temp_git_repo):
+        """Test POST /mcp without tool name returns error."""
+        # Create a session first
+        create_response = await async_client.post(
+            "/mcp/session/create",
+            json={
+                "repository_path": str(temp_git_repo),
+                "expected_remote_url": "https://github.com/test/repo.git",
+            },
+        )
+        session_id = create_response.json()["session_id"]
+
+        response = await async_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {
+                    "arguments": {},
+                },
+                "id": 1,
+            },
+            headers={"MCP-Session-Id": session_id},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jsonrpc"] == "2.0"
+        assert "error" in data
+        assert data["error"]["code"] == -32602
+
+
+class TestConcurrentSessions:
+    """Test concurrent session handling and isolation."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_sessions(self, async_client):
+        """Test creating multiple sessions and verifying isolation."""
+        # Create multiple temporary git repos
+        repos = []
+        for i in range(3):
+            temp_dir = tempfile.mkdtemp()
+            repo_path = Path(temp_dir) / "test_repo"
+            repo_path.mkdir()
+
+            # Initialize git repo
+            subprocess.run(
+                ["git", "init"], cwd=repo_path, check=True, capture_output=True
+            )
+            subprocess.run(
+                ["git", "config", "user.name", f"Test User {i}"],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.email", f"test{i}@example.com"],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                [
+                    "git",
+                    "remote",
+                    "add",
+                    "origin",
+                    f"https://github.com/test/repo{i}.git",
+                ],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+            )
+
+            # Create initial commit
+            (repo_path / "README.md").write_text(f"# Test Repository {i}")
+            subprocess.run(
+                ["git", "add", "README.md"],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+            )
+            subprocess.run(
+                ["git", "commit", "-m", f"Initial commit {i}"],
+                cwd=repo_path,
+                check=True,
+                capture_output=True,
+            )
+
+            repos.append((repo_path, f"https://github.com/test/repo{i}.git"))
+
+        try:
+            # Create sessions concurrently
+            session_tasks = [
+                async_client.post(
+                    "/mcp/session/create",
+                    json={
+                        "repository_path": str(repo_path),
+                        "expected_remote_url": remote_url,
+                    },
+                )
+                for repo_path, remote_url in repos
+            ]
+
+            responses = await asyncio.gather(*session_tasks)
+
+            # Verify all sessions created successfully
+            session_ids = []
+            for response in responses:
+                assert response.status_code == 201
+                data = response.json()
+                assert "session_id" in data
+                session_ids.append(data["session_id"])
+
+            # Verify session IDs are unique
+            assert len(session_ids) == len(set(session_ids))
+
+            # Verify each session has correct binding
+            for i, session_id in enumerate(session_ids):
+                status_response = await async_client.get(
+                    f"/mcp/session/{session_id}/status"
+                )
+                assert status_response.status_code == 200
+                status_data = status_response.json()
+                binding_info = status_data["binding_info"]
+                # repository_path is inside binding object
+                binding = binding_info.get("binding", {})
+                assert repos[i][0].name in str(
+                    binding.get("repository_path", "")
+                )
+
+            # Execute tool in each session concurrently
+            tool_tasks = [
+                async_client.post(
+                    "/mcp",
+                    json={
+                        "jsonrpc": "2.0",
+                        "method": "tools/call",
+                        "params": {
+                            "name": "discover_tools",
+                            "arguments": {"pattern": ""},
+                        },
+                        "id": i,
+                    },
+                    headers={"MCP-Session-Id": session_id},
+                )
+                for i, session_id in enumerate(session_ids)
+            ]
+
+            tool_responses = await asyncio.gather(*tool_tasks)
+
+            # Verify all tool executions succeeded
+            for response in tool_responses:
+                assert response.status_code == 200
+                data = response.json()
+                assert "result" in data
+
+            # Clean up sessions
+            close_tasks = [
+                async_client.delete(f"/mcp/session/{session_id}")
+                for session_id in session_ids
+            ]
+            await asyncio.gather(*close_tasks)
+
+        finally:
+            # Clean up temp directories
+            import shutil
+
+            for repo_path, _ in repos:
+                shutil.rmtree(repo_path.parent, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_session_isolation(self, async_client, temp_git_repo):
+        """Test that sessions are properly isolated from each other."""
+        # Create two sessions with same repo
+        create_tasks = [
+            async_client.post(
+                "/mcp/session/create",
+                json={
+                    "repository_path": str(temp_git_repo),
+                    "expected_remote_url": "https://github.com/test/repo.git",
+                },
+            )
+            for _ in range(2)
+        ]
+
+        responses = await asyncio.gather(*create_tasks)
+        session_ids = [resp.json()["session_id"] for resp in responses]
+
+        # Verify different session IDs
+        assert session_ids[0] != session_ids[1]
+
+        # Close one session
+        await async_client.delete(f"/mcp/session/{session_ids[0]}")
+
+        # Verify first session is gone
+        status_response1 = await async_client.get(
+            f"/mcp/session/{session_ids[0]}/status"
+        )
+        assert status_response1.status_code == 404
+
+        # Verify second session still exists
+        status_response2 = await async_client.get(
+            f"/mcp/session/{session_ids[1]}/status"
+        )
+        assert status_response2.status_code == 200
+
+        # Clean up
+        await async_client.delete(f"/mcp/session/{session_ids[1]}")

--- a/tests/unit/transport/__init__.py
+++ b/tests/unit/transport/__init__.py
@@ -1,0 +1,1 @@
+"""Unit tests for HTTP transport module."""

--- a/tests/unit/transport/test_http_session_manager.py
+++ b/tests/unit/transport/test_http_session_manager.py
@@ -1,0 +1,815 @@
+"""
+Unit tests for HTTP Session Manager.
+
+This module provides comprehensive unit tests for the HTTPSessionManager class,
+testing session lifecycle, repository isolation, contamination detection, and
+timeout handling.
+
+Critical for TDD Compliance:
+    These tests define the interface that HTTPSessionManager must implement.
+    DO NOT modify these tests to match implementation - the implementation
+    must satisfy these test requirements to prevent LLM compliance issues.
+"""
+
+import asyncio
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mcp_server_git.repository_binding import (
+    RemoteContaminationError,
+    RepositoryBinding,
+    RepositoryBindingError,
+    RepositoryBindingManager,
+)
+from mcp_server_git.transport.http_session_manager import (
+    HTTPSessionManager,
+    SessionContext,
+)
+
+
+class TestSessionContext:
+    """Test SessionContext dataclass."""
+
+    @pytest.mark.asyncio
+    async def test_session_context_initialization(self, temp_dir):
+        """Test SessionContext initializes with all required fields."""
+        # Create a mock binding manager
+        binding_manager = RepositoryBindingManager(server_name="test-session")
+
+        # Create mock services
+        from mcp_server_git.services.git_service import GitService
+        from mcp_server_git.services.github_service import GitHubService
+
+        git_service = GitService()
+        github_service = GitHubService()
+
+        # Create session context
+        current_time = time.time()
+        context = SessionContext(
+            session_id="mcp-test123",
+            binding_manager=binding_manager,
+            repository_binding=None,
+            created_at=current_time,
+            last_activity=current_time,
+            git_service=git_service,
+            github_service=github_service,
+        )
+
+        # Verify basic fields
+        assert context.session_id == "mcp-test123"
+        assert context.binding_manager is binding_manager
+        assert context.repository_binding is None
+        assert context.created_at == current_time
+        assert context.last_activity == current_time
+        assert context.git_service is git_service
+        assert context.github_service is github_service
+
+        # Verify lean interface was initialized
+        assert context.lean_interface is not None
+        assert context.lean_interface.app_name == "mcp-git-session-mcp-test123"
+
+    @pytest.mark.asyncio
+    async def test_session_context_with_binding(self, temp_dir):
+        """Test SessionContext with repository binding."""
+        repo_path = temp_dir / "test_repo"
+        repo_path.mkdir()
+
+        # Initialize git repo
+        import subprocess
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        # Create binding
+        binding = RepositoryBinding(
+            repository_path=repo_path,
+            expected_remote_url="https://github.com/test/repo.git",
+        )
+
+        # Create services
+        from mcp_server_git.services.git_service import GitService
+        from mcp_server_git.services.github_service import GitHubService
+
+        binding_manager = RepositoryBindingManager(server_name="test-session")
+        context = SessionContext(
+            session_id="mcp-test456",
+            binding_manager=binding_manager,
+            repository_binding=binding,
+            created_at=time.time(),
+            last_activity=time.time(),
+            git_service=GitService(),
+            github_service=GitHubService(),
+        )
+
+        assert context.repository_binding is binding
+        assert context.repository_binding.repository_path == repo_path
+        assert context.repository_binding.expected_remote_url == "https://github.com/test/repo.git"
+
+
+class TestHTTPSessionManager:
+    """Test HTTPSessionManager functionality."""
+
+    @pytest.mark.asyncio
+    async def test_create_session_success(self, temp_dir):
+        """Test creating session with valid repository."""
+        # Create and initialize git repo
+        repo_path = temp_dir / "test_repo"
+        repo_path.mkdir()
+
+        import subprocess
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        # Create session manager
+        manager = HTTPSessionManager(session_timeout=3600.0)
+
+        # Create session
+        session = await manager.create_session(
+            repo_path=repo_path,
+            expected_remote_url="https://github.com/test/repo.git",
+        )
+
+        # Verify session created
+        assert session.session_id.startswith("mcp-")
+        assert session.repository_binding is not None
+        assert session.repository_binding.repository_path == repo_path.resolve()
+        assert session.repository_binding.expected_remote_url == "https://github.com/test/repo.git"
+        assert session.git_service is not None
+        assert session.github_service is not None
+        assert session.lean_interface is not None
+
+    @pytest.mark.asyncio
+    async def test_create_session_invalid_repo(self, temp_dir):
+        """Test creating session with non-existent repository raises error."""
+        repo_path = temp_dir / "nonexistent"
+
+        manager = HTTPSessionManager()
+
+        with pytest.raises(RepositoryBindingError, match="does not exist"):
+            await manager.create_session(
+                repo_path=repo_path,
+                expected_remote_url="https://github.com/test/repo.git",
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_session_invalid_git_repo(self, temp_dir):
+        """Test creating session with invalid git repository raises error."""
+        repo_path = temp_dir / "not_a_git_repo"
+        repo_path.mkdir()
+
+        manager = HTTPSessionManager()
+
+        with pytest.raises(RepositoryBindingError, match="Invalid git repository"):
+            await manager.create_session(
+                repo_path=repo_path,
+                expected_remote_url="https://github.com/test/repo.git",
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_session_remote_mismatch(self, temp_dir):
+        """Test creating session with mismatched remote URL raises error."""
+        repo_path = temp_dir / "test_repo"
+        repo_path.mkdir()
+
+        import subprocess
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/wrong/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        manager = HTTPSessionManager()
+
+        with pytest.raises(RemoteContaminationError, match="Remote URL mismatch"):
+            await manager.create_session(
+                repo_path=repo_path,
+                expected_remote_url="https://github.com/expected/repo.git",
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_session_updates_activity(self, temp_dir):
+        """Test getting session updates last_activity timestamp."""
+        # Create and initialize git repo
+        repo_path = temp_dir / "test_repo"
+        repo_path.mkdir()
+
+        import subprocess
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        manager = HTTPSessionManager()
+        session = await manager.create_session(
+            repo_path=repo_path,
+            expected_remote_url="https://github.com/test/repo.git",
+        )
+
+        # Get initial activity time
+        initial_activity = session.last_activity
+
+        # Wait a bit to ensure timestamp difference
+        await asyncio.sleep(0.1)
+
+        # Get session again
+        retrieved_session = await manager.get_session(session.session_id)
+
+        # Verify last_activity was updated
+        assert retrieved_session is not None
+        assert retrieved_session.last_activity > initial_activity
+        assert retrieved_session.session_id == session.session_id
+
+    @pytest.mark.asyncio
+    async def test_get_session_not_found(self):
+        """Test getting non-existent session returns None."""
+        manager = HTTPSessionManager()
+
+        session = await manager.get_session("mcp-nonexistent")
+
+        assert session is None
+
+    @pytest.mark.asyncio
+    async def test_close_session_success(self, temp_dir):
+        """Test closing existing session removes it."""
+        # Create and initialize git repo
+        repo_path = temp_dir / "test_repo"
+        repo_path.mkdir()
+
+        import subprocess
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        manager = HTTPSessionManager()
+        session = await manager.create_session(
+            repo_path=repo_path,
+            expected_remote_url="https://github.com/test/repo.git",
+        )
+
+        # Verify session exists
+        assert await manager.get_session(session.session_id) is not None
+
+        # Close session
+        result = await manager.close_session(session.session_id)
+
+        # Verify session was closed
+        assert result is True
+        assert await manager.get_session(session.session_id) is None
+
+    @pytest.mark.asyncio
+    async def test_close_session_not_found(self):
+        """Test closing non-existent session returns False."""
+        manager = HTTPSessionManager()
+
+        result = await manager.close_session("mcp-nonexistent")
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_session_isolation(self, temp_dir):
+        """Test two sessions get independent service instances."""
+        # Create two git repos
+        repo1_path = temp_dir / "repo1"
+        repo2_path = temp_dir / "repo2"
+        repo1_path.mkdir()
+        repo2_path.mkdir()
+
+        import subprocess
+
+        # Initialize repo1
+        subprocess.run(["git", "init"], cwd=repo1_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo1_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo1_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo1.git"],
+            cwd=repo1_path,
+            check=True,
+        )
+
+        # Initialize repo2
+        subprocess.run(["git", "init"], cwd=repo2_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo2_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo2_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo2.git"],
+            cwd=repo2_path,
+            check=True,
+        )
+
+        manager = HTTPSessionManager()
+
+        # Create two sessions
+        session1 = await manager.create_session(
+            repo_path=repo1_path,
+            expected_remote_url="https://github.com/test/repo1.git",
+        )
+        session2 = await manager.create_session(
+            repo_path=repo2_path,
+            expected_remote_url="https://github.com/test/repo2.git",
+        )
+
+        # Verify sessions are different
+        assert session1.session_id != session2.session_id
+
+        # Verify service instances are different
+        assert session1.git_service is not session2.git_service
+        assert session1.github_service is not session2.github_service
+        assert session1.binding_manager is not session2.binding_manager
+        assert session1.lean_interface is not session2.lean_interface
+
+        # Verify bindings are different
+        assert session1.repository_binding.repository_path == repo1_path.resolve()
+        assert session2.repository_binding.repository_path == repo2_path.resolve()
+        assert session1.repository_binding.expected_remote_url == "https://github.com/test/repo1.git"
+        assert session2.repository_binding.expected_remote_url == "https://github.com/test/repo2.git"
+
+    @pytest.mark.asyncio
+    async def test_cleanup_expired_sessions(self, temp_dir):
+        """Test sessions older than timeout are cleaned up."""
+        # Create git repo
+        repo_path = temp_dir / "test_repo"
+        repo_path.mkdir()
+
+        import subprocess
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        # Create manager with short timeout
+        manager = HTTPSessionManager(session_timeout=0.2)
+
+        # Create session
+        session = await manager.create_session(
+            repo_path=repo_path,
+            expected_remote_url="https://github.com/test/repo.git",
+        )
+
+        # Verify session exists
+        assert await manager.get_session(session.session_id) is not None
+
+        # Wait for timeout
+        await asyncio.sleep(0.3)
+
+        # Cleanup expired sessions
+        cleaned_count = await manager.cleanup_expired_sessions()
+
+        # Verify session was cleaned up
+        assert cleaned_count == 1
+        assert await manager.get_session(session.session_id) is None
+
+    @pytest.mark.asyncio
+    async def test_cleanup_does_not_remove_active_sessions(self, temp_dir):
+        """Test cleanup does not remove sessions within timeout."""
+        # Create git repo
+        repo_path = temp_dir / "test_repo"
+        repo_path.mkdir()
+
+        import subprocess
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        # Create manager with longer timeout
+        manager = HTTPSessionManager(session_timeout=60.0)
+
+        # Create session
+        session = await manager.create_session(
+            repo_path=repo_path,
+            expected_remote_url="https://github.com/test/repo.git",
+        )
+
+        # Wait briefly but less than timeout
+        await asyncio.sleep(0.1)
+
+        # Cleanup
+        cleaned_count = await manager.cleanup_expired_sessions()
+
+        # Verify session was NOT cleaned up
+        assert cleaned_count == 0
+        assert await manager.get_session(session.session_id) is not None
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_validates_binding(self, temp_dir):
+        """Test tool execution validates binding integrity."""
+        # Create git repo
+        repo_path = temp_dir / "test_repo"
+        repo_path.mkdir()
+
+        import subprocess
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        manager = HTTPSessionManager()
+        session = await manager.create_session(
+            repo_path=repo_path,
+            expected_remote_url="https://github.com/test/repo.git",
+        )
+
+        # Mock the lean interface's execute_tool_direct to avoid actual execution
+        session.lean_interface.execute_tool_direct = AsyncMock(return_value={"result": "success"})
+
+        # Execute tool
+        result = await manager.execute_tool(
+            session_id=session.session_id,
+            tool_name="git_status",
+            args={"repo_path": str(repo_path)},
+        )
+
+        # Verify tool was executed
+        assert result == {"result": "success"}
+        session.lean_interface.execute_tool_direct.assert_called_once_with(
+            "git_status",
+            {"repo_path": str(repo_path)},
+        )
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_session_not_found(self):
+        """Test tool execution with non-existent session raises error."""
+        manager = HTTPSessionManager()
+
+        with pytest.raises(ValueError, match="Session not found"):
+            await manager.execute_tool(
+                session_id="mcp-nonexistent",
+                tool_name="git_status",
+                args={},
+            )
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_detects_binding_corruption(self, temp_dir):
+        """Test tool execution detects binding corruption."""
+        # Create git repo
+        repo_path = temp_dir / "test_repo"
+        repo_path.mkdir()
+
+        import subprocess
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        manager = HTTPSessionManager()
+        session = await manager.create_session(
+            repo_path=repo_path,
+            expected_remote_url="https://github.com/test/repo.git",
+        )
+
+        # Mock verify_integrity at the class level to simulate corruption
+        with patch.object(RepositoryBinding, 'verify_integrity', return_value=False):
+            with pytest.raises(ValueError, match="binding corrupted"):
+                await manager.execute_tool(
+                    session_id=session.session_id,
+                    tool_name="git_status",
+                    args={},
+                )
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_detects_remote_contamination(self, temp_dir):
+        """Test tool execution detects remote contamination."""
+        # Create git repo
+        repo_path = temp_dir / "test_repo"
+        repo_path.mkdir()
+
+        import subprocess
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        manager = HTTPSessionManager()
+        session = await manager.create_session(
+            repo_path=repo_path,
+            expected_remote_url="https://github.com/test/repo.git",
+        )
+
+        # Change the remote URL to simulate contamination
+        subprocess.run(
+            ["git", "remote", "set-url", "origin", "https://github.com/contaminated/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        # Try to execute tool
+        with pytest.raises(RemoteContaminationError, match="Remote contamination detected"):
+            await manager.execute_tool(
+                session_id=session.session_id,
+                tool_name="git_status",
+                args={"repo_path": str(repo_path)},
+            )
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_validates_operation_path(self, temp_dir):
+        """Test tool execution validates operation path against binding."""
+        # Create git repo
+        repo_path = temp_dir / "test_repo"
+        repo_path.mkdir()
+
+        import subprocess
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        # Create another directory outside the repo
+        other_path = temp_dir / "other_repo"
+        other_path.mkdir()
+
+        manager = HTTPSessionManager()
+        session = await manager.create_session(
+            repo_path=repo_path,
+            expected_remote_url="https://github.com/test/repo.git",
+        )
+
+        # Try to execute tool with path outside bound repository
+        with pytest.raises(RepositoryBindingError, match="outside bound repository"):
+            await manager.execute_tool(
+                session_id=session.session_id,
+                tool_name="git_status",
+                args={"repo_path": str(other_path)},
+            )
+
+    @pytest.mark.asyncio
+    async def test_get_session_info(self, temp_dir):
+        """Test getting session information."""
+        # Create git repo
+        repo_path = temp_dir / "test_repo"
+        repo_path.mkdir()
+
+        import subprocess
+        subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+            cwd=repo_path,
+            check=True,
+        )
+
+        manager = HTTPSessionManager()
+        session = await manager.create_session(
+            repo_path=repo_path,
+            expected_remote_url="https://github.com/test/repo.git",
+        )
+
+        # Get session info
+        info = await manager.get_session_info(session.session_id)
+
+        # Verify info structure
+        assert info is not None
+        assert info["session_id"] == session.session_id
+        assert "created_at" in info
+        assert "last_activity" in info
+        assert "age" in info
+        assert "idle_time" in info
+        assert "binding_info" in info
+        assert info["age"] >= 0
+        assert info["idle_time"] >= 0
+
+    @pytest.mark.asyncio
+    async def test_get_session_info_not_found(self):
+        """Test getting info for non-existent session returns None."""
+        manager = HTTPSessionManager()
+
+        info = await manager.get_session_info("mcp-nonexistent")
+
+        assert info is None
+
+    @pytest.mark.asyncio
+    async def test_get_all_sessions_info(self, temp_dir):
+        """Test getting information for all active sessions."""
+        # Create two git repos
+        repo1_path = temp_dir / "repo1"
+        repo2_path = temp_dir / "repo2"
+        repo1_path.mkdir()
+        repo2_path.mkdir()
+
+        import subprocess
+
+        # Initialize repo1
+        subprocess.run(["git", "init"], cwd=repo1_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo1_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo1_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo1.git"],
+            cwd=repo1_path,
+            check=True,
+        )
+
+        # Initialize repo2
+        subprocess.run(["git", "init"], cwd=repo2_path, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.name", "Test User"],
+            cwd=repo2_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.email", "test@example.com"],
+            cwd=repo2_path,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", "https://github.com/test/repo2.git"],
+            cwd=repo2_path,
+            check=True,
+        )
+
+        manager = HTTPSessionManager()
+
+        # Create two sessions
+        session1 = await manager.create_session(
+            repo_path=repo1_path,
+            expected_remote_url="https://github.com/test/repo1.git",
+        )
+        session2 = await manager.create_session(
+            repo_path=repo2_path,
+            expected_remote_url="https://github.com/test/repo2.git",
+        )
+
+        # Get all sessions info
+        all_info = await manager.get_all_sessions_info()
+
+        # Verify info for both sessions
+        assert len(all_info) == 2
+        session_ids = {info["session_id"] for info in all_info}
+        assert session1.session_id in session_ids
+        assert session2.session_id in session_ids
+
+        for info in all_info:
+            assert "created_at" in info
+            assert "last_activity" in info
+            assert "age" in info
+            assert "idle_time" in info
+            assert "binding_info" in info

--- a/tests/unit/transport/test_http_session_manager.py
+++ b/tests/unit/transport/test_http_session_manager.py
@@ -79,6 +79,7 @@ class TestSessionContext:
 
         # Initialize git repo
         import subprocess
+
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],
@@ -119,7 +120,10 @@ class TestSessionContext:
 
         assert context.repository_binding is binding
         assert context.repository_binding.repository_path == repo_path
-        assert context.repository_binding.expected_remote_url == "https://github.com/test/repo.git"
+        assert (
+            context.repository_binding.expected_remote_url
+            == "https://github.com/test/repo.git"
+        )
 
 
 class TestHTTPSessionManager:
@@ -133,6 +137,7 @@ class TestHTTPSessionManager:
         repo_path.mkdir()
 
         import subprocess
+
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],
@@ -163,7 +168,10 @@ class TestHTTPSessionManager:
         assert session.session_id.startswith("mcp-")
         assert session.repository_binding is not None
         assert session.repository_binding.repository_path == repo_path.resolve()
-        assert session.repository_binding.expected_remote_url == "https://github.com/test/repo.git"
+        assert (
+            session.repository_binding.expected_remote_url
+            == "https://github.com/test/repo.git"
+        )
         assert session.git_service is not None
         assert session.github_service is not None
         assert session.lean_interface is not None
@@ -202,6 +210,7 @@ class TestHTTPSessionManager:
         repo_path.mkdir()
 
         import subprocess
+
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],
@@ -235,6 +244,7 @@ class TestHTTPSessionManager:
         repo_path.mkdir()
 
         import subprocess
+
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],
@@ -289,6 +299,7 @@ class TestHTTPSessionManager:
         repo_path.mkdir()
 
         import subprocess
+
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],
@@ -402,8 +413,14 @@ class TestHTTPSessionManager:
         # Verify bindings are different
         assert session1.repository_binding.repository_path == repo1_path.resolve()
         assert session2.repository_binding.repository_path == repo2_path.resolve()
-        assert session1.repository_binding.expected_remote_url == "https://github.com/test/repo1.git"
-        assert session2.repository_binding.expected_remote_url == "https://github.com/test/repo2.git"
+        assert (
+            session1.repository_binding.expected_remote_url
+            == "https://github.com/test/repo1.git"
+        )
+        assert (
+            session2.repository_binding.expected_remote_url
+            == "https://github.com/test/repo2.git"
+        )
 
     @pytest.mark.asyncio
     async def test_cleanup_expired_sessions(self, temp_dir):
@@ -413,6 +430,7 @@ class TestHTTPSessionManager:
         repo_path.mkdir()
 
         import subprocess
+
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],
@@ -460,6 +478,7 @@ class TestHTTPSessionManager:
         repo_path.mkdir()
 
         import subprocess
+
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],
@@ -504,6 +523,7 @@ class TestHTTPSessionManager:
         repo_path.mkdir()
 
         import subprocess
+
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],
@@ -528,7 +548,9 @@ class TestHTTPSessionManager:
         )
 
         # Mock the lean interface's execute_tool_direct to avoid actual execution
-        session.lean_interface.execute_tool_direct = AsyncMock(return_value={"result": "success"})
+        session.lean_interface.execute_tool_direct = AsyncMock(
+            return_value={"result": "success"}
+        )
 
         # Execute tool
         result = await manager.execute_tool(
@@ -564,6 +586,7 @@ class TestHTTPSessionManager:
         repo_path.mkdir()
 
         import subprocess
+
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],
@@ -588,7 +611,7 @@ class TestHTTPSessionManager:
         )
 
         # Mock verify_integrity at the class level to simulate corruption
-        with patch.object(RepositoryBinding, 'verify_integrity', return_value=False):
+        with patch.object(RepositoryBinding, "verify_integrity", return_value=False):
             with pytest.raises(ValueError, match="binding corrupted"):
                 await manager.execute_tool(
                     session_id=session.session_id,
@@ -604,6 +627,7 @@ class TestHTTPSessionManager:
         repo_path.mkdir()
 
         import subprocess
+
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],
@@ -629,13 +653,21 @@ class TestHTTPSessionManager:
 
         # Change the remote URL to simulate contamination
         subprocess.run(
-            ["git", "remote", "set-url", "origin", "https://github.com/contaminated/repo.git"],
+            [
+                "git",
+                "remote",
+                "set-url",
+                "origin",
+                "https://github.com/contaminated/repo.git",
+            ],
             cwd=repo_path,
             check=True,
         )
 
         # Try to execute tool
-        with pytest.raises(RemoteContaminationError, match="Remote contamination detected"):
+        with pytest.raises(
+            RemoteContaminationError, match="Remote contamination detected"
+        ):
             await manager.execute_tool(
                 session_id=session.session_id,
                 tool_name="git_status",
@@ -650,6 +682,7 @@ class TestHTTPSessionManager:
         repo_path.mkdir()
 
         import subprocess
+
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],
@@ -693,6 +726,7 @@ class TestHTTPSessionManager:
         repo_path.mkdir()
 
         import subprocess
+
         subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
         subprocess.run(
             ["git", "config", "user.name", "Test User"],

--- a/tests/unit/transport/test_security.py
+++ b/tests/unit/transport/test_security.py
@@ -103,6 +103,7 @@ class TestLocalhostOnlyMiddleware:
         # Mock call_next to return a success response
         async def mock_call_next(request):
             from starlette.responses import JSONResponse
+
             return JSONResponse({"message": "success"})
 
         response = await middleware.dispatch(mock_request, mock_call_next)
@@ -132,7 +133,10 @@ class TestLocalhostOnlyMiddleware:
 
         # Verify the response
         assert response.status_code == 403
-        assert response.body == b'{"error":"Forbidden","message":"Access restricted to localhost only"}'
+        assert (
+            response.body
+            == b'{"error":"Forbidden","message":"Access restricted to localhost only"}'
+        )
 
         # Verify call_next was not called
         call_next.assert_not_called()
@@ -161,7 +165,7 @@ class TestLocalhostOnlyMiddleware:
         assert "application/json" in response.headers.get("content-type", "")
 
         # Verify JSON structure
-        body = json.loads(response.body.decode('utf-8'))
+        body = json.loads(response.body.decode("utf-8"))
         assert "error" in body
         assert "message" in body
         assert body["error"] == "Forbidden"
@@ -187,18 +191,14 @@ class TestAPIKeyMiddleware:
     def test_valid_key_allowed(self, with_key_client):
         """Test that requests with correct X-API-Key header are allowed."""
         response = with_key_client.get(
-            "/test",
-            headers={"X-API-Key": "test-secret-key"}
+            "/test", headers={"X-API-Key": "test-secret-key"}
         )
         assert response.status_code == 200
         assert response.json() == {"message": "success"}
 
     def test_invalid_key_rejected(self, with_key_client):
         """Test that requests with wrong API key are rejected with 401."""
-        response = with_key_client.get(
-            "/test",
-            headers={"X-API-Key": "wrong-key"}
-        )
+        response = with_key_client.get("/test", headers={"X-API-Key": "wrong-key"})
         assert response.status_code == 401
 
         body = response.json()
@@ -226,10 +226,7 @@ class TestAPIKeyMiddleware:
         assert "message" in body
 
         # Test invalid key response
-        response = with_key_client.get(
-            "/test",
-            headers={"X-API-Key": "invalid"}
-        )
+        response = with_key_client.get("/test", headers={"X-API-Key": "invalid"})
         assert response.status_code == 401
         assert "application/json" in response.headers.get("content-type", "")
 

--- a/tests/unit/transport/test_security.py
+++ b/tests/unit/transport/test_security.py
@@ -1,0 +1,326 @@
+"""Unit tests for security middleware.
+
+Tests the LocalhostOnlyMiddleware and APIKeyMiddleware components
+used to secure the HTTP transport layer.
+"""
+
+import pytest
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from mcp_server_git.transport.security import (
+    APIKeyMiddleware,
+    LocalhostOnlyMiddleware,
+)
+
+
+# Test fixtures for LocalhostOnlyMiddleware
+@pytest.fixture
+def localhost_app():
+    """Create a simple FastAPI app with LocalhostOnlyMiddleware."""
+    app = FastAPI()
+    app.add_middleware(LocalhostOnlyMiddleware)
+
+    @app.get("/test")
+    async def test_endpoint():
+        return {"message": "success"}
+
+    return app
+
+
+@pytest.fixture
+def localhost_client(localhost_app):
+    """Create a test client for the localhost-only app."""
+    return TestClient(localhost_app)
+
+
+# Test fixtures for APIKeyMiddleware
+@pytest.fixture
+def no_key_app():
+    """Create a FastAPI app with APIKeyMiddleware but no key required."""
+    app = FastAPI()
+    app.add_middleware(APIKeyMiddleware, api_key=None)
+
+    @app.get("/test")
+    async def test_endpoint():
+        return {"message": "success"}
+
+    return app
+
+
+@pytest.fixture
+def with_key_app():
+    """Create a FastAPI app with APIKeyMiddleware requiring a key."""
+    app = FastAPI()
+    app.add_middleware(APIKeyMiddleware, api_key="test-secret-key")
+
+    @app.get("/test")
+    async def test_endpoint():
+        return {"message": "success"}
+
+    return app
+
+
+@pytest.fixture
+def no_key_client(no_key_app):
+    """Create a test client for the app with no key required."""
+    return TestClient(no_key_app)
+
+
+@pytest.fixture
+def with_key_client(with_key_app):
+    """Create a test client for the app requiring an API key."""
+    return TestClient(with_key_app)
+
+
+# LocalhostOnlyMiddleware Tests
+class TestLocalhostOnlyMiddleware:
+    """Tests for LocalhostOnlyMiddleware."""
+
+    def test_localhost_ipv4_allowed(self, localhost_client):
+        """Test that localhost IPv4 (127.0.0.1) requests are allowed."""
+        # TestClient by default uses testclient as the host,
+        # but we can override via base_url
+        response = localhost_client.get("/test")
+        assert response.status_code == 200
+        assert response.json() == {"message": "success"}
+
+    @pytest.mark.asyncio
+    async def test_localhost_ipv6_allowed(self, localhost_app):
+        """Test that localhost IPv6 (::1) requests are allowed."""
+        # Use mocking approach to simulate IPv6 client
+        from unittest.mock import AsyncMock, MagicMock
+        from starlette.requests import Request
+
+        middleware = LocalhostOnlyMiddleware(localhost_app)
+
+        # Create a mock request with IPv6 localhost
+        mock_request = MagicMock(spec=Request)
+        mock_request.client = MagicMock()
+        mock_request.client.host = "::1"
+        mock_request.url.path = "/test"
+
+        # Mock call_next to return a success response
+        async def mock_call_next(request):
+            from starlette.responses import JSONResponse
+            return JSONResponse({"message": "success"})
+
+        response = await middleware.dispatch(mock_request, mock_call_next)
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_external_ip_blocked(self, localhost_app):
+        """Test that external IP addresses are blocked with 403."""
+        # We need to create a test scenario where request.client.host
+        # is set to an external IP. We'll use a custom test setup.
+        from unittest.mock import AsyncMock, MagicMock
+        from starlette.requests import Request
+        from starlette.responses import Response
+
+        middleware = LocalhostOnlyMiddleware(localhost_app)
+
+        # Create a mock request with external IP
+        mock_request = MagicMock(spec=Request)
+        mock_request.client = MagicMock()
+        mock_request.client.host = "192.168.1.100"
+        mock_request.url.path = "/test"
+
+        # Mock call_next (should not be called for blocked requests)
+        call_next = AsyncMock()
+
+        response = await middleware.dispatch(mock_request, call_next)
+
+        # Verify the response
+        assert response.status_code == 403
+        assert response.body == b'{"error":"Forbidden","message":"Access restricted to localhost only"}'
+
+        # Verify call_next was not called
+        call_next.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_blocked_response_is_json(self, localhost_app):
+        """Test that blocked requests receive a valid JSON response."""
+        from unittest.mock import AsyncMock, MagicMock
+        from starlette.requests import Request
+        import json
+
+        middleware = LocalhostOnlyMiddleware(localhost_app)
+
+        # Create a mock request with external IP
+        mock_request = MagicMock(spec=Request)
+        mock_request.client = MagicMock()
+        mock_request.client.host = "10.0.0.1"
+        mock_request.url.path = "/test"
+
+        call_next = AsyncMock()
+
+        response = await middleware.dispatch(mock_request, call_next)
+
+        # Verify response is JSON
+        assert response.status_code == 403
+        assert "application/json" in response.headers.get("content-type", "")
+
+        # Verify JSON structure
+        body = json.loads(response.body.decode('utf-8'))
+        assert "error" in body
+        assert "message" in body
+        assert body["error"] == "Forbidden"
+        assert "localhost only" in body["message"]
+
+
+# APIKeyMiddleware Tests
+class TestAPIKeyMiddleware:
+    """Tests for APIKeyMiddleware."""
+
+    def test_no_key_required_allows_all(self, no_key_client):
+        """Test that when api_key=None, all requests are allowed."""
+        # Request without any API key header
+        response = no_key_client.get("/test")
+        assert response.status_code == 200
+        assert response.json() == {"message": "success"}
+
+        # Request with an arbitrary header (should still work)
+        response = no_key_client.get("/test", headers={"X-API-Key": "anything"})
+        assert response.status_code == 200
+        assert response.json() == {"message": "success"}
+
+    def test_valid_key_allowed(self, with_key_client):
+        """Test that requests with correct X-API-Key header are allowed."""
+        response = with_key_client.get(
+            "/test",
+            headers={"X-API-Key": "test-secret-key"}
+        )
+        assert response.status_code == 200
+        assert response.json() == {"message": "success"}
+
+    def test_invalid_key_rejected(self, with_key_client):
+        """Test that requests with wrong API key are rejected with 401."""
+        response = with_key_client.get(
+            "/test",
+            headers={"X-API-Key": "wrong-key"}
+        )
+        assert response.status_code == 401
+
+        body = response.json()
+        assert body["error"] == "Unauthorized"
+        assert "Invalid API key" in body["message"]
+
+    def test_missing_key_rejected(self, with_key_client):
+        """Test that requests missing X-API-Key header are rejected when key required."""
+        response = with_key_client.get("/test")
+        assert response.status_code == 401
+
+        body = response.json()
+        assert body["error"] == "Unauthorized"
+        assert "X-API-Key header required" in body["message"]
+
+    def test_unauthorized_response_is_json(self, with_key_client):
+        """Test that unauthorized responses are valid JSON."""
+        # Test missing key response
+        response = with_key_client.get("/test")
+        assert response.status_code == 401
+        assert "application/json" in response.headers.get("content-type", "")
+
+        body = response.json()
+        assert "error" in body
+        assert "message" in body
+
+        # Test invalid key response
+        response = with_key_client.get(
+            "/test",
+            headers={"X-API-Key": "invalid"}
+        )
+        assert response.status_code == 401
+        assert "application/json" in response.headers.get("content-type", "")
+
+        body = response.json()
+        assert "error" in body
+        assert "message" in body
+
+
+# Additional integration-style tests
+class TestMiddlewareCombination:
+    """Tests for middleware combinations."""
+
+    def test_both_middlewares_together(self):
+        """Test that both middlewares can work together."""
+        app = FastAPI()
+        # Apply both middlewares (order matters: outermost first)
+        app.add_middleware(APIKeyMiddleware, api_key="secret")
+        app.add_middleware(LocalhostOnlyMiddleware)
+
+        @app.get("/test")
+        async def test_endpoint():
+            return {"message": "success"}
+
+        client = TestClient(app)
+
+        # Request with valid API key should succeed
+        response = client.get("/test", headers={"X-API-Key": "secret"})
+        assert response.status_code == 200
+
+        # Request without API key should fail
+        response = client.get("/test")
+        assert response.status_code == 401
+
+    def test_middleware_init_logging(self, caplog):
+        """Test that middleware initialization logs appropriately."""
+        import logging
+
+        # Test APIKeyMiddleware with key
+        app = FastAPI()
+        with caplog.at_level(logging.INFO):
+            middleware = APIKeyMiddleware(app, api_key="test-key")
+            assert "API key authentication enabled" in caplog.text
+
+        caplog.clear()
+
+        # Test APIKeyMiddleware without key
+        app2 = FastAPI()
+        with caplog.at_level(logging.INFO):
+            middleware2 = APIKeyMiddleware(app2, api_key=None)
+            assert "API key authentication disabled" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_middleware_warning_logging(self, caplog):
+        """Test that middleware logs warnings for blocked requests."""
+        import logging
+        from unittest.mock import AsyncMock, MagicMock
+        from starlette.requests import Request
+
+        app = FastAPI()
+
+        # Test LocalhostOnlyMiddleware warning
+        middleware = LocalhostOnlyMiddleware(app)
+        mock_request = MagicMock(spec=Request)
+        mock_request.client = MagicMock()
+        mock_request.client.host = "192.168.1.1"
+        mock_request.url.path = "/test"
+
+        with caplog.at_level(logging.WARNING):
+            await middleware.dispatch(mock_request, AsyncMock())
+            assert "Blocked non-localhost request" in caplog.text
+            assert "192.168.1.1" in caplog.text
+
+        caplog.clear()
+
+        # Test APIKeyMiddleware warning for missing key
+        api_middleware = APIKeyMiddleware(app, api_key="secret")
+        mock_request2 = MagicMock(spec=Request)
+        mock_request2.headers.get.return_value = None
+        mock_request2.url.path = "/api/test"
+
+        with caplog.at_level(logging.WARNING):
+            await api_middleware.dispatch(mock_request2, AsyncMock())
+            assert "missing X-API-Key header" in caplog.text
+
+        caplog.clear()
+
+        # Test APIKeyMiddleware warning for invalid key
+        mock_request3 = MagicMock(spec=Request)
+        mock_request3.headers.get.return_value = "wrong-key"
+        mock_request3.url.path = "/api/test"
+
+        with caplog.at_level(logging.WARNING):
+            await api_middleware.dispatch(mock_request3, AsyncMock())
+            assert "invalid API key" in caplog.text


### PR DESCRIPTION
## Summary

- Add HTTP transport layer for shared MCP server instances
- Implement full MCP protocol with SSE (Server-Sent Events) support
- Add git stash tools to lean interface

## Changes

### HTTP Transport
- `GET /mcp` - SSE stream for server-to-client notifications
- `POST /mcp` - JSON-RPC 2.0 for client-to-server requests
- Raw JSON parsing (aligned with session-intelligence reference)
- Auto-session mode for MCP client compatibility
- 3-meta-tool pattern support (discover_tools, get_tool_spec, execute_tool)

### Git Stash Tools
- `git_stash_list` - List all stashes
- `git_stash_push` - Create stash with optional message
- `git_stash_pop` - Apply and remove stash
- `git_stash_drop` - Remove stash without applying

## Test plan

- [x] Verify HTTP server starts on port 4100
- [x] Test SSE endpoint with `curl -H 'Accept: text/event-stream'`
- [x] Test MCP protocol flow: initialize → tools/list → tools/call
- [x] Test stash operations via git-http

🤖 Generated with [Claude Code](https://claude.ai/code)