### PR TITLE
feat: add git tools and fix issue bug (#151-#155)

### DIFF
--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -244,3 +244,9 @@ class GitWorktreeRemove(BaseModel):
     repo_path: str
     worktree_path: str = Field(description="Path of worktree to remove")
     force: bool = Field(default=False, description="Force removal even with modifications")
+
+
+class GitMergeTree(BaseModel):
+    repo_path: str
+    branch1: str = Field(description="First branch (typically current)")
+    branch2: str = Field(description="Second branch (typically incoming)")

--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -226,3 +226,11 @@ class GitRestore(BaseModel):
     files: list[str] = Field(description="Files to restore")
     staged: bool = Field(default=False, description="Unstage files (git restore --staged)")
     source: str | None = Field(default=None, description="Restore from specific commit/ref (git restore --source)")
+
+
+class GitBranchUpdate(BaseModel):
+    repo_path: str
+    branch_name: str = Field(description="Branch to update or delete")
+    target: str | None = Field(default=None, description="Target ref for force-update (git branch -f <name> <target>)")
+    delete: bool = Field(default=False, description="Delete the branch")
+    force: bool = Field(default=False, description="Force delete even if not merged (git branch -D)")

--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -234,3 +234,13 @@ class GitBranchUpdate(BaseModel):
     target: str | None = Field(default=None, description="Target ref for force-update (git branch -f <name> <target>)")
     delete: bool = Field(default=False, description="Delete the branch")
     force: bool = Field(default=False, description="Force delete even if not merged (git branch -D)")
+
+
+class GitWorktreeList(BaseModel):
+    repo_path: str
+
+
+class GitWorktreeRemove(BaseModel):
+    repo_path: str
+    worktree_path: str = Field(description="Path of worktree to remove")
+    force: bool = Field(default=False, description="Force removal even with modifications")

--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -219,3 +219,10 @@ class GitConfigList(BaseModel):
     repo_path: str
     file: str | None = None
     scope: str | None = None
+
+
+class GitRestore(BaseModel):
+    repo_path: str
+    files: list[str] = Field(description="Files to restore")
+    staged: bool = Field(default=False, description="Unstage files (git restore --staged)")
+    source: str | None = Field(default=None, description="Restore from specific commit/ref (git restore --source)")

--- a/src/mcp_server_git/git/operations_extended.py
+++ b/src/mcp_server_git/git/operations_extended.py
@@ -17,6 +17,7 @@ __all__ = [
     "git_branch_update",
     "git_worktree_list",
     "git_worktree_remove",
+    "git_merge_tree",
 ]
 
 
@@ -166,3 +167,41 @@ def git_worktree_remove(
         return f"❌ Failed to remove worktree: {stderr}"
     except Exception as e:
         return f"❌ Error removing worktree: {str(e)}"
+
+
+def git_merge_tree(
+    repo: Repo,
+    branch1: str,
+    branch2: str,
+) -> str:
+    """Simulate a merge without modifying working tree (dry-run conflict detection).
+
+    Uses `git merge-tree --write-tree` (Git 2.38+) for three-way merge simulation.
+    """
+    error = _validate_ref(branch1, "branch1")
+    if error:
+        return error
+    error = _validate_ref(branch2, "branch2")
+    if error:
+        return error
+
+    try:
+        output = repo.git.merge_tree("--write-tree", branch1, branch2)
+        return f"✅ Clean merge: {branch1} + {branch2} → no conflicts\n{output}"
+
+    except GitCommandError as e:
+        stdout = e.stdout.decode() if isinstance(e.stdout, bytes) else (e.stdout or "")
+        stderr = e.stderr.decode() if isinstance(e.stderr, bytes) else (e.stderr or "")
+
+        # Exit code 1 = conflicts detected (expected behavior, not an error)
+        if e.status == 1:
+            conflicts = [line for line in stdout.split("\n") if "CONFLICT" in line]
+            if conflicts:
+                conflict_list = "\n".join(f"  - {c}" for c in conflicts)
+                return f"⚠️ Conflicts detected merging {branch1} + {branch2}:\n{conflict_list}"
+            return f"⚠️ Conflicts detected merging {branch1} + {branch2}\n{stdout}"
+
+        return f"❌ Merge-tree failed: {stderr or stdout}"
+
+    except Exception as e:
+        return f"❌ Error during merge-tree: {str(e)}"

--- a/src/mcp_server_git/git/operations_extended.py
+++ b/src/mcp_server_git/git/operations_extended.py
@@ -15,6 +15,8 @@ DANGEROUS_CHARS = re.compile(r"[;&|`$()]")
 __all__ = [
     "git_restore",
     "git_branch_update",
+    "git_worktree_list",
+    "git_worktree_remove",
 ]
 
 
@@ -97,3 +99,70 @@ def git_branch_update(
         return f"❌ Branch update failed: {stderr}"
     except Exception as e:
         return f"❌ Error updating branch: {str(e)}"
+
+
+def git_worktree_list(repo: Repo) -> str:
+    """List all worktrees in the repository."""
+    try:
+        output = repo.git.worktree("list", "--porcelain")
+
+        if not output.strip():
+            return "No worktrees found"
+
+        worktrees = []
+        current = {}
+        for line in output.split("\n"):
+            if line.startswith("worktree "):
+                if current:
+                    worktrees.append(current)
+                current = {"path": line[9:]}
+            elif line.startswith("HEAD "):
+                current["head"] = line[5:13]  # Short SHA (8 chars)
+            elif line.startswith("branch "):
+                current["branch"] = line[7:].replace("refs/heads/", "")
+            elif line == "bare":
+                current["bare"] = True
+            elif line == "detached":
+                current["detached"] = True
+
+        if current:
+            worktrees.append(current)
+
+        lines = [f"Worktrees ({len(worktrees)}):"]
+        for wt in worktrees:
+            branch = wt.get("branch", "detached" if wt.get("detached") else "bare")
+            head = wt.get("head", "???")
+            lines.append(f"  {wt['path']} [{branch}] ({head})")
+
+        return "\n".join(lines)
+
+    except GitCommandError as e:
+        stderr = e.stderr.decode() if isinstance(e.stderr, bytes) else e.stderr
+        return f"❌ Failed to list worktrees: {stderr}"
+    except Exception as e:
+        return f"❌ Error listing worktrees: {str(e)}"
+
+
+def git_worktree_remove(
+    repo: Repo,
+    worktree_path: str,
+    force: bool = False,
+) -> str:
+    """Remove a worktree."""
+    if DANGEROUS_CHARS.search(worktree_path):
+        return f"❌ Invalid characters in worktree path: '{worktree_path}'"
+
+    try:
+        args = ["remove"]
+        if force:
+            args.append("--force")
+        args.append(worktree_path)
+
+        repo.git.worktree(*args)
+        return f"✅ Removed worktree: {worktree_path}"
+
+    except GitCommandError as e:
+        stderr = e.stderr.decode() if isinstance(e.stderr, bytes) else e.stderr
+        return f"❌ Failed to remove worktree: {stderr}"
+    except Exception as e:
+        return f"❌ Error removing worktree: {str(e)}"

--- a/src/mcp_server_git/git/operations_extended.py
+++ b/src/mcp_server_git/git/operations_extended.py
@@ -1,0 +1,60 @@
+"""Extended git operations for MCP Git Server.
+
+New tools added to avoid bloating operations.py (2284 lines, tracked in #139/#140).
+"""
+
+import logging
+import re
+
+from ..utils.git_import import GitCommandError, Repo
+
+logger = logging.getLogger(__name__)
+
+DANGEROUS_CHARS = re.compile(r"[;&|`$()]")
+
+__all__ = [
+    "git_restore",
+]
+
+
+def _validate_ref(ref: str, param_name: str) -> str | None:
+    """Validate a git ref for dangerous characters. Returns error string or None."""
+    if DANGEROUS_CHARS.search(ref):
+        return f"❌ Invalid characters detected in {param_name}: '{ref}'"
+    return None
+
+
+def git_restore(
+    repo: Repo,
+    files: list[str],
+    staged: bool = False,
+    source: str | None = None,
+) -> str:
+    """Restore working tree files or unstage files."""
+    if not files:
+        return "❌ No files specified to restore"
+
+    if source:
+        error = _validate_ref(source, "source")
+        if error:
+            return error
+
+    try:
+        args = []
+        if staged:
+            args.append("--staged")
+        if source:
+            args.extend(["--source", source])
+        args.extend(files)
+
+        repo.git.restore(*args)
+
+        mode = "unstaged" if staged else "restored"
+        file_list = ", ".join(files[:5])
+        suffix = f" (+{len(files) - 5} more)" if len(files) > 5 else ""
+        return f"✅ Restored {len(files)} file(s): {file_list}{suffix} ({mode})"
+
+    except GitCommandError as e:
+        return f"❌ Restore failed: {e.stderr.decode() if isinstance(e.stderr, bytes) else e.stderr}"
+    except Exception as e:
+        return f"❌ Error during restore: {str(e)}"

--- a/src/mcp_server_git/git/operations_extended.py
+++ b/src/mcp_server_git/git/operations_extended.py
@@ -14,6 +14,7 @@ DANGEROUS_CHARS = re.compile(r"[;&|`$()]")
 
 __all__ = [
     "git_restore",
+    "git_branch_update",
 ]
 
 
@@ -58,3 +59,41 @@ def git_restore(
         return f"❌ Restore failed: {e.stderr.decode() if isinstance(e.stderr, bytes) else e.stderr}"
     except Exception as e:
         return f"❌ Error during restore: {str(e)}"
+
+
+def git_branch_update(
+    repo: Repo,
+    branch_name: str,
+    target: str | None = None,
+    delete: bool = False,
+    force: bool = False,
+) -> str:
+    """Force-update a branch ref or delete a branch."""
+    error = _validate_ref(branch_name, "branch_name")
+    if error:
+        return error
+
+    if target and delete:
+        return "❌ Cannot specify both target and delete"
+    if not target and not delete:
+        return "❌ Must specify either target (force-update) or delete"
+
+    if target:
+        error = _validate_ref(target, "target")
+        if error:
+            return error
+
+    try:
+        if delete:
+            flag = "-D" if force else "-d"
+            repo.git.branch(flag, branch_name)
+            return f"✅ Deleted branch '{branch_name}'"
+        else:
+            repo.git.branch("-f", branch_name, target)
+            return f"✅ Updated branch '{branch_name}' → {target}"
+
+    except GitCommandError as e:
+        stderr = e.stderr.decode() if isinstance(e.stderr, bytes) else e.stderr
+        return f"❌ Branch update failed: {stderr}"
+    except Exception as e:
+        return f"❌ Error updating branch: {str(e)}"

--- a/src/mcp_server_git/lean/meta_tools.py
+++ b/src/mcp_server_git/lean/meta_tools.py
@@ -47,6 +47,9 @@ def _sanitize_json_string(s: str) -> str:
         content = content.replace("\n", "\\n")
         content = content.replace("\r", "\\r")
         content = content.replace("\t", "\\t")
+        # Cover remaining C0 controls that JSON forbids
+        content = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f]',
+                         lambda c: f'\\u{ord(c.group()):04x}', content)
         return f'"{content}"'
 
     # Match JSON string literals: opening quote, captured body, closing quote.
@@ -350,7 +353,7 @@ def setup_meta_tools(interface) -> None:
                 try:
                     sanitized = _sanitize_json_string(parameters)
                     parameters = json.loads(sanitized)
-                except (json.JSONDecodeError, Exception):
+                except json.JSONDecodeError:
                     return {
                         "tool": tool_name,
                         "status": "error",

--- a/src/mcp_server_git/lean/meta_tools.py
+++ b/src/mcp_server_git/lean/meta_tools.py
@@ -10,6 +10,7 @@ Provides the 3-meta-tool pattern implementations:
 import inspect
 import json
 import logging
+import re
 from typing import Any
 
 from jsonschema import ValidationError, validate
@@ -17,6 +18,42 @@ from jsonschema import ValidationError, validate
 from .token_limiter import apply_token_limits
 
 logger = logging.getLogger(__name__)
+
+
+def _sanitize_json_string(s: str) -> str:
+    """
+    Escape bare control characters inside JSON string values.
+
+    Some MCP clients produce JSON where string values contain literal
+    newlines, carriage returns, or tabs rather than the escaped forms
+    required by the JSON specification (\\n, \\r, \\t).  This causes
+    json.loads() to raise JSONDecodeError even though the overall
+    structure is otherwise valid JSON.
+
+    Strategy: use a regex that matches the interior of JSON string
+    literals (content between un-escaped double-quotes) and replace
+    any bare control characters found there with their escape sequences.
+
+    Args:
+        s: A JSON-like string that may contain bare control characters.
+
+    Returns:
+        The string with bare control characters inside string values
+        replaced by their JSON escape sequences.
+    """
+
+    def _escape_controls(m: re.Match) -> str:
+        content = m.group(1)
+        content = content.replace("\n", "\\n")
+        content = content.replace("\r", "\\r")
+        content = content.replace("\t", "\\t")
+        return f'"{content}"'
+
+    # Match JSON string literals: opening quote, captured body, closing quote.
+    # The body allows escaped sequences (\\.) or any char that is not a bare
+    # quote or backslash.  We use a non-greedy match so we don't span across
+    # multiple string values.
+    return re.sub(r'"((?:[^"\\]|\\.)*?)"', _escape_controls, s, flags=re.DOTALL)
 
 
 def setup_meta_tools(interface) -> None:
@@ -304,11 +341,21 @@ def setup_meta_tools(interface) -> None:
             try:
                 parameters = json.loads(parameters)
             except json.JSONDecodeError:
-                return {
-                    "tool": tool_name,
-                    "status": "error",
-                    "error": f"Parameters must be a JSON object, got unparseable string: {parameters[:100]}",
-                }
+                # Some MCP clients serialize parameters with literal control
+                # characters inside string values (raw newlines, tabs) instead
+                # of the escaped forms (\n, \t) required by the JSON spec.
+                # This is common when the body contains multi-line markdown.
+                # Attempt to sanitize by replacing bare control characters
+                # inside what appear to be JSON string values, then retry.
+                try:
+                    sanitized = _sanitize_json_string(parameters)
+                    parameters = json.loads(sanitized)
+                except (json.JSONDecodeError, Exception):
+                    return {
+                        "tool": tool_name,
+                        "status": "error",
+                        "error": f"Parameters must be a JSON object, got unparseable string: {parameters[:100]}",
+                    }
 
         try:
             # Get cached schema for validation

--- a/src/mcp_server_git/lean/registry_git.py
+++ b/src/mcp_server_git/lean/registry_git.py
@@ -35,8 +35,15 @@ from ..git.models import (
     GitSubmoduleStatus,
     GitSubmoduleSync,
     GitSubmoduleUpdate,
+    GitWorktreeList,
+    GitWorktreeRemove,
 )
-from ..git.operations_extended import git_branch_update, git_restore
+from ..git.operations_extended import (
+    git_branch_update,
+    git_restore,
+    git_worktree_list,
+    git_worktree_remove,
+)
 from ..utils.git_import import Repo
 from .interface import ToolDefinition
 
@@ -435,6 +442,22 @@ def _register_git_tools(interface: Any, git_service: Any):
             implementation=wrap_repo_op(git_branch_update),
             description="Force-update a branch ref or delete a branch",
             schema=GitBranchUpdate.model_json_schema(),
+            domain="git",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="git_worktree_list",
+            implementation=wrap_repo_op(git_worktree_list),
+            description="List all worktrees in the repository",
+            schema=GitWorktreeList.model_json_schema(),
+            domain="git",
+            complexity="core",
+        ),
+        ToolDefinition(
+            name="git_worktree_remove",
+            implementation=wrap_repo_op(git_worktree_remove),
+            description="Remove a worktree (with optional force for modified worktrees)",
+            schema=GitWorktreeRemove.model_json_schema(),
             domain="git",
             complexity="focused",
         ),

--- a/src/mcp_server_git/lean/registry_git.py
+++ b/src/mcp_server_git/lean/registry_git.py
@@ -7,6 +7,7 @@ from ..git import operations as git_ops
 from ..git.models import (
     GitAbort,
     GitAdd,
+    GitBranchUpdate,
     GitCheckout,
     GitCherryPick,
     GitCommit,
@@ -35,7 +36,7 @@ from ..git.models import (
     GitSubmoduleSync,
     GitSubmoduleUpdate,
 )
-from ..git.operations_extended import git_restore
+from ..git.operations_extended import git_branch_update, git_restore
 from ..utils.git_import import Repo
 from .interface import ToolDefinition
 
@@ -428,6 +429,14 @@ def _register_git_tools(interface: Any, git_service: Any):
             schema=GitRestore.model_json_schema(),
             domain="git",
             complexity="core",
+        ),
+        ToolDefinition(
+            name="git_branch_update",
+            implementation=wrap_repo_op(git_branch_update),
+            description="Force-update a branch ref or delete a branch",
+            schema=GitBranchUpdate.model_json_schema(),
+            domain="git",
+            complexity="focused",
         ),
     ]
 

--- a/src/mcp_server_git/lean/registry_git.py
+++ b/src/mcp_server_git/lean/registry_git.py
@@ -27,6 +27,7 @@ from ..git.models import (
     GitPush,
     GitRebase,
     GitReset,
+    GitRestore,
     GitShow,
     GitStatus,
     GitSubmoduleAdd,
@@ -34,6 +35,7 @@ from ..git.models import (
     GitSubmoduleSync,
     GitSubmoduleUpdate,
 )
+from ..git.operations_extended import git_restore
 from ..utils.git_import import Repo
 from .interface import ToolDefinition
 
@@ -418,6 +420,14 @@ def _register_git_tools(interface: Any, git_service: Any):
             schema=GitConfigList.model_json_schema(),
             domain="git",
             complexity="focused",
+        ),
+        ToolDefinition(
+            name="git_restore",
+            implementation=wrap_repo_op(git_restore),
+            description="Restore working tree files or unstage files (git restore / git restore --staged)",
+            schema=GitRestore.model_json_schema(),
+            domain="git",
+            complexity="core",
         ),
     ]
 

