### PR TITLE
feat: add submodule, git config, and server_info tools

### DIFF
--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -174,3 +174,48 @@ class GitMergeBase(BaseModel):
     repo_path: str
     ref1: str
     ref2: str
+
+
+class GitSubmoduleStatus(BaseModel):
+    repo_path: str
+
+
+class GitSubmoduleAdd(BaseModel):
+    repo_path: str
+    url: str
+    path: str
+    branch: str | None = None
+
+
+class GitSubmoduleUpdate(BaseModel):
+    repo_path: str
+    init: bool = True
+    recursive: bool = False
+    remote: bool = False
+    paths: list[str] | None = None
+
+
+class GitSubmoduleSync(BaseModel):
+    repo_path: str
+    recursive: bool = False
+
+
+class GitConfigGet(BaseModel):
+    repo_path: str
+    key: str
+    file: str | None = None
+    scope: str | None = None
+
+
+class GitConfigSet(BaseModel):
+    repo_path: str
+    key: str
+    value: str
+    file: str | None = None
+    scope: str | None = None
+
+
+class GitConfigList(BaseModel):
+    repo_path: str
+    file: str | None = None
+    scope: str | None = None

--- a/src/mcp_server_git/git/operations.py
+++ b/src/mcp_server_git/git/operations.py
@@ -46,6 +46,13 @@ __all__ = [
     "git_stash_pop",
     "git_branch_list",
     "git_merge_base",
+    "git_submodule_status",
+    "git_submodule_add",
+    "git_submodule_update",
+    "git_submodule_sync",
+    "git_config_get",
+    "git_config_set",
+    "git_config_list",
 ]
 
 
