### PR TITLE
feat: add PR review comment retrieval and reply tools

### DIFF
--- a/src/mcp_server_git/github/api.py
+++ b/src/mcp_server_git/github/api.py
@@ -882,7 +882,8 @@ async def github_get_pr_comments(
     try:
         async with github_client_context() as client:
             response = await client.get(
-                f"/repos/{repo_owner}/{repo_name}/issues/{pr_number}/comments"
+                f"/repos/{repo_owner}/{repo_name}/issues/{pr_number}/comments",
+                params={"per_page": 100},
             )
 
             if response.status != 200:
@@ -898,7 +899,7 @@ async def github_get_pr_comments(
         for c in comments:
             author = c.get("user", {}).get("login", "unknown")
             created = c.get("created_at", "")
-            body = c.get("body", "").strip()
+            body = (c.get("body") or "").strip()
             comment_id = c.get("id", "")
             lines.append(f"  #{comment_id} by {author} ({created}):")
             lines.append(f"    {body}\n")
@@ -928,7 +929,8 @@ async def github_get_pr_reviews(repo_owner: str, repo_name: str, pr_number: int)
     try:
         async with github_client_context() as client:
             response = await client.get(
-                f"/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/comments"
+                f"/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/comments",
+                params={"per_page": 100},
             )
 
             if response.status != 200:
@@ -944,7 +946,7 @@ async def github_get_pr_reviews(repo_owner: str, repo_name: str, pr_number: int)
         for c in comments:
             author = c.get("user", {}).get("login", "unknown")
             created = c.get("created_at", "")
-            body = c.get("body", "").strip()
+            body = (c.get("body") or "").strip()
             path = c.get("path", "")
             line = c.get("line") or c.get("original_line", "")
             comment_id = c.get("id", "")
@@ -975,6 +977,11 @@ async def github_reply_to_pr_comment(
     repo_owner: str, repo_name: str, pr_number: int, comment_id: int, body: str
 ) -> str:
     """Reply to a specific review comment thread."""
+    if not body or not body.strip():
+        return "❌ Error: reply body cannot be empty"
+    if len(body) > 65536:
+        return "❌ Error: reply body exceeds GitHub's 65536 character limit"
+
     logger.debug(
         f"🚀 Replying to comment #{comment_id} on PR #{pr_number} in {repo_owner}/{repo_name}"
     )

--- a/src/mcp_server_git/github/api.py
+++ b/src/mcp_server_git/github/api.py
@@ -871,6 +871,146 @@ async def github_add_pr_comment(
         return f"❌ Error adding comment: {str(e)}"
 
 
+async def github_get_pr_comments(
+    repo_owner: str, repo_name: str, pr_number: int
+) -> str:
+    """Get top-level conversation comments on a PR."""
+    logger.debug(
+        f"🚀 Fetching comments for PR #{pr_number} in {repo_owner}/{repo_name}"
+    )
+
+    try:
+        async with github_client_context() as client:
+            response = await client.get(
+                f"/repos/{repo_owner}/{repo_name}/issues/{pr_number}/comments"
+            )
+
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to fetch comments: {response.status} - {error_text}"
+
+            comments = await response.json()
+
+        if not comments:
+            return f"No comments on PR #{pr_number}"
+
+        lines = [f"Comments on PR #{pr_number} ({len(comments)} total):\n"]
+        for c in comments:
+            author = c.get("user", {}).get("login", "unknown")
+            created = c.get("created_at", "")
+            body = c.get("body", "").strip()
+            comment_id = c.get("id", "")
+            lines.append(f"  #{comment_id} by {author} ({created}):")
+            lines.append(f"    {body}\n")
+
+        return "\n".join(lines)
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error fetching PR comments: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error fetching PR comments: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error fetching comments for PR #{pr_number}: {e}",
+            exc_info=True,
+        )
+        return f"❌ Error fetching PR comments: {str(e)}"
+
+
+async def github_get_pr_reviews(repo_owner: str, repo_name: str, pr_number: int) -> str:
+    """Get inline code review comments on a PR."""
+    logger.debug(
+        f"🚀 Fetching review comments for PR #{pr_number} in {repo_owner}/{repo_name}"
+    )
+
+    try:
+        async with github_client_context() as client:
+            response = await client.get(
+                f"/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/comments"
+            )
+
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to fetch review comments: {response.status} - {error_text}"
+
+            comments = await response.json()
+
+        if not comments:
+            return f"No review comments on PR #{pr_number}"
+
+        lines = [f"Review comments on PR #{pr_number} ({len(comments)} total):\n"]
+        for c in comments:
+            author = c.get("user", {}).get("login", "unknown")
+            created = c.get("created_at", "")
+            body = c.get("body", "").strip()
+            path = c.get("path", "")
+            line = c.get("line") or c.get("original_line", "")
+            comment_id = c.get("id", "")
+            in_reply_to = c.get("in_reply_to_id", "")
+            reply_info = f" (reply to #{in_reply_to})" if in_reply_to else ""
+
+            lines.append(f"  #{comment_id} by {author} ({created}){reply_info}:")
+            lines.append(f"    File: {path}:{line}")
+            lines.append(f"    {body}\n")
+
+        return "\n".join(lines)
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error fetching PR review comments: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error fetching PR review comments: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error fetching review comments for PR #{pr_number}: {e}",
+            exc_info=True,
+        )
+        return f"❌ Error fetching PR review comments: {str(e)}"
+
+
+async def github_reply_to_pr_comment(
+    repo_owner: str, repo_name: str, pr_number: int, comment_id: int, body: str
+) -> str:
+    """Reply to a specific review comment thread."""
+    logger.debug(
+        f"🚀 Replying to comment #{comment_id} on PR #{pr_number} in {repo_owner}/{repo_name}"
+    )
+
+    try:
+        async with github_client_context() as client:
+            response = await client.post(
+                f"/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/comments/{comment_id}/replies",
+                json={"body": body},
+            )
+
+            if response.status != 201:
+                error_text = await response.text()
+                return f"❌ Failed to post reply: {response.status} - {error_text}"
+
+            result = await response.json()
+            reply_id = result.get("id", "unknown")
+            logger.info(
+                f"✅ Successfully replied to comment #{comment_id} on PR #{pr_number}"
+            )
+            return f"✅ Reply #{reply_id} posted to comment #{comment_id} on PR #{pr_number}"
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error replying to PR comment: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error replying to PR comment: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(
+            f"Unexpected error replying to comment #{comment_id} on PR #{pr_number}: {e}",
+            exc_info=True,
+        )
+        return f"❌ Error replying to comment: {str(e)}"
+
+
 async def github_close_pr(repo_owner: str, repo_name: str, pr_number: int) -> str:
     """Close a pull request."""
     logger.debug(f"🚀 Closing PR #{pr_number} in {repo_owner}/{repo_name}")

--- a/src/mcp_server_git/github/models.py
+++ b/src/mcp_server_git/github/models.py
@@ -342,6 +342,32 @@ class GitHubAddPRComment(BaseModel):
     body: str
 
 
+class GitHubGetPRComments(BaseModel):
+    """Retrieve top-level conversation comments on a PR."""
+
+    repo_owner: str
+    repo_name: str
+    pr_number: int
+
+
+class GitHubGetPRReviews(BaseModel):
+    """Retrieve inline code review comments on a PR."""
+
+    repo_owner: str
+    repo_name: str
+    pr_number: int
+
+
+class GitHubReplyToPRComment(BaseModel):
+    """Reply to a specific review comment thread."""
+
+    repo_owner: str
+    repo_name: str
+    pr_number: int
+    comment_id: int
+    body: str
+
+
 class GitHubClosePR(BaseModel):
     repo_owner: str
     repo_name: str

--- a/src/mcp_server_git/lean/tool_registry.py
+++ b/src/mcp_server_git/lean/tool_registry.py
@@ -653,6 +653,53 @@ def _register_github_tools(interface: Any, github_service: Any):
             complexity="focused",
         ),
         ToolDefinition(
+            name="github_get_pr_comments",
+            implementation=github_ops.github_get_pr_comments,
+            description="Get top-level conversation comments on a pull request",
+            schema={
+                "type": "object",
+                "properties": {
+                    "repo_owner": {"type": "string"},
+                    "repo_name": {"type": "string"},
+                    "pr_number": {"type": "integer"},
+                },
+            },
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_get_pr_reviews",
+            implementation=github_ops.github_get_pr_reviews,
+            description="Get inline code review comments on a pull request",
+            schema={
+                "type": "object",
+                "properties": {
+                    "repo_owner": {"type": "string"},
+                    "repo_name": {"type": "string"},
+                    "pr_number": {"type": "integer"},
+                },
+            },
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="github_reply_to_pr_comment",
+            implementation=github_ops.github_reply_to_pr_comment,
+            description="Reply to a specific review comment thread on a pull request",
+            schema={
+                "type": "object",
+                "properties": {
+                    "repo_owner": {"type": "string"},
+                    "repo_name": {"type": "string"},
+                    "pr_number": {"type": "integer"},
+                    "comment_id": {"type": "integer"},
+                    "body": {"type": "string"},
+                },
+            },
+            domain="github",
+            complexity="focused",
+        ),
+        ToolDefinition(
             name="github_close_pr",
             implementation=github_ops.github_close_pr,
             description="Close a pull request",


### PR DESCRIPTION
## Summary
Adds three new GitHub tools for PR review comment workflows:

- **`github_get_pr_comments`** — retrieve top-level conversation comments on a PR
- **`github_get_pr_reviews`** — retrieve inline code review comments (path, line, thread info)
- **`github_reply_to_pr_comment`** — reply to a specific review comment thread

Closes #137

## Motivation
The server supports writing PR comments (`github_add_pr_comment`) but had no tools for reading review feedback. This prevented automated code review workflows from analyzing reviewer comments programmatically.

## Test plan
- [x] Existing lean tests pass
- [x] Lint/format clean
- [ ] Live test: fetch comments from an active PR
- [ ] Live test: fetch review comments from a reviewed PR
- [ ] Live test: reply to a review comment thread