### PR TITLE
feat: add --amend support to git_commit

### DIFF
--- a/src/mcp_server_git/core/handlers.py
+++ b/src/mcp_server_git/core/handlers.py
@@ -100,7 +100,7 @@ class CallToolHandler:
             "git_commit": self._create_git_handler(
                 git_commit,
                 requires_repo=True,
-                extra_args=["message", "gpg_sign", "gpg_key_id"],
+                extra_args=["message", "amend", "gpg_sign", "gpg_key_id"],
             ),
             "git_add": self._create_git_handler(
                 git_add, requires_repo=True, extra_args=["files"]

--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -25,6 +25,7 @@ class GitDiff(BaseModel):
 class GitCommit(BaseModel):
     repo_path: str
     message: str
+    amend: bool = False
     gpg_sign: bool = False
     gpg_key_id: Optional[str] = None
 

--- a/src/mcp_server_git/git/operations.py
+++ b/src/mcp_server_git/git/operations.py
@@ -48,10 +48,11 @@ def git_diff(repo: Repo, target: str) -> str:
 def git_commit(
     repo: Repo,
     message: str,
+    amend: bool = False,
     gpg_sign: bool = False,
     gpg_key_id: Optional[str] = None,
 ) -> str:
-    """Commit staged changes with optional GPG signing and automatic security enforcement"""
+    """Commit staged changes with optional amend, GPG signing and automatic security enforcement"""
     try:
         # Import security functions locally to avoid circular imports
         from .security import enforce_secure_git_config
@@ -84,6 +85,8 @@ def git_commit(
         if force_gpg:
             # Use git command directly for GPG signing
             cmd = ["git", "commit"]
+            if amend:
+                cmd.append("--amend")
             cmd.append(f"--gpg-sign={force_key_id}")
             cmd.extend(["-m", message])
 
@@ -104,8 +107,9 @@ def git_commit(
                     else "unknown"
                 )
 
+                action = "amended" if amend else "created"
                 success_msg = (
-                    f"✅ Commit {commit_hash} created with VERIFIED GPG signature"
+                    f"✅ Commit {commit_hash} {action} with VERIFIED GPG signature"
                 )
                 if security_messages:
                     success_msg += f"\n{chr(10).join(security_messages)}"

--- a/src/mcp_server_git/server.py
+++ b/src/mcp_server_git/server.py
@@ -987,9 +987,9 @@ def git_diff(repo: Repo, target: str) -> str:
 
 
 def git_commit(
-    repo: Repo, message: str, gpg_sign: bool = False, gpg_key_id: str | None = None
+    repo: Repo, message: str, amend: bool = False, gpg_sign: bool = False, gpg_key_id: str | None = None
 ) -> str:
-    """Commit staged changes with optional GPG signing and automatic security enforcement"""
+    """Commit staged changes with optional amend, GPG signing and automatic security enforcement"""
     import subprocess
     import logging
 
@@ -1028,6 +1028,8 @@ def git_commit(
         if force_gpg:  # This will always be true due to the security requirement
             # Use git command directly for GPG signing with comprehensive error handling
             cmd = ["git", "commit"]
+            if amend:
+                cmd.append("--amend")
             # Ensure the key ID is passed correctly
             if force_key_id:
                 cmd.append(f"--gpg-sign={force_key_id}")
@@ -1061,8 +1063,9 @@ def git_commit(
                         else "unknown"
                     )
 
+                    action = "amended" if amend else "created"
                     success_msg = (
-                        f"✅ Commit {commit_hash} created with VERIFIED GPG signature"
+                        f"✅ Commit {commit_hash} {action} with VERIFIED GPG signature"
                     )
                     if security_messages:
                         success_msg += f"\n{chr(10).join(security_messages)}"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -339,3 +339,55 @@ def test_advanced_git_tools_enum():
     assert GitTools.CHERRY_PICK == "git_cherry_pick"
     assert GitTools.ABORT == "git_abort"
     assert GitTools.CONTINUE == "git_continue"
+
+
+def test_git_commit_amend(test_repository):
+    """Test git commit with --amend flag builds the correct command"""
+    from unittest.mock import patch, MagicMock
+    from mcp_server_git.git.operations import git_commit
+
+    # Make a change and commit it
+    (Path(test_repository.working_dir) / "amend_test.txt").write_text("original")
+    test_repository.index.add(["amend_test.txt"])
+    test_repository.index.commit("original message")
+
+    # Stage a new change
+    (Path(test_repository.working_dir) / "amend_test.txt").write_text("amended")
+    test_repository.index.add(["amend_test.txt"])
+
+    # Mock subprocess.run to capture the command and verify --amend is passed
+    mock_commit_result = MagicMock(returncode=0, stderr="", stdout="")
+    mock_hash_result = MagicMock(returncode=0, stdout="abc12345\n", stderr="")
+
+    with patch("mcp_server_git.git.operations.subprocess.run", side_effect=[mock_commit_result, mock_hash_result]) as mock_run, \
+         patch.dict("os.environ", {"GPG_SIGNING_KEY": "TESTKEY123"}):
+        result = git_commit(test_repository, "amended message", amend=True)
+
+    # Verify --amend was in the git commit command
+    commit_cmd = mock_run.call_args_list[0][0][0]
+    assert "--amend" in commit_cmd
+    assert "-m" in commit_cmd
+    assert "amended message" in commit_cmd
+    assert "amended" in result
+
+
+def test_git_commit_no_amend(test_repository):
+    """Test git commit without --amend does not include the flag"""
+    from unittest.mock import patch, MagicMock
+    from mcp_server_git.git.operations import git_commit
+
+    # Stage a change
+    (Path(test_repository.working_dir) / "no_amend.txt").write_text("content")
+    test_repository.index.add(["no_amend.txt"])
+
+    mock_commit_result = MagicMock(returncode=0, stderr="", stdout="")
+    mock_hash_result = MagicMock(returncode=0, stdout="def67890\n", stderr="")
+
+    with patch("mcp_server_git.git.operations.subprocess.run", side_effect=[mock_commit_result, mock_hash_result]) as mock_run, \
+         patch.dict("os.environ", {"GPG_SIGNING_KEY": "TESTKEY123"}):
+        result = git_commit(test_repository, "new commit")
+
+    # Verify --amend was NOT in the command
+    commit_cmd = mock_run.call_args_list[0][0][0]
+    assert "--amend" not in commit_cmd
+    assert "created" in result


### PR DESCRIPTION
## Summary

- Add `amend: bool = False` parameter to `git_commit` across model, operations, server fallback, and handler
- When `amend=True`, passes `--amend` flag to git commit command
- Success message says "amended" instead of "created" when amending

## Test plan

- [x] `test_git_commit_amend` - verifies `--amend` flag is included in command
- [x] `test_git_commit_no_amend` - verifies `--amend` is absent by default
- [x] All 19 existing tests in test_server.py still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)