### PR TITLE
feat: add github_create_repo tool for repository creation

### DIFF
--- a/src/mcp_server_git/github/__init__.py
+++ b/src/mcp_server_git/github/__init__.py
@@ -6,6 +6,7 @@ from .api import (
     # GitHub Issues API
     github_create_issue,
     github_create_pr,
+    github_create_repo,
     github_get_failing_jobs,
     github_get_job_logs,
     github_get_pr_checks,
@@ -25,6 +26,7 @@ from .client import GitHubClient, get_github_client
 from .models import (
     # GitHub Issues Models
     GitHubCreateIssue,
+    GitHubCreateRepo,
     GitHubGetFailingJobs,
     GitHubGetJobLogs,
     GitHubGetPRChecks,
@@ -55,6 +57,7 @@ __all__ = [
     # Write operations
     "github_update_pr",
     "github_create_pr",
+    "github_create_repo",
     "github_merge_pr",
     "github_add_pr_comment",
     "github_close_pr",
@@ -62,6 +65,8 @@ __all__ = [
     "github_create_issue",
     "github_update_issue",
     # Models
+    "GitHubCreateIssue",
+    "GitHubCreateRepo",
     "GitHubGetFailingJobs",
     "GitHubGetJobLogs",
     "GitHubGetPRChecks",
@@ -71,7 +76,6 @@ __all__ = [
     "GitHubGetWorkflowRun",
     "GitHubListPullRequests",
     "GitHubListWorkflowRuns",
-    "GitHubCreateIssue",
     "GitHubListIssues",
     "GitHubUpdateIssue",
 ]

--- a/src/mcp_server_git/github/api.py
+++ b/src/mcp_server_git/github/api.py
@@ -3809,7 +3809,7 @@ async def github_create_repo(
         Success message with repository URLs or error message
     """
     target = f"{org}/{name}" if org else name
-    logger.debug(f"🚀 Creating repository: {target} (private={private})")
+    logger.debug(f"Creating repository: {target} (private={private})")
 
     try:
         async with github_client_context() as client:
@@ -3840,25 +3840,23 @@ async def github_create_repo(
 
             if response.status == 201:
                 result = await response.json()
-                logger.info(
-                    f"✅ Successfully created repository: {result['full_name']}"
-                )
+                logger.info(f"Successfully created repository: {result['full_name']}")
 
                 output = [
-                    f"✅ Successfully created repository: {result['full_name']}",
+                    f"Successfully created repository: {result['full_name']}",
                     "",
-                    f"📍 URL: {result['html_url']}",
-                    f"🔗 Clone (HTTPS): {result['clone_url']}",
-                    f"🔗 Clone (SSH): {result['ssh_url']}",
+                    f"URL: {result['html_url']}",
+                    f"Clone (HTTPS): {result['clone_url']}",
+                    f"Clone (SSH): {result['ssh_url']}",
                 ]
 
                 if result.get("private"):
-                    output.append("🔒 Visibility: Private")
+                    output.append("Visibility: Private")
                 else:
-                    output.append("🌐 Visibility: Public")
+                    output.append("Visibility: Public")
 
                 if auto_init:
-                    output.append("📄 Initialized with README")
+                    output.append("Initialized with README")
 
                 return "\n".join(output)
 
@@ -3870,33 +3868,33 @@ async def github_create_repo(
                     e.get("message", "").startswith("name already exists")
                     for e in errors
                 ):
-                    return f"❌ Repository '{target}' already exists"
+                    return f"Error: Repository '{target}' already exists"
                 return (
-                    f"❌ Validation error: {error_data.get('message', 'Unknown error')}"
+                    f"Validation error: {error_data.get('message', 'Unknown error')}"
                 )
 
             elif response.status == 403:
-                return "❌ Permission denied. Check your token has 'repo' scope."
+                return "Error: Permission denied. Check your token has 'repo' scope."
 
             elif response.status == 404:
                 if org:
                     return (
-                        f"❌ Organization '{org}' not found or you don't have access."
+                        f"Error: Organization '{org}' not found or you don't have access."
                     )
-                return f"❌ Not found error: {await response.text()}"
+                return f"Error: Not found - {await response.text()}"
 
             else:
                 error_text = await response.text()
                 return (
-                    f"❌ Failed to create repository: {response.status} - {error_text}"
+                    f"Error: Failed to create repository: {response.status} - {error_text}"
                 )
 
     except ValueError as auth_error:
         logger.error(f"Authentication error creating repo: {auth_error}")
-        return f"❌ {str(auth_error)}"
+        return f"Error: {str(auth_error)}"
     except ConnectionError as conn_error:
         logger.error(f"Connection error creating repo: {conn_error}")
-        return f"❌ Network connection failed: {str(conn_error)}"
+        return f"Error: Network connection failed: {str(conn_error)}"
     except Exception as e:
         logger.error(f"Unexpected error creating repo: {e}", exc_info=True)
-        return f"❌ Error creating repository: {str(e)}"
+        return f"Error: Failed to create repository: {str(e)}"

--- a/src/mcp_server_git/github/api.py
+++ b/src/mcp_server_git/github/api.py
@@ -3769,3 +3769,134 @@ async def github_get_job_logs(
     except Exception as e:
         logger.error(f"Unexpected error getting job logs: {e}", exc_info=True)
         return f"❌ Error getting job logs: {str(e)}"
+
+
+# ============================================================================
+# GitHub Repository Creation (Issue #127)
+# ============================================================================
+
+
+async def github_create_repo(
+    name: str,
+    org: str | None = None,
+    description: str | None = None,
+    private: bool = False,
+    auto_init: bool = False,
+    gitignore_template: str | None = None,
+    license_template: str | None = None,
+    has_issues: bool = True,
+    has_projects: bool = True,
+    has_wiki: bool = True,
+) -> str:
+    """Create a new GitHub repository.
+
+    Creates a repository for the authenticated user or an organization.
+    Returns the repository URL and clone URLs on success.
+
+    Args:
+        name: Repository name (required)
+        org: Organization name (None = personal repo)
+        description: Repository description
+        private: True for private, False for public
+        auto_init: Initialize with README
+        gitignore_template: e.g., "Python", "Node"
+        license_template: e.g., "mit", "apache-2.0"
+        has_issues: Enable issues
+        has_projects: Enable projects
+        has_wiki: Enable wiki
+
+    Returns:
+        Success message with repository URLs or error message
+    """
+    target = f"{org}/{name}" if org else name
+    logger.debug(f"🚀 Creating repository: {target} (private={private})")
+
+    try:
+        async with github_client_context() as client:
+            # Build payload with only non-None values
+            payload: dict[str, Any] = {
+                "name": name,
+                "private": private,
+                "auto_init": auto_init,
+                "has_issues": has_issues,
+                "has_projects": has_projects,
+                "has_wiki": has_wiki,
+            }
+
+            if description is not None:
+                payload["description"] = description
+            if gitignore_template is not None:
+                payload["gitignore_template"] = gitignore_template
+            if license_template is not None:
+                payload["license_template"] = license_template
+
+            # Use different endpoint for org vs personal repos
+            if org:
+                endpoint = f"/orgs/{org}/repos"
+            else:
+                endpoint = "/user/repos"
+
+            response = await client.post(endpoint, json=payload)
+
+            if response.status == 201:
+                result = await response.json()
+                logger.info(
+                    f"✅ Successfully created repository: {result['full_name']}"
+                )
+
+                output = [
+                    f"✅ Successfully created repository: {result['full_name']}",
+                    "",
+                    f"📍 URL: {result['html_url']}",
+                    f"🔗 Clone (HTTPS): {result['clone_url']}",
+                    f"🔗 Clone (SSH): {result['ssh_url']}",
+                ]
+
+                if result.get("private"):
+                    output.append("🔒 Visibility: Private")
+                else:
+                    output.append("🌐 Visibility: Public")
+
+                if auto_init:
+                    output.append("📄 Initialized with README")
+
+                return "\n".join(output)
+
+            elif response.status == 422:
+                # Validation error - usually repo already exists
+                error_data = await response.json()
+                errors = error_data.get("errors", [])
+                if errors and any(
+                    e.get("message", "").startswith("name already exists")
+                    for e in errors
+                ):
+                    return f"❌ Repository '{target}' already exists"
+                return (
+                    f"❌ Validation error: {error_data.get('message', 'Unknown error')}"
+                )
+
+            elif response.status == 403:
+                return "❌ Permission denied. Check your token has 'repo' scope."
+
+            elif response.status == 404:
+                if org:
+                    return (
+                        f"❌ Organization '{org}' not found or you don't have access."
+                    )
+                return f"❌ Not found error: {await response.text()}"
+
+            else:
+                error_text = await response.text()
+                return (
+                    f"❌ Failed to create repository: {response.status} - {error_text}"
+                )
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error creating repo: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error creating repo: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error creating repo: {e}", exc_info=True)
+        return f"❌ Error creating repository: {str(e)}"

--- a/src/mcp_server_git/github/api.py
+++ b/src/mcp_server_git/github/api.py
@@ -3869,25 +3869,19 @@ async def github_create_repo(
                     for e in errors
                 ):
                     return f"Error: Repository '{target}' already exists"
-                return (
-                    f"Validation error: {error_data.get('message', 'Unknown error')}"
-                )
+                return f"Validation error: {error_data.get('message', 'Unknown error')}"
 
             elif response.status == 403:
                 return "Error: Permission denied. Check your token has 'repo' scope."
 
             elif response.status == 404:
                 if org:
-                    return (
-                        f"Error: Organization '{org}' not found or you don't have access."
-                    )
+                    return f"Error: Organization '{org}' not found or you don't have access."
                 return f"Error: Not found - {await response.text()}"
 
             else:
                 error_text = await response.text()
-                return (
-                    f"Error: Failed to create repository: {response.status} - {error_text}"
-                )
+                return f"Error: Failed to create repository: {response.status} - {error_text}"
 
     except ValueError as auth_error:
         logger.error(f"Authentication error creating repo: {auth_error}")

--- a/src/mcp_server_git/github/models.py
+++ b/src/mcp_server_git/github/models.py
@@ -895,3 +895,37 @@ class GitHubCreateRepo(BaseModel):
     has_issues: bool = True  # Enable issues
     has_projects: bool = True  # Enable projects
     has_wiki: bool = True  # Enable wiki
+
+    @field_validator("name")
+    @classmethod
+    def validate_repo_name(cls, v: str) -> str:
+        """Validate repository name follows GitHub naming rules."""
+        if not v:
+            raise ValueError("Repository name cannot be empty")
+        if len(v) > 100:
+            raise ValueError("Repository name too long (max 100 characters)")
+        if v.startswith("."):
+            raise ValueError("Repository name cannot start with a period")
+        if not re.match(r"^[a-zA-Z0-9._-]+$", v):
+            raise ValueError(
+                "Repository name can only contain alphanumeric characters, "
+                "periods, hyphens, and underscores"
+            )
+        return v
+
+    @field_validator("org")
+    @classmethod
+    def validate_org_name(cls, v: str | None) -> str | None:
+        """Validate organization name if provided."""
+        if v is None:
+            return v
+        if not v:
+            raise ValueError("Organization name cannot be empty string")
+        if len(v) > 39:
+            raise ValueError("Organization name too long (max 39 characters)")
+        if not re.match(r"^[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?$", v):
+            raise ValueError(
+                "Organization name must start/end with alphanumeric and "
+                "can only contain alphanumeric characters and hyphens"
+            )
+        return v

--- a/src/mcp_server_git/github/models.py
+++ b/src/mcp_server_git/github/models.py
@@ -853,3 +853,45 @@ class GitHubGetJobLogs(BaseModel):
     job_id: int  # Job ID from GitHub Actions (from check runs or workflow jobs)
     tail_lines: int | None = None  # Return only last N lines; None uses default (500)
     full_log: bool = False  # If True, skip line limit (still has 100KB char limit)
+
+
+# ============================================================================
+# GitHub Repository Creation Model (Issue #127)
+# ============================================================================
+
+
+class GitHubCreateRepo(BaseModel):
+    """Model for creating a new GitHub repository.
+
+    Creates a new repository for the authenticated user or an organization.
+    If org is provided, creates an organization repository (requires org admin rights).
+
+    Example usage:
+        # Create personal public repo
+        github_create_repo(name="my-project", private=False)
+
+        # Create org private repo with settings
+        github_create_repo(
+            name="internal-tool",
+            org="my-org",
+            private=True,
+            description="Internal tooling",
+            auto_init=True,
+            gitignore_template="Python",
+            license_template="mit"
+        )
+
+    Common gitignore_template values: Python, Node, Go, Java, Rust, C++, etc.
+    Common license_template values: mit, apache-2.0, gpl-3.0, bsd-3-clause, etc.
+    """
+
+    name: str  # Repository name (required)
+    org: str | None = None  # Organization name (None = personal repo)
+    description: str | None = None  # Repository description
+    private: bool = False  # True for private, False for public
+    auto_init: bool = False  # Initialize with README
+    gitignore_template: str | None = None  # e.g., "Python", "Node"
+    license_template: str | None = None  # e.g., "mit", "apache-2.0"
+    has_issues: bool = True  # Enable issues
+    has_projects: bool = True  # Enable projects
+    has_wiki: bool = True  # Enable wiki

--- a/src/mcp_server_git/lean/tool_registry.py
+++ b/src/mcp_server_git/lean/tool_registry.py
@@ -425,6 +425,7 @@ def _register_github_tools(interface: Any, github_service: Any):
         GitHubCreateIssue,
         GitHubCreateIssueFromTemplate,
         GitHubCreateRelease,
+        GitHubCreateRepo,
         GitHubDeleteBranchProtection,
         GitHubDeleteRelease,
         GitHubDeleteReleaseAsset,
@@ -905,6 +906,15 @@ def _register_github_tools(interface: Any, github_service: Any):
             implementation=github_ops.github_delete_release_asset,
             description="Delete an asset from a release",
             schema=GitHubDeleteReleaseAsset.model_json_schema(),
+            domain="github",
+            complexity="focused",
+        ),
+        # Repository Creation (Issue #127)
+        ToolDefinition(
+            name="github_create_repo",
+            implementation=github_ops.github_create_repo,
+            description="Create a new GitHub repository (personal or organization)",
+            schema=GitHubCreateRepo.model_json_schema(),
             domain="github",
             complexity="focused",
         ),

--- a/tests/unit/github/test_github_create_repo.py
+++ b/tests/unit/github/test_github_create_repo.py
@@ -1,0 +1,519 @@
+"""
+Unit tests for GitHub repository creation functionality.
+
+Tests the github_create_repo function including:
+- Creating personal repositories
+- Creating organization repositories
+- Pydantic model validation for GitHubCreateRepo
+- Error handling (repo exists, permission denied, org not found)
+- Authentication and connection error handling
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import ValidationError
+
+from src.mcp_server_git.github.api import github_create_repo
+from src.mcp_server_git.github.models import GitHubCreateRepo
+
+
+class TestGitHubCreateRepoModel:
+    """Test GitHubCreateRepo Pydantic model validation."""
+
+    def test_valid_repo_name(self):
+        """Test valid repository names are accepted."""
+        valid_names = [
+            "my-repo",
+            "my_repo",
+            "my.repo",
+            "MyRepo123",
+            "a",
+            "repo-name-with-many-parts",
+        ]
+        for name in valid_names:
+            model = GitHubCreateRepo(name=name)
+            assert model.name == name
+
+    def test_invalid_repo_name_empty(self):
+        """Test empty repository name is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubCreateRepo(name="")
+        assert "cannot be empty" in str(exc_info.value)
+
+    def test_invalid_repo_name_starts_with_period(self):
+        """Test repository name starting with period is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubCreateRepo(name=".hidden-repo")
+        assert "cannot start with a period" in str(exc_info.value)
+
+    def test_invalid_repo_name_special_chars(self):
+        """Test repository name with invalid characters is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubCreateRepo(name="repo/name")
+        assert "alphanumeric" in str(exc_info.value)
+
+    def test_invalid_repo_name_too_long(self):
+        """Test repository name exceeding 100 characters is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubCreateRepo(name="a" * 101)
+        assert "too long" in str(exc_info.value)
+
+    def test_valid_org_name(self):
+        """Test valid organization names are accepted."""
+        valid_orgs = [
+            "my-org",
+            "MyOrg123",
+            "org",
+            "my-org-name",
+        ]
+        for org in valid_orgs:
+            model = GitHubCreateRepo(name="repo", org=org)
+            assert model.org == org
+
+    def test_org_name_none_is_valid(self):
+        """Test None organization name is valid (personal repo)."""
+        model = GitHubCreateRepo(name="repo", org=None)
+        assert model.org is None
+
+    def test_invalid_org_name_empty_string(self):
+        """Test empty string organization name is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubCreateRepo(name="repo", org="")
+        assert "cannot be empty string" in str(exc_info.value)
+
+    def test_invalid_org_name_starts_with_hyphen(self):
+        """Test organization name starting with hyphen is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubCreateRepo(name="repo", org="-invalid")
+        assert "start/end with alphanumeric" in str(exc_info.value)
+
+    def test_invalid_org_name_too_long(self):
+        """Test organization name exceeding 39 characters is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            GitHubCreateRepo(name="repo", org="a" * 40)
+        assert "too long" in str(exc_info.value)
+
+    def test_all_optional_fields(self):
+        """Test model with all optional fields specified."""
+        model = GitHubCreateRepo(
+            name="my-repo",
+            org="my-org",
+            description="A test repository",
+            private=True,
+            auto_init=True,
+            gitignore_template="Python",
+            license_template="mit",
+            has_issues=False,
+            has_projects=False,
+            has_wiki=False,
+        )
+        assert model.name == "my-repo"
+        assert model.org == "my-org"
+        assert model.description == "A test repository"
+        assert model.private is True
+        assert model.auto_init is True
+        assert model.gitignore_template == "Python"
+        assert model.license_template == "mit"
+        assert model.has_issues is False
+
+
+class TestGitHubCreateRepoPersonal:
+    """Test github_create_repo for personal repositories."""
+
+    @pytest.mark.asyncio
+    async def test_create_personal_repo_success(self):
+        """Test successfully creating a personal repository."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 201
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "user/my-repo",
+                "html_url": "https://github.com/user/my-repo",
+                "clone_url": "https://github.com/user/my-repo.git",
+                "ssh_url": "git@github.com:user/my-repo.git",
+                "private": False,
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_repo(name="my-repo")
+
+            assert "Successfully created repository: user/my-repo" in result
+            assert "https://github.com/user/my-repo" in result
+            assert "Clone (HTTPS):" in result
+            assert "Clone (SSH):" in result
+            assert "Visibility: Public" in result
+            mock_client.post.assert_called_once_with(
+                "/user/repos",
+                json={
+                    "name": "my-repo",
+                    "private": False,
+                    "auto_init": False,
+                    "has_issues": True,
+                    "has_projects": True,
+                    "has_wiki": True,
+                },
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_private_repo_success(self):
+        """Test successfully creating a private repository."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 201
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "user/private-repo",
+                "html_url": "https://github.com/user/private-repo",
+                "clone_url": "https://github.com/user/private-repo.git",
+                "ssh_url": "git@github.com:user/private-repo.git",
+                "private": True,
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_repo(name="private-repo", private=True)
+
+            assert "Successfully created repository" in result
+            assert "Visibility: Private" in result
+
+    @pytest.mark.asyncio
+    async def test_create_repo_with_auto_init(self):
+        """Test creating a repository with README initialization."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 201
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "user/initialized-repo",
+                "html_url": "https://github.com/user/initialized-repo",
+                "clone_url": "https://github.com/user/initialized-repo.git",
+                "ssh_url": "git@github.com:user/initialized-repo.git",
+                "private": False,
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_repo(name="initialized-repo", auto_init=True)
+
+            assert "Initialized with README" in result
+
+
+class TestGitHubCreateRepoOrganization:
+    """Test github_create_repo for organization repositories."""
+
+    @pytest.mark.asyncio
+    async def test_create_org_repo_success(self):
+        """Test successfully creating an organization repository."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 201
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "my-org/team-repo",
+                "html_url": "https://github.com/my-org/team-repo",
+                "clone_url": "https://github.com/my-org/team-repo.git",
+                "ssh_url": "git@github.com:my-org/team-repo.git",
+                "private": True,
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_repo(
+                name="team-repo",
+                org="my-org",
+                private=True,
+                description="Team repository",
+            )
+
+            assert "Successfully created repository: my-org/team-repo" in result
+            mock_client.post.assert_called_once()
+            call_args = mock_client.post.call_args
+            assert call_args[0][0] == "/orgs/my-org/repos"
+            assert call_args[1]["json"]["description"] == "Team repository"
+
+    @pytest.mark.asyncio
+    async def test_create_org_repo_not_found(self):
+        """Test creating repository in non-existent organization."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_repo(name="repo", org="nonexistent-org")
+
+            assert "Error:" in result
+            assert "nonexistent-org" in result
+            assert "not found" in result
+
+
+class TestGitHubCreateRepoErrors:
+    """Test error handling for github_create_repo."""
+
+    @pytest.mark.asyncio
+    async def test_repo_already_exists(self):
+        """Test error when repository already exists."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 422
+        mock_response.json = AsyncMock(
+            return_value={
+                "message": "Validation Failed",
+                "errors": [{"message": "name already exists on this account"}],
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_repo(name="existing-repo")
+
+            assert "Error:" in result
+            assert "already exists" in result
+
+    @pytest.mark.asyncio
+    async def test_permission_denied(self):
+        """Test error when permission is denied."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 403
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_repo(name="repo")
+
+            assert "Error: Permission denied" in result
+            assert "'repo' scope" in result
+
+    @pytest.mark.asyncio
+    async def test_validation_error_generic(self):
+        """Test generic validation error from GitHub API."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 422
+        mock_response.json = AsyncMock(
+            return_value={
+                "message": "Repository creation failed",
+                "errors": [],
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_repo(name="repo")
+
+            assert "Validation error" in result
+            assert "Repository creation failed" in result
+
+    @pytest.mark.asyncio
+    async def test_authentication_error(self):
+        """Test error when authentication fails."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ValueError(
+                "GitHub token not configured"
+            )
+
+            result = await github_create_repo(name="repo")
+
+            assert "Error:" in result
+            assert "token" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_connection_error(self):
+        """Test error when network connection fails."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = ConnectionError(
+                "Network unreachable"
+            )
+
+            result = await github_create_repo(name="repo")
+
+            assert "Error:" in result
+            assert "Network connection failed" in result
+
+    @pytest.mark.asyncio
+    async def test_unexpected_error(self):
+        """Test handling of unexpected errors."""
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.side_effect = RuntimeError(
+                "Unexpected failure"
+            )
+
+            result = await github_create_repo(name="repo")
+
+            assert "Error:" in result
+            assert "Unexpected failure" in result
+
+    @pytest.mark.asyncio
+    async def test_unknown_status_code(self):
+        """Test handling of unknown HTTP status codes."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 500
+        mock_response.text = AsyncMock(return_value="Internal Server Error")
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_create_repo(name="repo")
+
+            assert "Error:" in result
+            assert "500" in result
+
+
+class TestGitHubCreateRepoOptions:
+    """Test github_create_repo with various options."""
+
+    @pytest.mark.asyncio
+    async def test_create_repo_with_gitignore_template(self):
+        """Test creating repository with gitignore template."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 201
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "user/python-project",
+                "html_url": "https://github.com/user/python-project",
+                "clone_url": "https://github.com/user/python-project.git",
+                "ssh_url": "git@github.com:user/python-project.git",
+                "private": False,
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            await github_create_repo(
+                name="python-project",
+                gitignore_template="Python",
+            )
+
+            call_args = mock_client.post.call_args
+            assert call_args[1]["json"]["gitignore_template"] == "Python"
+
+    @pytest.mark.asyncio
+    async def test_create_repo_with_license_template(self):
+        """Test creating repository with license template."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 201
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "user/mit-project",
+                "html_url": "https://github.com/user/mit-project",
+                "clone_url": "https://github.com/user/mit-project.git",
+                "ssh_url": "git@github.com:user/mit-project.git",
+                "private": False,
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            await github_create_repo(
+                name="mit-project",
+                license_template="mit",
+            )
+
+            call_args = mock_client.post.call_args
+            assert call_args[1]["json"]["license_template"] == "mit"
+
+    @pytest.mark.asyncio
+    async def test_create_repo_disable_features(self):
+        """Test creating repository with features disabled."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 201
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "user/minimal-repo",
+                "html_url": "https://github.com/user/minimal-repo",
+                "clone_url": "https://github.com/user/minimal-repo.git",
+                "ssh_url": "git@github.com:user/minimal-repo.git",
+                "private": False,
+            }
+        )
+        mock_client.post = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.api.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            await github_create_repo(
+                name="minimal-repo",
+                has_issues=False,
+                has_projects=False,
+                has_wiki=False,
+            )
+
+            call_args = mock_client.post.call_args
+            payload = call_args[1]["json"]
+            assert payload["has_issues"] is False
+            assert payload["has_projects"] is False
+            assert payload["has_wiki"] is False


### PR DESCRIPTION
## Summary

Implement Issue #127 - Add `github_create_repo` tool to create GitHub repositories from the MCP server.

## Changes

- **github/models.py**: Add `GitHubCreateRepo` Pydantic model
- **github/api.py**: Add `github_create_repo()` async function
- **lean/tool_registry.py**: Register tool with schema
- **github/__init__.py**: Export function and model

## Features

- Create personal or organization repositories
- Configure visibility (public/private)
- Auto-initialize with README
- Apply gitignore and license templates
- Enable/disable issues, projects, wiki

## Use Case

```python
# 1. Create repo
github_create_repo(name="my-project", private=False)

# 2. Add remote
git_remote_add(name="origin", url="...")

# 3. Push
git_push(branch="main")
```

Closes #127

## Test Plan

- [ ] Unit tests for GitHubCreateRepo model validation
- [ ] Integration test for personal repo creation
- [ ] Integration test for org repo creation
- [ ] Error handling tests (repo exists, permission denied)

🤖 Generated with [Claude Code](https://claude.ai/code)