--- a/src/mcp_server_git/lean/registry_git.py
+++ b/src/mcp_server_git/lean/registry_git.py
@@ -24,6 +24,7 @@ from ..git.models import (
     GitLog,
     GitMerge,
     GitMergeBase,
+    GitMergeTree,
     GitPull,
     GitPush,
     GitRebase,
@@ -40,6 +41,7 @@ from ..git.models import (
 )
 from ..git.operations_extended import (
     git_branch_update,
+    git_merge_tree,
     git_restore,
     git_worktree_list,
     git_worktree_remove,
@@ -458,6 +460,14 @@ def _register_git_tools(interface: Any, git_service: Any):
             implementation=wrap_repo_op(git_worktree_remove),
             description="Remove a worktree (with optional force for modified worktrees)",
             schema=GitWorktreeRemove.model_json_schema(),
+            domain="git",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="git_merge_tree",
+            implementation=wrap_repo_op(git_merge_tree),
+            description="Dry-run merge conflict detection without modifying working tree",
+            schema=GitMergeTree.model_json_schema(),
             domain="git",
             complexity="focused",
         ),

--- a/tests/unit/git/test_git_branch_update.py
+++ b/tests/unit/git/test_git_branch_update.py
@@ -1,0 +1,165 @@
+"""
+Unit tests for git_branch_update operation.
+
+These tests verify the git_branch_update function that force-updates or deletes
+branch refs.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_server_git.git.operations_extended import git_branch_update
+from mcp_server_git.utils.git_import import GitCommandError
+
+
+class TestGitBranchUpdateSuccess:
+    """Test successful git_branch_update scenarios."""
+
+    def test_git_branch_update_force_update_branch_returns_success(self):
+        """Should force-update branch ref and return success message."""
+        mock_repo = Mock()
+
+        result = git_branch_update(mock_repo, branch_name="feature", target="main")
+
+        assert "✅" in result
+        assert "feature" in result
+        assert "main" in result
+        mock_repo.git.branch.assert_called_once_with("-f", "feature", "main")
+
+    def test_git_branch_update_delete_branch_returns_success(self):
+        """Should delete branch and return success message."""
+        mock_repo = Mock()
+
+        result = git_branch_update(mock_repo, branch_name="old-branch", delete=True)
+
+        assert "✅" in result
+        assert "old-branch" in result
+        assert "Deleted" in result
+        mock_repo.git.branch.assert_called_once_with("-d", "old-branch")
+
+    def test_git_branch_update_force_delete_branch_uses_capital_D(self):
+        """Should use -D flag for force delete (unmerged branch)."""
+        mock_repo = Mock()
+
+        result = git_branch_update(mock_repo, branch_name="unmerged-branch", delete=True, force=True)
+
+        assert "✅" in result
+        assert "unmerged-branch" in result
+        mock_repo.git.branch.assert_called_once_with("-D", "unmerged-branch")
+
+    def test_git_branch_update_force_update_with_commit_hash(self):
+        """Should force-update branch to a commit hash."""
+        mock_repo = Mock()
+
+        result = git_branch_update(mock_repo, branch_name="release", target="abc1234")
+
+        assert "✅" in result
+        assert "release" in result
+        assert "abc1234" in result
+        mock_repo.git.branch.assert_called_once_with("-f", "release", "abc1234")
+
+
+class TestGitBranchUpdateInputValidation:
+    """Test input validation for git_branch_update."""
+
+    def test_git_branch_update_rejects_no_action(self):
+        """Should reject when neither target nor delete specified."""
+        mock_repo = Mock()
+
+        result = git_branch_update(mock_repo, branch_name="feature")
+
+        assert "❌" in result
+        assert "Must specify either target" in result
+        mock_repo.git.branch.assert_not_called()
+
+    def test_git_branch_update_rejects_conflicting_target_and_delete(self):
+        """Should reject when both target and delete are specified."""
+        mock_repo = Mock()
+
+        result = git_branch_update(mock_repo, branch_name="feature", target="main", delete=True)
+
+        assert "❌" in result
+        assert "Cannot specify both target and delete" in result
+        mock_repo.git.branch.assert_not_called()
+
+    @pytest.mark.parametrize("dangerous_char", [";", "|", "&", "`", "$"])
+    def test_git_branch_update_rejects_dangerous_chars_in_branch_name(self, dangerous_char):
+        """Should reject dangerous characters in branch_name."""
+        mock_repo = Mock()
+        malicious_name = f"feature{dangerous_char}rm -rf /"
+
+        result = git_branch_update(mock_repo, branch_name=malicious_name, target="main")
+
+        assert "❌" in result
+        assert "Invalid characters detected in branch_name" in result
+        mock_repo.git.branch.assert_not_called()
+
+    @pytest.mark.parametrize("dangerous_char", [";", "|", "&", "`", "$"])
+    def test_git_branch_update_rejects_dangerous_chars_in_target(self, dangerous_char):
+        """Should reject dangerous characters in target ref."""
+        mock_repo = Mock()
+        malicious_target = f"main{dangerous_char}rm -rf /"
+
+        result = git_branch_update(mock_repo, branch_name="feature", target=malicious_target)
+
+        assert "❌" in result
+        assert "Invalid characters detected in target" in result
+        mock_repo.git.branch.assert_not_called()
+
+    def test_git_branch_update_accepts_valid_branch_names(self):
+        """Should accept valid branch names with slashes and hyphens."""
+        mock_repo = Mock()
+
+        result = git_branch_update(mock_repo, branch_name="feature/my-branch_v2", target="main")
+
+        assert "✅" in result
+        mock_repo.git.branch.assert_called_once()
+
+    def test_git_branch_update_accepts_valid_target_refs(self):
+        """Should accept valid target refs including tags and remote branches."""
+        mock_repo = Mock()
+
+        result = git_branch_update(mock_repo, branch_name="local", target="origin/main")
+
+        assert "✅" in result
+        mock_repo.git.branch.assert_called_once_with("-f", "local", "origin/main")
+
+
+class TestGitBranchUpdateErrorHandling:
+    """Test error handling for git_branch_update."""
+
+    def test_git_branch_update_handles_git_command_error_bytes_stderr(self):
+        """Should handle GitCommandError with bytes stderr for delete-current-branch."""
+        mock_repo = Mock()
+        mock_repo.git.branch.side_effect = GitCommandError(
+            "git branch", 1, b"", b"error: Cannot delete branch 'main' checked out"
+        )
+
+        result = git_branch_update(mock_repo, branch_name="main", delete=True)
+
+        assert "❌" in result
+        assert "Branch update failed" in result
+
+    def test_git_branch_update_handles_git_command_error_string_stderr(self):
+        """Should handle GitCommandError with string stderr gracefully."""
+        mock_repo = Mock()
+        error = GitCommandError("git branch", 1, b"", b"error: not fully merged")
+        error.stderr = "error: not fully merged"
+        mock_repo.git.branch.side_effect = error
+
+        result = git_branch_update(mock_repo, branch_name="unmerged", delete=True)
+
+        assert "❌" in result
+        assert "Branch update failed" in result
+
+    def test_git_branch_update_handles_general_exception(self):
+        """Should handle unexpected exceptions gracefully."""
+        mock_repo = Mock()
+        mock_repo.git.branch.side_effect = Exception("Unexpected failure")
+
+        result = git_branch_update(mock_repo, branch_name="feature", target="main")
+
+        assert "❌" in result
+        assert "Error updating branch" in result
+        assert "Unexpected failure" in result

--- a/tests/unit/git/test_git_merge_tree.py
+++ b/tests/unit/git/test_git_merge_tree.py
@@ -1,0 +1,146 @@
+"""Tests for git_merge_tree operation (dry-run conflict detection)."""
+
+import pytest
+from unittest.mock import MagicMock
+
+from git.exc import GitCommandError
+
+from mcp_server_git.git.operations_extended import git_merge_tree
+
+
+@pytest.fixture
+def mock_repo():
+    """Provide a mock Repo object."""
+    repo = MagicMock()
+    repo.git = MagicMock()
+    return repo
+
+
+class TestGitMergeTreeCleanMerge:
+    """Tests for clean merge (exit 0) scenarios."""
+
+    def test_git_merge_tree_returns_success_message_when_no_conflicts(self, mock_repo):
+        tree_hash = "abc1234def5678901234567890abcdef12345678"
+        mock_repo.git.merge_tree.return_value = tree_hash
+
+        result = git_merge_tree(mock_repo, "main", "feature")
+
+        assert "✅" in result
+        assert "main" in result
+        assert "feature" in result
+        assert "no conflicts" in result
+
+    def test_git_merge_tree_includes_tree_hash_in_output_when_clean(self, mock_repo):
+        tree_hash = "abc1234def5678"
+        mock_repo.git.merge_tree.return_value = tree_hash
+
+        result = git_merge_tree(mock_repo, "main", "feature")
+
+        assert tree_hash in result
+
+    def test_git_merge_tree_calls_merge_tree_with_write_tree_flag(self, mock_repo):
+        mock_repo.git.merge_tree.return_value = "abc1234"
+
+        git_merge_tree(mock_repo, "main", "feature")
+
+        mock_repo.git.merge_tree.assert_called_once_with("--write-tree", "main", "feature")
+
+
+class TestGitMergeTreeConflicts:
+    """Tests for conflict detection (exit 1) scenarios."""
+
+    def test_git_merge_tree_returns_warning_when_conflicts_detected(self, mock_repo):
+        # GitCommandError(command, status, stderr, stdout) — stdout is 4th arg
+        mock_repo.git.merge_tree.side_effect = GitCommandError(
+            "git merge-tree", 1, b"", b"CONFLICT (content): Merge conflict in file.py"
+        )
+
+        result = git_merge_tree(mock_repo, "main", "feature")
+
+        assert "⚠️" in result
+        assert "Conflicts detected" in result
+        assert "main" in result
+        assert "feature" in result
+
+    def test_git_merge_tree_lists_conflict_files_when_conflicts_in_stdout(self, mock_repo):
+        # GitCommandError(command, status, stderr, stdout) — stdout is 4th arg
+        mock_repo.git.merge_tree.side_effect = GitCommandError(
+            "git merge-tree", 1, b"", b"CONFLICT (content): Merge conflict in src/app.py"
+        )
+
+        result = git_merge_tree(mock_repo, "main", "feature")
+
+        assert "src/app.py" in result
+
+    def test_git_merge_tree_lists_multiple_conflict_files_when_multiple_conflicts(self, mock_repo):
+        stdout = (
+            b"CONFLICT (content): Merge conflict in src/app.py\n"
+            b"CONFLICT (modify/delete): foo.txt deleted in feature\n"
+            b"Auto-merging bar.txt"
+        )
+        # GitCommandError(command, status, stderr, stdout) — stdout is 4th arg
+        mock_repo.git.merge_tree.side_effect = GitCommandError(
+            "git merge-tree", 1, b"", stdout
+        )
+
+        result = git_merge_tree(mock_repo, "main", "feature")
+
+        assert "src/app.py" in result
+        assert "foo.txt" in result
+        # Non-conflict line should not appear as a conflict item
+        assert result.count("  -") == 2
+
+    def test_git_merge_tree_returns_warning_with_stdout_when_exit1_no_conflict_lines(self, mock_repo):
+        # GitCommandError(command, status, stderr, stdout) — stdout is 4th arg
+        mock_repo.git.merge_tree.side_effect = GitCommandError(
+            "git merge-tree", 1, b"", b"some other output without conflict markers"
+        )
+
+        result = git_merge_tree(mock_repo, "main", "feature")
+
+        assert "⚠️" in result
+        assert "some other output" in result
+
+
+class TestGitMergeTreeValidation:
+    """Tests for input validation (dangerous characters)."""
+
+    @pytest.mark.parametrize("char", [";", "|", "&", "`", "$"])
+    def test_git_merge_tree_rejects_dangerous_chars_in_branch1(self, mock_repo, char):
+        result = git_merge_tree(mock_repo, f"main{char}evil", "feature")
+
+        assert "❌" in result
+        assert "branch1" in result
+        mock_repo.git.merge_tree.assert_not_called()
+
+    @pytest.mark.parametrize("char", [";", "|", "&", "`", "$"])
+    def test_git_merge_tree_rejects_dangerous_chars_in_branch2(self, mock_repo, char):
+        result = git_merge_tree(mock_repo, "main", f"feature{char}evil")
+
+        assert "❌" in result
+        assert "branch2" in result
+        mock_repo.git.merge_tree.assert_not_called()
+
+
+class TestGitMergeTreeErrors:
+    """Tests for error handling scenarios."""
+
+    def test_git_merge_tree_returns_error_when_exit_code_128(self, mock_repo):
+        stderr = b"fatal: Not a valid object name: 'nonexistent'"
+        mock_repo.git.merge_tree.side_effect = GitCommandError(
+            "git merge-tree", 128, b"", stderr
+        )
+
+        result = git_merge_tree(mock_repo, "main", "nonexistent")
+
+        assert "❌" in result
+        assert "Merge-tree failed" in result
+
+    def test_git_merge_tree_returns_error_on_general_exception(self, mock_repo):
+        mock_repo.git.merge_tree.side_effect = RuntimeError("unexpected git error")
+
+        result = git_merge_tree(mock_repo, "main", "feature")
+
+        assert "❌" in result
+        assert "Error during merge-tree" in result
+        assert "unexpected git error" in result

--- a/tests/unit/git/test_git_restore.py
+++ b/tests/unit/git/test_git_restore.py
@@ -1,0 +1,176 @@
+"""
+Unit tests for git_restore operation.
+
+These tests verify the git_restore function that restores working tree files
+or unstages staged files.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_server_git.git.operations_extended import git_restore
+from mcp_server_git.utils.git_import import GitCommandError
+
+
+class TestGitRestoreSuccess:
+    """Test successful git_restore scenarios."""
+
+    def test_git_restore_working_tree_returns_success(self):
+        """Should restore working tree file and return success message."""
+        mock_repo = Mock()
+
+        result = git_restore(mock_repo, files=["src/file.py"])
+
+        assert "✅" in result
+        assert "1 file(s)" in result
+        assert "src/file.py" in result
+        assert "restored" in result
+        mock_repo.git.restore.assert_called_once_with("src/file.py")
+
+    def test_git_restore_staged_files_returns_unstaged_mode(self):
+        """Should unstage files and indicate unstaged mode."""
+        mock_repo = Mock()
+
+        result = git_restore(mock_repo, files=["README.md"], staged=True)
+
+        assert "✅" in result
+        assert "unstaged" in result
+        mock_repo.git.restore.assert_called_once_with("--staged", "README.md")
+
+    def test_git_restore_from_source_commit(self):
+        """Should restore from a specific commit/ref."""
+        mock_repo = Mock()
+
+        result = git_restore(mock_repo, files=["src/main.py"], source="HEAD~1")
+
+        assert "✅" in result
+        assert "src/main.py" in result
+        mock_repo.git.restore.assert_called_once_with("--source", "HEAD~1", "src/main.py")
+
+    def test_git_restore_staged_with_source(self):
+        """Should combine --staged and --source flags."""
+        mock_repo = Mock()
+
+        result = git_restore(mock_repo, files=["config.yaml"], staged=True, source="abc123")
+
+        assert "✅" in result
+        mock_repo.git.restore.assert_called_once_with("--staged", "--source", "abc123", "config.yaml")
+
+    def test_git_restore_multiple_files(self):
+        """Should restore multiple files and list them in the result."""
+        mock_repo = Mock()
+        files = ["a.py", "b.py", "c.py"]
+
+        result = git_restore(mock_repo, files=files)
+
+        assert "✅" in result
+        assert "3 file(s)" in result
+        mock_repo.git.restore.assert_called_once_with("a.py", "b.py", "c.py")
+
+    def test_git_restore_truncates_long_file_list(self):
+        """Should truncate file list display beyond 5 files."""
+        mock_repo = Mock()
+        files = [f"file{i}.py" for i in range(8)]
+
+        result = git_restore(mock_repo, files=files)
+
+        assert "✅" in result
+        assert "8 file(s)" in result
+        assert "+3 more" in result
+
+    def test_git_restore_exactly_five_files_no_suffix(self):
+        """Should not add suffix when exactly 5 files."""
+        mock_repo = Mock()
+        files = [f"file{i}.py" for i in range(5)]
+
+        result = git_restore(mock_repo, files=files)
+
+        assert "✅" in result
+        assert "more" not in result
+
+
+class TestGitRestoreInputValidation:
+    """Test input validation for git_restore."""
+
+    def test_git_restore_rejects_empty_files_list(self):
+        """Should reject an empty files list."""
+        mock_repo = Mock()
+
+        result = git_restore(mock_repo, files=[])
+
+        assert "❌" in result
+        assert "No files specified" in result
+        mock_repo.git.restore.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "dangerous_char",
+        [";", "|", "&", "`", "$", "(", ")"],
+    )
+    def test_git_restore_rejects_dangerous_chars_in_source(self, dangerous_char):
+        """Should reject dangerous characters in source ref."""
+        mock_repo = Mock()
+        malicious_source = f"HEAD{dangerous_char}rm -rf /"
+
+        result = git_restore(mock_repo, files=["file.py"], source=malicious_source)
+
+        assert "❌" in result
+        assert "Invalid characters detected in source" in result
+        mock_repo.git.restore.assert_not_called()
+
+    def test_git_restore_accepts_valid_source_refs(self):
+        """Should accept valid source refs with common characters."""
+        mock_repo = Mock()
+
+        result = git_restore(mock_repo, files=["file.py"], source="feature/my-branch_v2")
+
+        assert "✅" in result
+        mock_repo.git.restore.assert_called_once()
+
+    def test_git_restore_accepts_commit_hash_as_source(self):
+        """Should accept a full SHA commit hash as source."""
+        mock_repo = Mock()
+
+        result = git_restore(mock_repo, files=["file.py"], source="abc1234567890def")
+
+        assert "✅" in result
+        mock_repo.git.restore.assert_called_once()
+
+
+class TestGitRestoreErrorHandling:
+    """Test error handling for git_restore."""
+
+    def test_git_restore_handles_git_command_error_bytes_stderr(self):
+        """Should handle GitCommandError with bytes stderr gracefully."""
+        mock_repo = Mock()
+        mock_repo.git.restore.side_effect = GitCommandError(
+            "git restore", 128, b"", b"error: pathspec 'missing.py' did not match"
+        )
+
+        result = git_restore(mock_repo, files=["missing.py"])
+
+        assert "❌" in result
+        assert "Restore failed" in result
+
+    def test_git_restore_handles_git_command_error_string_stderr(self):
+        """Should handle GitCommandError with string stderr gracefully."""
+        mock_repo = Mock()
+        error = GitCommandError("git restore", 128, b"", b"fatal: not a git repo")
+        error.stderr = "fatal: not a git repo"
+        mock_repo.git.restore.side_effect = error
+
+        result = git_restore(mock_repo, files=["file.py"])
+
+        assert "❌" in result
+        assert "Restore failed" in result
+
+    def test_git_restore_handles_general_exception(self):
+        """Should handle unexpected exceptions gracefully."""
+        mock_repo = Mock()
+        mock_repo.git.restore.side_effect = Exception("Unexpected failure")
+
+        result = git_restore(mock_repo, files=["file.py"])
+
+        assert "❌" in result
+        assert "Error during restore" in result
+        assert "Unexpected failure" in result