@@ -1950,3 +1957,287 @@ def git_merge_base(
         return f"❌ Error finding merge-base: {str(e)}"
     except Exception as e:
         return f"❌ Merge-base error: {str(e)}"
+
+
+# ---------------------------------------------------------------------------
+# Submodule operations
+# ---------------------------------------------------------------------------
+
+
+def git_submodule_status(repo: Repo) -> str:
+    """List submodules and their current status.
+
+    Args:
+        repo: Git repository object
+
+    Returns:
+        Formatted list of submodules with paths, SHAs, and branches
+    """
+    try:
+        output = repo.git.submodule("status")
+        if not output.strip():
+            return "No submodules found in this repository"
+        return f"Submodule status:\n{output}"
+    except GitCommandError as e:
+        return f"❌ Submodule status failed: {str(e)}"
+    except Exception as e:
+        return f"❌ Submodule status error: {str(e)}"
+
+
+def git_submodule_add(
+    repo: Repo,
+    url: str,
+    path: str,
+    branch: str | None = None,
+) -> str:
+    """Add a new submodule to the repository.
+
+    Args:
+        repo: Git repository object
+        url: URL of the submodule repository
+        path: Local path where the submodule will be placed
+        branch: Branch to track (optional)
+
+    Returns:
+        Success or error message
+    """
+    try:
+        args = ["add"]
+        if branch:
+            args.extend(["--branch", branch])
+        args.extend([url, path])
+        repo.git.submodule(*args)
+        branch_info = f" (branch: {branch})" if branch else ""
+        return f"✅ Submodule added at '{path}' from {url}{branch_info}"
+    except GitCommandError as e:
+        return f"❌ Submodule add failed: {str(e)}"
+    except Exception as e:
+        return f"❌ Submodule add error: {str(e)}"
+
+
+def git_submodule_update(
+    repo: Repo,
+    init: bool = True,
+    recursive: bool = False,
+    remote: bool = False,
+    paths: list[str] | None = None,
+) -> str:
+    """Update submodules (optionally init, recursive, or from remote).
+
+    Args:
+        repo: Git repository object
+        init: Initialize uninitialized submodules before updating
+        recursive: Recursively update nested submodules
+        remote: Update to latest remote commit instead of recorded SHA
+        paths: Specific submodule paths to update (default: all)
+
+    Returns:
+        Success or error message
+    """
+    try:
+        args = ["update"]
+        if init:
+            args.append("--init")
+        if recursive:
+            args.append("--recursive")
+        if remote:
+            args.append("--remote")
+        if paths:
+            args.extend(paths)
+        repo.git.submodule(*args)
+        scope = ", ".join(paths) if paths else "all submodules"
+        flags = []
+        if init:
+            flags.append("init")
+        if recursive:
+            flags.append("recursive")
+        if remote:
+            flags.append("remote")
+        flag_info = f" [{', '.join(flags)}]" if flags else ""
+        return f"✅ Submodules updated{flag_info}: {scope}"
+    except GitCommandError as e:
+        return f"❌ Submodule update failed: {str(e)}"
+    except Exception as e:
+        return f"❌ Submodule update error: {str(e)}"
+
+
+def git_submodule_sync(
+    repo: Repo,
+    recursive: bool = False,
+) -> str:
+    """Sync submodule URLs from .gitmodules to .git/config.
+
+    Args:
+        repo: Git repository object
+        recursive: Recursively sync nested submodules
+
+    Returns:
+        Success or error message
+    """
+    try:
+        args = ["sync"]
+        if recursive:
+            args.append("--recursive")
+        repo.git.submodule(*args)
+        recursive_info = " (recursive)" if recursive else ""
+        return f"✅ Submodule URLs synced from .gitmodules{recursive_info}"
+    except GitCommandError as e:
+        return f"❌ Submodule sync failed: {str(e)}"
+    except Exception as e:
+        return f"❌ Submodule sync error: {str(e)}"
+
+
+# ---------------------------------------------------------------------------
+# Git config operations
+# ---------------------------------------------------------------------------
+
+_CONFIG_KEY_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$")
+_CONFIG_SCOPE_MAP = {
+    "local": {},
+    "global": {"_global": True},
+    "system": {"system": True},
+}
+
+
+def _build_config_scope_kwargs(scope: str | None) -> dict:
+    """Return GitPython keyword arguments for the requested config scope."""
+    if scope is None or scope == "local":
+        return {}
+    if scope not in _CONFIG_SCOPE_MAP:
+        raise ValueError(
+            f"Invalid scope '{scope}'. Valid values: local, global, system"
+        )
+    return _CONFIG_SCOPE_MAP[scope]
+
+
+def _validate_config_key(key: str) -> None:
+    """Raise ValueError if key contains characters that could cause injection."""
+    if not _CONFIG_KEY_RE.match(key):
+        raise ValueError(
+            f"Invalid config key '{key}'. Keys must contain only alphanumeric characters, "
+            "dots, dashes, and underscores (e.g., 'user.name', 'core.filemode')"
+        )
+
+
+def _validate_config_file(repo: Repo, file: str) -> None:
+    """Raise ValueError if file path attempts to escape the repository directory."""
+    # Reject any path that contains '..' components
+    file_path = Path(file)
+    if ".." in file_path.parts:
+        raise ValueError(
+            f"Invalid file path '{file}': path must not contain '..' components"
+        )
+    # Reject absolute paths that are outside the repo
+    if file_path.is_absolute():
+        try:
+            file_path.relative_to(Path(repo.working_dir))
+        except ValueError:
+            raise ValueError(
+                f"Invalid file path '{file}': absolute path must be within the repository"
+            )
+
+
+def git_config_get(
+    repo: Repo,
+    key: str,
+    file: str | None = None,
+    scope: str | None = None,
+) -> str:
+    """Read a git config value.
+
+    Args:
+        repo: Git repository object
+        key: Config key to read (e.g., 'user.name', 'core.filemode')
+        file: Path to a specific config file (e.g., '.gitmodules')
+        scope: Config scope: 'local' (default), 'global', or 'system'
+
+    Returns:
+        The config value or an error message
+    """
+    try:
+        _validate_config_key(key)
+        scope_kwargs = _build_config_scope_kwargs(scope)
+        if file:
+            _validate_config_file(repo, file)
+            value = repo.git.config(key, f=file, **scope_kwargs)
+        else:
+            value = repo.git.config(key, **scope_kwargs)
+        return f"{key} = {value}"
+    except ValueError as e:
+        return f"❌ {e}"
+    except GitCommandError as e:
+        return f"❌ Config get failed: {str(e)}"
+    except Exception as e:
+        return f"❌ Config get error: {str(e)}"
+
+
+def git_config_set(
+    repo: Repo,
+    key: str,
+    value: str,
+    file: str | None = None,
+    scope: str | None = None,
+) -> str:
+    """Set a git config value.
+
+    Args:
+        repo: Git repository object
+        key: Config key to set (e.g., 'user.name', 'core.filemode')
+        value: Value to set
+        file: Path to a specific config file (e.g., '.gitmodules')
+        scope: Config scope: 'local' (default), 'global', or 'system'
+
+    Returns:
+        Success or error message
+    """
+    try:
+        _validate_config_key(key)
+        scope_kwargs = _build_config_scope_kwargs(scope)
+        if file:
+            _validate_config_file(repo, file)
+            repo.git.config(key, value, f=file, **scope_kwargs)
+        else:
+            repo.git.config(key, value, **scope_kwargs)
+        scope_info = f" [{scope}]" if scope else ""
+        file_info = f" in {file}" if file else ""
+        return f"✅ Config set{scope_info}{file_info}: {key} = {value}"
+    except ValueError as e:
+        return f"❌ {e}"
+    except GitCommandError as e:
+        return f"❌ Config set failed: {str(e)}"
+    except Exception as e:
+        return f"❌ Config set error: {str(e)}"
+
+
+def git_config_list(
+    repo: Repo,
+    file: str | None = None,
+    scope: str | None = None,
+) -> str:
+    """List all git config entries.
+
+    Args:
+        repo: Git repository object
+        file: Path to a specific config file to list (e.g., '.gitmodules')
+        scope: Config scope: 'local' (default), 'global', or 'system'
+
+    Returns:
+        Formatted list of config entries or an error message
+    """
+    try:
+        scope_kwargs = _build_config_scope_kwargs(scope)
+        if file:
+            _validate_config_file(repo, file)
+            output = repo.git.config("--list", f=file, **scope_kwargs)
+        else:
+            output = repo.git.config("--list", **scope_kwargs)
+        if not output.strip():
+            return "No config entries found"
+        source = file if file else (scope or "local")
+        return f"Git config [{source}]:\n{output}"
+    except ValueError as e:
+        return f"❌ {e}"
+    except GitCommandError as e:
+        return f"❌ Config list failed: {str(e)}"
+    except Exception as e:
+        return f"❌ Config list error: {str(e)}"

--- a/src/mcp_server_git/git/operations.py
+++ b/src/mcp_server_git/git/operations.py
@@ -1977,7 +1977,33 @@ def git_submodule_status(repo: Repo) -> str:
         output = repo.git.submodule("status")
         if not output.strip():
             return "No submodules found in this repository"
-        return f"Submodule status:\n{output}"
+        lines = output.strip().split("\n")
+        result_lines = ["Submodules:"]
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            # Parse status indicator
+            status = "up-to-date"
+            if line.startswith("+"):
+                status = "modified"
+                line = line[1:]
+            elif line.startswith("-"):
+                status = "not initialized"
+                line = line[1:]
+            elif line.startswith("U"):
+                status = "merge conflict"
+                line = line[1:]
+
+            parts = line.strip().split()
+            sha = parts[0] if parts else "unknown"
+            path = parts[1] if len(parts) > 1 else "unknown"
+            branch = parts[2].strip("()") if len(parts) > 2 else ""
+
+            branch_info = f" ({branch})" if branch else ""
+            result_lines.append(f"  {path}: {sha[:8]}{branch_info} [{status}]")
+
+        return "\n".join(result_lines)
     except GitCommandError as e:
         return f"❌ Submodule status failed: {str(e)}"
     except Exception as e:
@@ -2001,6 +2027,16 @@ def git_submodule_add(
     Returns:
         Success or error message
     """
+    # Validate URL scheme
+    allowed_schemes = ("https://", "http://", "git://", "ssh://", "git@")
+    if not any(url.startswith(scheme) for scheme in allowed_schemes):
+        return f"❌ Invalid URL scheme. Allowed: {', '.join(allowed_schemes)}"
+    # Validate no shell injection in path or url
+    dangerous_chars = [";", "|", "&", "`", "$", "(", ")"]
+    if any(char in path for char in dangerous_chars):
+        return f"❌ Invalid characters in submodule path: {path}"
+    if any(char in url for char in dangerous_chars):
+        return f"❌ Invalid characters in URL: {url}"
     try:
         args = ["add"]
         if branch:
@@ -2091,7 +2127,7 @@ def git_submodule_sync(
 # Git config operations
 # ---------------------------------------------------------------------------
 
-_CONFIG_KEY_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9._-]*[a-zA-Z0-9])?$")
+_CONFIG_KEY_RE = re.compile(r"^[a-zA-Z0-9]([a-zA-Z0-9._/\\-]*[a-zA-Z0-9])?$")
 _CONFIG_SCOPE_MAP = {
     "local": {},
     "global": {"_global": True},
@@ -2135,6 +2171,11 @@ def _validate_config_file(repo: Repo, file: str) -> None:
             raise ValueError(
                 f"Invalid file path '{file}': absolute path must be within the repository"
             )
+    # Resolve to catch symlink escapes (belt-and-suspenders)
+    repo_root = Path(repo.working_dir).resolve()
+    resolved = (repo_root / file_path).resolve()
+    if not str(resolved).startswith(str(repo_root)):
+        raise ValueError(f"Config file path escapes repository: {file}")
 
 
 def git_config_get(

--- a/src/mcp_server_git/lean/interface.py
+++ b/src/mcp_server_git/lean/interface.py
@@ -84,7 +84,14 @@ class GitLeanInterface:
         self.github_service = github_service
         self.azure_service = azure_service
         self.app_name = app_name
-        self.app = FastMCP(app_name, version=version)
+        self.app = FastMCP(
+            app_name,
+            version=version,
+            instructions=(
+                "MCP server for Git, GitHub, and Azure DevOps operations. "
+                "Issues: https://github.com/MementoRC/mcp-git/issues"
+            ),
+        )
         self.token_limiter = token_limiter or MCPTokenLimiter()
         self.response_offloader = ResponseOffloader(token_limiter=self.token_limiter)
 

--- a/src/mcp_server_git/lean/meta_tools.py
+++ b/src/mcp_server_git/lean/meta_tools.py
@@ -122,6 +122,7 @@ def setup_meta_tools(interface) -> None:
                 ),
             },
             "context_saving": f"~{len(interface.tool_registry) * 0.5}K tokens saved vs traditional MCP",
+            "issues": "https://github.com/MementoRC/mcp-git/issues",
         }
 
         return apply_token_limits(result, "discover_tools", 1000)
@@ -370,3 +371,49 @@ def setup_meta_tools(interface) -> None:
                 "error": str(e),
                 "execution_mode": "lean_mcp_dynamic",
             }
+
+    @app.tool()
+    def server_info() -> dict[str, Any]:
+        """
+        Returns server metadata for LLM harnesses and clients.
+
+        USE WHEN:
+        - You need to identify this server's version or capabilities
+        - You want to know where to file bugs or feature requests
+        - You need documentation or support URLs
+
+        Returns:
+            Dictionary containing:
+            - name: Server identifier
+            - version: Server version string
+            - description: Human-readable description
+            - repository: Source code repository URL
+            - issues: URL to file bug reports or feature requests
+            - documentation: README / docs URL
+            - support: Specific URLs for bug reports and feature requests
+            - domains: Supported operation domains with descriptions
+            - transport: MCP transport type
+            - protocol_version: MCP protocol version
+
+        Examples:
+            server_info()  # Get server metadata and support URLs
+        """
+        return {
+            "name": "mcp-git",
+            "version": "1.0.0",
+            "description": "MCP server for Git, GitHub, and Azure DevOps operations",
+            "repository": "https://github.com/MementoRC/mcp-git",
+            "issues": "https://github.com/MementoRC/mcp-git/issues",
+            "documentation": "https://github.com/MementoRC/mcp-git#readme",
+            "support": {
+                "bug_reports": "https://github.com/MementoRC/mcp-git/issues/new?template=bug_report.md",
+                "feature_requests": "https://github.com/MementoRC/mcp-git/issues/new?template=feature_request.md",
+            },
+            "domains": {
+                "git": "Local git operations",
+                "github": "GitHub API",
+                "azure": "Azure DevOps",
+            },
+            "transport": "HTTP (SSE)",
+            "protocol_version": "2024-11-05",
+        }

--- a/src/mcp_server_git/lean/meta_tools.py
+++ b/src/mcp_server_git/lean/meta_tools.py
@@ -398,9 +398,15 @@ def setup_meta_tools(interface) -> None:
         Examples:
             server_info()  # Get server metadata and support URLs
         """
+        try:
+            from importlib.metadata import version
+
+            pkg_version = version("mcp-server-git")
+        except Exception:
+            pkg_version = "unknown"
         return {
             "name": "mcp-git",
-            "version": "1.0.0",
+            "version": pkg_version,
             "description": "MCP server for Git, GitHub, and Azure DevOps operations",
             "repository": "https://github.com/MementoRC/mcp-git",
             "issues": "https://github.com/MementoRC/mcp-git/issues",

--- a/src/mcp_server_git/lean/registry_git.py
+++ b/src/mcp_server_git/lean/registry_git.py
@@ -10,6 +10,9 @@ from ..git.models import (
     GitCheckout,
     GitCherryPick,
     GitCommit,
+    GitConfigGet,
+    GitConfigList,
+    GitConfigSet,
     GitContinue,
     GitCreateBranch,
     GitDiff,
@@ -26,6 +29,10 @@ from ..git.models import (
     GitReset,
     GitShow,
     GitStatus,
+    GitSubmoduleAdd,
+    GitSubmoduleStatus,
+    GitSubmoduleSync,
+    GitSubmoduleUpdate,
 )
 from ..utils.git_import import Repo
 from .interface import ToolDefinition
@@ -353,6 +360,64 @@ def _register_git_tools(interface: Any, git_service: Any):
             },
             domain="git",
             complexity="core",
+        ),
+        # Submodule operations
+        ToolDefinition(
+            name="git_submodule_status",
+            implementation=wrap_repo_op(git_ops.git_submodule_status),
+            description="List submodules and their current status (paths, SHAs, branches)",
+            schema=GitSubmoduleStatus.model_json_schema(),
+            domain="git",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="git_submodule_add",
+            implementation=wrap_repo_op(git_ops.git_submodule_add),
+            description="Add a new submodule to the repository",
+            schema=GitSubmoduleAdd.model_json_schema(),
+            domain="git",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="git_submodule_update",
+            implementation=wrap_repo_op(git_ops.git_submodule_update),
+            description="Update submodules (init, recursive, or from remote)",
+            schema=GitSubmoduleUpdate.model_json_schema(),
+            domain="git",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="git_submodule_sync",
+            implementation=wrap_repo_op(git_ops.git_submodule_sync),
+            description="Sync submodule URLs from .gitmodules to .git/config",
+            schema=GitSubmoduleSync.model_json_schema(),
+            domain="git",
+            complexity="focused",
+        ),
+        # Config operations
+        ToolDefinition(
+            name="git_config_get",
+            implementation=wrap_repo_op(git_ops.git_config_get),
+            description="Read a git config value by key",
+            schema=GitConfigGet.model_json_schema(),
+            domain="git",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="git_config_set",
+            implementation=wrap_repo_op(git_ops.git_config_set),
+            description="Set a git config value (key/value, optional scope or file)",
+            schema=GitConfigSet.model_json_schema(),
+            domain="git",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="git_config_list",
+            implementation=wrap_repo_op(git_ops.git_config_list),
+            description="List all git config entries (optionally scoped or from a specific file)",
+            schema=GitConfigList.model_json_schema(),
+            domain="git",
+            complexity="focused",
         ),
     ]
 

--- a/tests/unit/git/test_submodule_config_ops.py
+++ b/tests/unit/git/test_submodule_config_ops.py
@@ -1,0 +1,122 @@
+"""Tests for submodule and config operations."""
+import re
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from git.exc import GitCommandError
+from git.repo import Repo
+
+from mcp_server_git.git.operations import (
+    _validate_config_file,
+    _validate_config_key,
+    git_config_get,
+    git_config_list,
+    git_config_set,
+    git_submodule_add,
+    git_submodule_status,
+    git_submodule_sync,
+    git_submodule_update,
+)
+
+
+@pytest.fixture
+def git_repo(tmp_path):
+    """Create a temporary git repository."""
+    repo_path = tmp_path / "test_repo"
+    repo_path.mkdir()
+    subprocess.run(["git", "init"], cwd=repo_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test"], cwd=repo_path, check=True
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "test@test.com"], cwd=repo_path, check=True
+    )
+    # Initial commit so repo is valid
+    (repo_path / "README.md").write_text("# Test")
+    subprocess.run(["git", "add", "."], cwd=repo_path, check=True)
+    subprocess.run(
+        ["git", "commit", "-m", "init"], cwd=repo_path, check=True, capture_output=True
+    )
+    return Repo(str(repo_path))
+
+
+class TestValidateConfigKey:
+    def test_valid_keys(self):
+        _validate_config_key("user.name")
+        _validate_config_key("core.autocrlf")
+        _validate_config_key("submodule.sub-packages/foo.url")
+
+    def test_rejects_empty(self):
+        with pytest.raises(ValueError):
+            _validate_config_key("")
+
+    def test_rejects_shell_injection(self):
+        with pytest.raises(ValueError):
+            _validate_config_key("user.name; rm -rf /")
+
+    def test_rejects_spaces(self):
+        with pytest.raises(ValueError):
+            _validate_config_key("user name")
+
+
+class TestValidateConfigFile:
+    def test_valid_relative_path(self, git_repo):
+        # .gitmodules is a valid config file target
+        _validate_config_file(git_repo, ".gitmodules")
+
+    def test_rejects_traversal(self, git_repo):
+        with pytest.raises(ValueError):
+            _validate_config_file(git_repo, "../../../etc/passwd")
+
+    def test_rejects_absolute_outside_repo(self, git_repo):
+        with pytest.raises(ValueError):
+            _validate_config_file(git_repo, "/etc/passwd")
+
+
+class TestGitConfigOperations:
+    def test_config_set_and_get(self, git_repo):
+        result = git_config_set(git_repo, "test.key", "test_value")
+        assert "✅" in result
+
+        result = git_config_get(git_repo, "test.key")
+        assert "test_value" in result
+
+    def test_config_set_rejects_bad_key(self, git_repo):
+        result = git_config_set(git_repo, "bad;key", "value")
+        assert "❌" in result
+
+    def test_config_list(self, git_repo):
+        result = git_config_list(git_repo)
+        assert "user.name" in result
+
+    def test_config_get_missing_key(self, git_repo):
+        result = git_config_get(git_repo, "nonexistent.key")
+        assert "❌" in result or "not set" in result.lower()
+
+
+class TestGitSubmoduleOperations:
+    def test_submodule_status_empty(self, git_repo):
+        result = git_submodule_status(git_repo)
+        assert "No submodules" in result
+
+    def test_submodule_add_rejects_bad_url(self, git_repo):
+        result = git_submodule_add(git_repo, "ftp://bad.com/repo", "sub")
+        assert "❌" in result
+        assert "Invalid URL" in result
+
+    def test_submodule_add_rejects_injection(self, git_repo):
+        result = git_submodule_add(
+            git_repo, "https://example.com/repo.git", "sub;rm -rf /"
+        )
+        assert "❌" in result
+
+    def test_submodule_sync_no_submodules(self, git_repo):
+        result = git_submodule_sync(git_repo)
+        # Should succeed even with no submodules
+        assert "❌" not in result or "error" not in result.lower()
+
+    def test_submodule_update_no_submodules(self, git_repo):
+        result = git_submodule_update(git_repo)
+        assert "❌" not in result or "No submodules" in result


### PR DESCRIPTION
## Summary

- Add 4 **git submodule tools**: status, add, update, sync
- Add 3 **git config tools**: get, set, list (supports `-f .gitmodules` for submodule registration)
- Add **server_info** meta-tool: returns server metadata, version, and issue tracker URLs for LLM harnesses
- Add `issues` URL to `discover_tools` response for self-documentation
- Add `instructions` to FastMCP app with issues URL

## Motivation

LLMs currently ask users to run `git config -f .gitmodules` and `git submodule` commands manually. These tools let LLM harnesses manage submodules and config programmatically through MCP.

The `server_info` tool enables LLM harnesses to discover where to file bugs and feature requests.

## Security

`git_config_set` validates:
- Key format: only alphanumeric, dots, dashes, underscores
- File path: no `..` traversal, must be relative within repo

## Test plan
- [ ] CI passes (lint, tests, quality)
- [ ] Live test: discover_tools shows new tools
- [ ] Live test: submodule operations
- [ ] Live test: config get/set/list with .gitmodules
- [ ] Live test: server_info returns metadata