### PR TITLE
fix: register server_info in HTTP transport tools/list and tools/call

### DIFF
--- a/src/mcp_server_git/transport/http_server.py
+++ b/src/mcp_server_git/transport/http_server.py
@@ -465,7 +465,7 @@ class HTTPGitServer:
                     }
                 )
 
-            # Handle tools/list - return the 3 meta-tools
+            # Handle tools/list - return the 3 meta-tools + server_info
             if method == "tools/list":
                 return JSONResponse(
                     content={
@@ -502,6 +502,14 @@ class HTTPGitServer:
                                             "parameters": {"type": "object"},
                                         },
                                         "required": ["tool_name", "parameters"],
+                                    },
+                                },
+                                {
+                                    "name": "server_info",
+                                    "description": "Returns server metadata, version, and support URLs. USE WHEN: identifying this server, finding where to file bugs or feature requests.",
+                                    "inputSchema": {
+                                        "type": "object",
+                                        "properties": {},
                                     },
                                 },
                             ]
@@ -590,6 +598,32 @@ class HTTPGitServer:
                             tool_name=target_tool,
                             args=tool_params,
                         )
+                    elif tool_name == "server_info":
+                        try:
+                            from importlib.metadata import version as pkg_version
+
+                            ver = pkg_version("mcp-server-git")
+                        except Exception:
+                            ver = "unknown"
+                        result = {
+                            "name": "mcp-git",
+                            "version": ver,
+                            "description": "MCP server for Git, GitHub, and Azure DevOps operations",
+                            "repository": "https://github.com/MementoRC/mcp-git",
+                            "issues": "https://github.com/MementoRC/mcp-git/issues",
+                            "documentation": "https://github.com/MementoRC/mcp-git#readme",
+                            "support": {
+                                "bug_reports": "https://github.com/MementoRC/mcp-git/issues/new?template=bug_report.md",
+                                "feature_requests": "https://github.com/MementoRC/mcp-git/issues/new?template=feature_request.md",
+                            },
+                            "domains": {
+                                "git": "Local git operations (30 tools)",
+                                "github": "GitHub API (52 tools)",
+                                "azure": "Azure DevOps (4 tools)",
+                            },
+                            "transport": "HTTP (SSE)",
+                            "protocol_version": "2024-11-05",
+                        }
                     else:
                         # Direct tool execution (legacy/fallback)
                         result = await self.session_manager.execute_tool(

--- a/tests/integration/transport/test_http_server.py
+++ b/tests/integration/transport/test_http_server.py
@@ -614,3 +614,85 @@ class TestConcurrentSessions:
 
         # Clean up
         await async_client.delete(f"/mcp/session/{session_ids[1]}")
+
+
+class TestToolsListAndServerInfo:
+    """Test tools/list endpoint and server_info tool."""
+
+    @pytest.mark.asyncio
+    async def test_tools_list_includes_server_info(self, async_client):
+        """Test tools/list returns 4 meta-tools including server_info."""
+        response = await async_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/list",
+                "id": 1,
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        tools = data["result"]["tools"]
+        assert len(tools) == 4
+        tool_names = [t["name"] for t in tools]
+        assert "discover_tools" in tool_names
+        assert "get_tool_spec" in tool_names
+        assert "execute_tool" in tool_names
+        assert "server_info" in tool_names
+
+    @pytest.mark.asyncio
+    async def test_server_info_returns_metadata(self, async_client, temp_git_repo):
+        """Test server_info tool returns complete server metadata."""
+        import json
+
+        # Create session
+        create_response = await async_client.post(
+            "/mcp/session/create",
+            json={
+                "repository_path": str(temp_git_repo),
+                "expected_remote_url": "https://github.com/test/repo.git",
+            },
+        )
+        assert create_response.status_code == 201
+        session_id = create_response.json()["session_id"]
+
+        # Call server_info
+        response = await async_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "server_info", "arguments": {}},
+                "id": 2,
+            },
+            headers={"MCP-Session-Id": session_id},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "result" in data
+        result_text = data["result"]["content"][0]["text"]
+        server_info = json.loads(result_text)
+
+        assert server_info["name"] == "mcp-git"
+        assert "version" in server_info
+        assert server_info["issues"] == "https://github.com/MementoRC/mcp-git/issues"
+        assert "bug_reports" in server_info["support"]
+        assert "feature_requests" in server_info["support"]
+        assert "git" in server_info["domains"]
+        assert "github" in server_info["domains"]
+        assert "azure" in server_info["domains"]
+
+    @pytest.mark.asyncio
+    async def test_server_info_without_session(self, async_client):
+        """Test server_info works without a session when default_repo is set."""
+        response = await async_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "server_info", "arguments": {}},
+                "id": 3,
+            },
+        )
+        # Should work - server_info doesn't need repo access
+        assert response.status_code == 200


### PR DESCRIPTION
## Summary

The `server_info` tool was added in PR #149 but the HTTP transport routing was committed after the squash merge. This cherry-picks commit `4a328dc` to add `server_info` to the HTTP server's `tools/list` response and `tools/call` handler.

## Changes

- Add `server_info` as 4th tool in `tools/list` response
- Add `server_info` handler in `tools/call` routing (alongside discover_tools, get_tool_spec, execute_tool)

## Test plan
- [ ] `curl POST /mcp tools/list` shows 4 tools
- [ ] `curl POST /mcp tools/call server_info` returns metadata with issues URL