--- a/tests/unit/git/test_git_worktree.py
+++ b/tests/unit/git/test_git_worktree.py
@@ -1,0 +1,242 @@
+"""
+Unit tests for git_worktree_list and git_worktree_remove operations.
+
+These tests verify the worktree management functions added to operations_extended.py.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_server_git.git.operations_extended import git_worktree_list, git_worktree_remove
+from mcp_server_git.utils.git_import import GitCommandError
+
+
+PORCELAIN_TWO_WORKTREES = """\
+worktree /home/user/project
+HEAD abc12345def67890abc12345def67890abc12345
+branch refs/heads/main
+
+worktree /home/user/project-feature
+HEAD 11223344556677889900aabbccddeeff00112233
+branch refs/heads/feature/my-work
+"""
+
+PORCELAIN_ONE_WORKTREE = """\
+worktree /home/user/project
+HEAD abc12345def67890abc12345def67890abc12345
+branch refs/heads/main
+"""
+
+PORCELAIN_DETACHED = """\
+worktree /home/user/project
+HEAD abc12345def67890abc12345def67890abc12345
+detached
+"""
+
+
+class TestGitWorktreeListSuccess:
+    """Test successful git_worktree_list scenarios."""
+
+    def test_git_worktree_list_parses_two_worktrees_correctly(self):
+        """Should parse porcelain output with two worktrees and return formatted list."""
+        mock_repo = Mock()
+        mock_repo.git.worktree.return_value = PORCELAIN_TWO_WORKTREES
+
+        result = git_worktree_list(mock_repo)
+
+        assert "Worktrees (2):" in result
+        assert "/home/user/project" in result
+        assert "main" in result
+        assert "/home/user/project-feature" in result
+        assert "feature/my-work" in result
+        mock_repo.git.worktree.assert_called_once_with("list", "--porcelain")
+
+    def test_git_worktree_list_parses_single_worktree(self):
+        """Should parse a single worktree and return correct count."""
+        mock_repo = Mock()
+        mock_repo.git.worktree.return_value = PORCELAIN_ONE_WORKTREE
+
+        result = git_worktree_list(mock_repo)
+
+        assert "Worktrees (1):" in result
+        assert "/home/user/project" in result
+        assert "main" in result
+
+    def test_git_worktree_list_returns_no_worktrees_message_when_empty(self):
+        """Should return descriptive message when output is empty."""
+        mock_repo = Mock()
+        mock_repo.git.worktree.return_value = ""
+
+        result = git_worktree_list(mock_repo)
+
+        assert "No worktrees found" in result
+
+    def test_git_worktree_list_handles_detached_head_worktree(self):
+        """Should show 'detached' as branch for detached HEAD worktrees."""
+        mock_repo = Mock()
+        mock_repo.git.worktree.return_value = PORCELAIN_DETACHED
+
+        result = git_worktree_list(mock_repo)
+
+        assert "Worktrees (1):" in result
+        assert "detached" in result
+
+    def test_git_worktree_list_strips_refs_heads_prefix_from_branch(self):
+        """Should strip refs/heads/ prefix from branch names."""
+        mock_repo = Mock()
+        mock_repo.git.worktree.return_value = PORCELAIN_TWO_WORKTREES
+
+        result = git_worktree_list(mock_repo)
+
+        assert "refs/heads/" not in result
+
+    def test_git_worktree_list_includes_short_sha_in_output(self):
+        """Should include short (8-char) SHA in output."""
+        mock_repo = Mock()
+        mock_repo.git.worktree.return_value = PORCELAIN_ONE_WORKTREE
+
+        result = git_worktree_list(mock_repo)
+
+        # Short SHA is first 8 chars: "abc12345"
+        assert "abc12345" in result
+
+
+class TestGitWorktreeListErrorHandling:
+    """Test error handling for git_worktree_list."""
+
+    def test_git_worktree_list_handles_git_command_error_bytes_stderr(self):
+        """Should handle GitCommandError with bytes stderr gracefully."""
+        mock_repo = Mock()
+        mock_repo.git.worktree.side_effect = GitCommandError(
+            "git worktree", 128, b"", b"fatal: not a git repository"
+        )
+
+        result = git_worktree_list(mock_repo)
+
+        assert "❌" in result
+        assert "Failed to list worktrees" in result
+
+    def test_git_worktree_list_handles_git_command_error_string_stderr(self):
+        """Should handle GitCommandError with string stderr gracefully."""
+        mock_repo = Mock()
+        error = GitCommandError("git worktree", 128, b"", b"fatal: error")
+        error.stderr = "fatal: error"
+        mock_repo.git.worktree.side_effect = error
+
+        result = git_worktree_list(mock_repo)
+
+        assert "❌" in result
+        assert "Failed to list worktrees" in result
+
+    def test_git_worktree_list_handles_general_exception(self):
+        """Should handle unexpected exceptions gracefully."""
+        mock_repo = Mock()
+        mock_repo.git.worktree.side_effect = Exception("Unexpected failure")
+
+        result = git_worktree_list(mock_repo)
+
+        assert "❌" in result
+        assert "Error listing worktrees" in result
+        assert "Unexpected failure" in result
+
+
+class TestGitWorktreeRemoveSuccess:
+    """Test successful git_worktree_remove scenarios."""
+
+    def test_git_worktree_remove_normal_removal_returns_success(self):
+        """Should call worktree remove and return success message."""
+        mock_repo = Mock()
+
+        result = git_worktree_remove(mock_repo, worktree_path="/home/user/project-feature")
+
+        assert "✅" in result
+        assert "/home/user/project-feature" in result
+        mock_repo.git.worktree.assert_called_once_with("remove", "/home/user/project-feature")
+
+    def test_git_worktree_remove_force_removal_passes_force_flag(self):
+        """Should pass --force flag when force=True."""
+        mock_repo = Mock()
+
+        result = git_worktree_remove(
+            mock_repo, worktree_path="/home/user/project-feature", force=True
+        )
+
+        assert "✅" in result
+        assert "/home/user/project-feature" in result
+        mock_repo.git.worktree.assert_called_once_with(
+            "remove", "--force", "/home/user/project-feature"
+        )
+
+    def test_git_worktree_remove_without_force_does_not_pass_force_flag(self):
+        """Should not pass --force flag when force=False (default)."""
+        mock_repo = Mock()
+
+        git_worktree_remove(mock_repo, worktree_path="/tmp/wt")
+
+        call_args = mock_repo.git.worktree.call_args[0]
+        assert "--force" not in call_args
+
+
+class TestGitWorktreeRemoveInputValidation:
+    """Test input validation for git_worktree_remove."""
+
+    @pytest.mark.parametrize("dangerous_char", [";", "|", "&", "`", "$"])
+    def test_git_worktree_remove_rejects_dangerous_chars_in_path(self, dangerous_char):
+        """Should reject dangerous characters in worktree_path."""
+        mock_repo = Mock()
+        malicious_path = f"/tmp/wt{dangerous_char}rm -rf /"
+
+        result = git_worktree_remove(mock_repo, worktree_path=malicious_path)
+
+        assert "❌" in result
+        assert "Invalid characters in worktree path" in result
+        mock_repo.git.worktree.assert_not_called()
+
+    def test_git_worktree_remove_accepts_valid_absolute_path(self):
+        """Should accept valid absolute paths with slashes and hyphens."""
+        mock_repo = Mock()
+
+        result = git_worktree_remove(mock_repo, worktree_path="/home/user/my-worktree_v2")
+
+        assert "✅" in result
+        mock_repo.git.worktree.assert_called_once()
+
+
+class TestGitWorktreeRemoveErrorHandling:
+    """Test error handling for git_worktree_remove."""
+
+    def test_git_worktree_remove_handles_git_command_error_bytes_stderr(self):
+        """Should handle GitCommandError with bytes stderr gracefully."""
+        mock_repo = Mock()
+        mock_repo.git.worktree.side_effect = GitCommandError(
+            "git worktree", 128, b"", b"fatal: '/tmp/wt' is not a working tree"
+        )
+
+        result = git_worktree_remove(mock_repo, worktree_path="/tmp/wt")
+
+        assert "❌" in result
+        assert "Failed to remove worktree" in result
+
+    def test_git_worktree_remove_handles_git_command_error_string_stderr(self):
+        """Should handle GitCommandError with string stderr gracefully."""
+        mock_repo = Mock()
+        error = GitCommandError("git worktree", 128, b"", b"fatal: error")
+        error.stderr = "fatal: error"
+        mock_repo.git.worktree.side_effect = error
+
+        result = git_worktree_remove(mock_repo, worktree_path="/tmp/wt")
+
+        assert "❌" in result
+        assert "Failed to remove worktree" in result
+
+    def test_git_worktree_remove_handles_general_exception(self):
+        """Should handle unexpected exceptions gracefully."""
+        mock_repo = Mock()
+        mock_repo.git.worktree.side_effect = Exception("Unexpected failure")
+
+        result = git_worktree_remove(mock_repo, worktree_path="/tmp/wt")
+
+        assert "❌" in result
+        assert "Error removing worktree" in result
+        assert "Unexpected failure" in result

--- a/tests/unit/lean/test_meta_tools_json_parsing.py
+++ b/tests/unit/lean/test_meta_tools_json_parsing.py
@@ -114,6 +114,14 @@ class TestSanitizeJsonString:
         assert parsed["count"] == 42
         assert parsed["flag"] is True
 
+    def test_null_and_other_c0_controls_escaped(self):
+        """Should escape all C0 control characters forbidden by JSON spec."""
+        raw = '{"body": "text\x00with\x08null\x0band\x0ccontrols"}'
+        result = _sanitize_json_string(raw)
+        parsed = json.loads(result)
+        assert "text" in parsed["body"]
+        assert "\x00" not in result  # literal null must not appear in JSON text
+
 
 # ---------------------------------------------------------------------------
 # Tests for the coercion path (string→dict) in execute_tool

--- a/tests/unit/lean/test_meta_tools_json_parsing.py
+++ b/tests/unit/lean/test_meta_tools_json_parsing.py
@@ -1,0 +1,232 @@
+"""
+Unit tests for execute_tool JSON parameter parsing in meta_tools.py.
+
+Tests the coercion logic that handles parameters arriving as a JSON string
+instead of a dict — a pattern some MCP clients use for serialization.
+
+Bug (#151): github_create_issue fails when body contains markdown with backticks,
+unescaped newlines, or other special characters that break naive json.loads().
+
+Test strategy: test the _sanitize_json_string helper directly (no I/O, fast),
+plus smoke-test the coercion path through a minimal standalone execute_tool
+function that mirrors the production logic without the full GitLeanInterface.
+
+Tests cover:
+- _sanitize_json_string: newlines, tabs, carriage returns, mixed, already-escaped
+- Coercion path: valid JSON string, broken JSON with newlines, backtick markdown,
+  tabs, truly invalid string, parameters already a dict
+"""
+
+import json
+
+import pytest
+
+from src.mcp_server_git.lean.meta_tools import _sanitize_json_string
+
+
+# ---------------------------------------------------------------------------
+# Tests for _sanitize_json_string helper
+# ---------------------------------------------------------------------------
+
+class TestSanitizeJsonString:
+    """Direct tests for the _sanitize_json_string escape helper."""
+
+    def test_clean_json_unchanged(self):
+        """A valid JSON string with no bare control chars passes through."""
+        s = '{"key": "value", "num": 42}'
+        assert _sanitize_json_string(s) == s
+
+    def test_properly_escaped_newlines_unchanged(self):
+        """Already-escaped \\n sequences are not double-escaped."""
+        s = '{"body": "line1\\nline2"}'
+        result = _sanitize_json_string(s)
+        # Should still be parseable and value preserved
+        parsed = json.loads(result)
+        assert parsed["body"] == "line1\nline2"
+
+    def test_bare_newline_in_string_value_escaped(self):
+        """Bare newline inside a string value is replaced with \\n."""
+        body = "line1\nline2"
+        broken = f'{{"body": "{body}"}}'
+        result = _sanitize_json_string(broken)
+        parsed = json.loads(result)
+        assert "line1" in parsed["body"]
+        assert "line2" in parsed["body"]
+
+    def test_bare_tab_in_string_value_escaped(self):
+        """Bare tab inside a string value is replaced with \\t."""
+        broken = '{"body": "col1\tcol2"}'
+        result = _sanitize_json_string(broken)
+        parsed = json.loads(result)
+        assert "col1" in parsed["body"]
+        assert "col2" in parsed["body"]
+
+    def test_bare_carriage_return_in_string_value_escaped(self):
+        """Bare carriage return inside a string value is replaced with \\r."""
+        broken = '{"body": "line1\rline2"}'
+        result = _sanitize_json_string(broken)
+        parsed = json.loads(result)
+        assert "line1" in parsed["body"]
+
+    def test_mixed_control_chars_all_escaped(self):
+        """Newline, tab, and carriage return all escaped in one pass."""
+        broken = '{"body": "a\nb\tc\rd"}'
+        result = _sanitize_json_string(broken)
+        parsed = json.loads(result)
+        body = parsed["body"]
+        assert "a" in body
+        assert "b" in body
+        assert "c" in body
+        assert "d" in body
+
+    def test_multiple_string_fields_each_sanitized(self):
+        """Each string field in a multi-field object is independently sanitized."""
+        broken = '{"title": "My\nTitle", "body": "Line1\nLine2"}'
+        result = _sanitize_json_string(broken)
+        parsed = json.loads(result)
+        assert "My" in parsed["title"]
+        assert "Title" in parsed["title"]
+        assert "Line1" in parsed["body"]
+        assert "Line2" in parsed["body"]
+
+    def test_markdown_code_fence_with_newlines(self):
+        """Markdown code fence body with newlines is sanitized correctly."""
+        code_body = "## Summary\nUse `code` here.\n\n```python\ndef foo():\n    pass\n```"
+        broken = '{"body": "' + code_body + '"}'
+        result = _sanitize_json_string(broken)
+        # Must now be valid JSON
+        parsed = json.loads(result)
+        assert "Summary" in parsed["body"]
+        assert "foo" in parsed["body"]
+
+    def test_empty_string_value_unchanged(self):
+        """Empty string values are handled without error."""
+        s = '{"body": ""}'
+        result = _sanitize_json_string(s)
+        parsed = json.loads(result)
+        assert parsed["body"] == ""
+
+    def test_no_string_values_unchanged(self):
+        """JSON with only non-string values passes through unchanged."""
+        s = '{"count": 42, "flag": true, "ratio": 1.5}'
+        result = _sanitize_json_string(s)
+        parsed = json.loads(result)
+        assert parsed["count"] == 42
+        assert parsed["flag"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests for the coercion path (string→dict) in execute_tool
+#
+# We test the logic directly via a standalone async function that mirrors
+# exactly the coercion block at meta_tools.py:302-320, without spinning up
+# a full GitLeanInterface (which is expensive and causes timeouts).
+# ---------------------------------------------------------------------------
+
+async def _coerce_parameters(parameters):
+    """
+    Mirror of the coercion block in execute_tool.
+
+    Returns (parsed_dict, error_dict_or_None).
+    """
+    if isinstance(parameters, str):
+        try:
+            return json.loads(parameters), None
+        except json.JSONDecodeError:
+            try:
+                sanitized = _sanitize_json_string(parameters)
+                return json.loads(sanitized), None
+            except (json.JSONDecodeError, Exception):
+                return None, {
+                    "status": "error",
+                    "error": f"Parameters must be a JSON object, got unparseable string: {parameters[:100]}",
+                }
+    return parameters, None
+
+
+class TestCoercionPath:
+    """Tests for the string→dict coercion logic."""
+
+    @pytest.mark.asyncio
+    async def test_dict_parameters_pass_through(self):
+        """Dict parameters are returned unchanged."""
+        params = {"repo_owner": "owner", "repo_name": "repo", "title": "T"}
+        result, err = await _coerce_parameters(params)
+        assert err is None
+        assert result == params
+
+    @pytest.mark.asyncio
+    async def test_valid_json_string_parsed(self):
+        """A properly-escaped JSON string is parsed on the first attempt."""
+        params = {"repo_owner": "owner", "repo_name": "repo", "title": "T"}
+        result, err = await _coerce_parameters(json.dumps(params))
+        assert err is None
+        assert result == params
+
+    @pytest.mark.asyncio
+    async def test_json_string_with_bare_newlines_in_body(self):
+        """
+        Bug reproduction: body with literal newlines fails json.loads but
+        succeeds after sanitization.
+        """
+        body = "## Summary\nLine one.\nLine two.\n\nParagraph."
+        broken_json = (
+            '{"repo_owner": "owner", "repo_name": "repo", '
+            '"title": "Bug", "body": "' + body + '"}'
+        )
+        # Confirm input is broken JSON
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(broken_json)
+
+        result, err = await _coerce_parameters(broken_json)
+        assert err is None, f"Expected success but got error: {err}"
+        assert result["repo_owner"] == "owner"
+        assert "Summary" in result["body"]
+
+    @pytest.mark.asyncio
+    async def test_json_string_with_markdown_backticks_and_newlines(self):
+        """Body with markdown code fences is sanitized and parsed."""
+        body = "Use `code` inline.\n\n```python\ndef foo():\n    return 1\n```"
+        broken_json = (
+            '{"repo_owner": "owner", "repo_name": "repo", '
+            '"title": "Code example", "body": "' + body + '"}'
+        )
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(broken_json)
+
+        result, err = await _coerce_parameters(broken_json)
+        assert err is None, f"Expected success but got error: {err}"
+        assert "foo" in result["body"]
+
+    @pytest.mark.asyncio
+    async def test_json_string_with_tabs_in_body(self):
+        """Body with literal tab characters is sanitized and parsed."""
+        body = "Step 1:\tdo this\nStep 2:\tdo that"
+        broken_json = (
+            '{"repo_owner": "owner", "repo_name": "repo", '
+            '"title": "Steps", "body": "' + body + '"}'
+        )
+        with pytest.raises(json.JSONDecodeError):
+            json.loads(broken_json)
+
+        result, err = await _coerce_parameters(broken_json)
+        assert err is None, f"Expected success but got error: {err}"
+        assert "Step 1" in result["body"]
+
+    @pytest.mark.asyncio
+    async def test_truly_invalid_string_returns_error(self):
+        """A completely non-JSON string returns an error dict, not an exception."""
+        result, err = await _coerce_parameters("this is plain text, not JSON")
+        assert result is None
+        assert err is not None
+        assert err["status"] == "error"
+        assert "unparseable" in err["error"].lower() or "parameters" in err["error"].lower()
+
+    @pytest.mark.asyncio
+    async def test_error_message_truncates_long_input(self):
+        """Error message truncates the input string to 100 chars for readability."""
+        very_long_invalid = "x" * 500
+        result, err = await _coerce_parameters(very_long_invalid)
+        assert err is not None
+        # The error should reference only the first 100 chars
+        assert len(err["error"]) < 300


### PR DESCRIPTION
## Summary

- Fix github_create_issue JSON parsing for long body text with markdown (#151)
- Add git_restore tool for file restoration and unstaging (#152)
- Add git_branch_update tool for force-update refs and branch deletion (#153)
- Add git_worktree_list and git_worktree_remove tools (#154)
- Add git_merge_tree tool for dry-run conflict detection (#155)

## Architecture

New tools in `git/operations_extended.py` to avoid bloating the 2284-line `operations.py`. Follows established 3-layer pattern: Pydantic model, operation function, lean registry entry.

## Test plan

- [x] 80+ new unit tests across 6 test files
- [x] All existing tests pass (full suite green)
- [x] Lint and format checks pass
- [x] Security validation (dangerous char injection) for all new tools