### PR TITLE
feat: add safe git_rm tool with single-file constraint

### DIFF
--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -250,3 +250,10 @@ class GitMergeTree(BaseModel):
     repo_path: str
     branch1: str = Field(description="First branch (typically current)")
     branch2: str = Field(description="Second branch (typically incoming)")
+
+
+class GitRm(BaseModel):
+    repo_path: str
+    file: str = Field(description="Single file path to remove (no wildcards, no directories)")
+    cached: bool = Field(default=False, description="Remove from index only, keep working tree file (--cached)")
+    dry_run: bool = Field(default=False, description="Show what would be removed without doing it (--dry-run)")

--- a/src/mcp_server_git/git/operations_extended.py
+++ b/src/mcp_server_git/git/operations_extended.py
@@ -18,6 +18,7 @@ __all__ = [
     "git_worktree_list",
     "git_worktree_remove",
     "git_merge_tree",
+    "git_rm",
 ]
 
 
@@ -205,3 +206,59 @@ def git_merge_tree(
 
     except Exception as e:
         return f"❌ Error during merge-tree: {str(e)}"
+
+
+# Dangerous-path blocklist for git_rm: reject wildcards, directories, bare '.'
+_UNSAFE_PATH = re.compile(r"[*?\[\]{}]")
+
+
+def git_rm(
+    repo: Repo,
+    file: str,
+    cached: bool = False,
+    dry_run: bool = False,
+) -> str:
+    """Remove a single, explicitly-named file from the working tree and index.
+
+    Safety: rejects wildcards, '.', '..', and directory separators ending in '/'.
+    """
+    if not file or not file.strip():
+        return "❌ No file specified"
+
+    file = file.strip()
+
+    # Block directory-style paths and current/parent dir
+    if file in (".", ".."):
+        return "❌ Refusing to remove '.' or '..'. Specify an explicit file path."
+
+    if file.endswith("/"):
+        return "❌ Directory removal not supported. Specify an explicit file path."
+
+    if _UNSAFE_PATH.search(file):
+        return "❌ Wildcards/globs not allowed. Specify an explicit file path."
+
+    if DANGEROUS_CHARS.search(file):
+        return f"❌ Invalid characters detected in file path: '{file}'"
+
+    try:
+        args = []
+        if cached:
+            args.append("--cached")
+        if dry_run:
+            args.append("--dry-run")
+        args.append("--")
+        args.append(file)
+
+        output = repo.git.rm(*args)
+
+        if dry_run:
+            return f"🔍 Dry-run: would remove '{file}'\n{output}"
+
+        mode = "from index (kept on disk)" if cached else "from working tree and index"
+        return f"✅ Removed '{file}' {mode}"
+
+    except GitCommandError as e:
+        stderr = e.stderr.decode() if isinstance(e.stderr, bytes) else e.stderr
+        return f"❌ git rm failed: {stderr}"
+    except Exception as e:
+        return f"❌ Error during git rm: {str(e)}"

--- a/src/mcp_server_git/git/operations_extended.py
+++ b/src/mcp_server_git/git/operations_extended.py
@@ -239,6 +239,10 @@ def git_rm(
     if file in (".", ".."):
         return "❌ Refusing to remove '.' or '..'. Specify an explicit file path."
 
+    # Block absolute paths to prevent accidental system file removal
+    if os.path.isabs(file):
+        return "❌ Absolute paths not allowed. Use a path relative to the repository root."
+
     if _UNSAFE_PATH.search(file):
         return "❌ Wildcards/globs not allowed. Specify an explicit file path."
 

--- a/src/mcp_server_git/git/operations_extended.py
+++ b/src/mcp_server_git/git/operations_extended.py
@@ -4,6 +4,7 @@ New tools added to avoid bloating operations.py (2284 lines, tracked in #139/#14
 """
 
 import logging
+import os
 import re
 
 from ..utils.git_import import GitCommandError, Repo
@@ -227,12 +228,16 @@ def git_rm(
 
     file = file.strip()
 
-    # Block directory-style paths and current/parent dir
-    if file in (".", ".."):
-        return "❌ Refusing to remove '.' or '..'. Specify an explicit file path."
-
+    # Check trailing slash before normpath strips it
     if file.endswith("/"):
         return "❌ Directory removal not supported. Specify an explicit file path."
+
+    # Normalize path to collapse ./, ../, and redundant separators
+    file = os.path.normpath(file)
+
+    # Block current/parent dir (also catches paths that normalize to . or ..)
+    if file in (".", ".."):
+        return "❌ Refusing to remove '.' or '..'. Specify an explicit file path."
 
     if _UNSAFE_PATH.search(file):
         return "❌ Wildcards/globs not allowed. Specify an explicit file path."

--- a/src/mcp_server_git/lean/registry_git.py
+++ b/src/mcp_server_git/lean/registry_git.py
@@ -36,6 +36,7 @@ from ..git.models import (
     GitSubmoduleStatus,
     GitSubmoduleSync,
     GitSubmoduleUpdate,
+    GitRm,
     GitWorktreeList,
     GitWorktreeRemove,
 )
@@ -43,6 +44,7 @@ from ..git.operations_extended import (
     git_branch_update,
     git_merge_tree,
     git_restore,
+    git_rm,
     git_worktree_list,
     git_worktree_remove,
 )
@@ -468,6 +470,14 @@ def _register_git_tools(interface: Any, git_service: Any):
             implementation=wrap_repo_op(git_merge_tree),
             description="Dry-run merge conflict detection without modifying working tree",
             schema=GitMergeTree.model_json_schema(),
+            domain="git",
+            complexity="focused",
+        ),
+        ToolDefinition(
+            name="git_rm",
+            implementation=wrap_repo_op(git_rm),
+            description="Remove a single file from working tree and/or index (safe: no wildcards, no directories)",
+            schema=GitRm.model_json_schema(),
             domain="git",
             complexity="focused",
         ),

--- a/tests/unit/git/test_git_rm.py
+++ b/tests/unit/git/test_git_rm.py
@@ -1,0 +1,201 @@
+"""
+Unit tests for git_rm operation.
+
+These tests verify the git_rm function that removes a single, explicitly-named
+file from the working tree and/or index with safety guards against wildcards,
+directories, and shell injection.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from mcp_server_git.git.operations_extended import git_rm
+from mcp_server_git.utils.git_import import GitCommandError
+
+
+class TestGitRmSuccess:
+    """Test successful git_rm scenarios."""
+
+    def test_git_rm_returns_success_for_tracked_file(self):
+        """Should remove file from working tree and index."""
+        mock_repo = Mock()
+        mock_repo.git.rm.return_value = "rm 'src/old.py'"
+
+        result = git_rm(mock_repo, file="src/old.py")
+
+        assert "✅" in result
+        assert "src/old.py" in result
+        assert "working tree and index" in result
+        mock_repo.git.rm.assert_called_once_with("--", "src/old.py")
+
+    def test_git_rm_cached_returns_index_only_message(self):
+        """Should remove from index only when cached=True."""
+        mock_repo = Mock()
+        mock_repo.git.rm.return_value = "rm 'config.yaml'"
+
+        result = git_rm(mock_repo, file="config.yaml", cached=True)
+
+        assert "✅" in result
+        assert "from index (kept on disk)" in result
+        mock_repo.git.rm.assert_called_once_with("--cached", "--", "config.yaml")
+
+    def test_git_rm_dry_run_returns_preview(self):
+        """Should show what would be removed without doing it."""
+        mock_repo = Mock()
+        mock_repo.git.rm.return_value = "rm 'temp.txt'"
+
+        result = git_rm(mock_repo, file="temp.txt", dry_run=True)
+
+        assert "🔍" in result
+        assert "Dry-run" in result
+        assert "temp.txt" in result
+        mock_repo.git.rm.assert_called_once_with("--dry-run", "--", "temp.txt")
+
+    def test_git_rm_cached_and_dry_run_combined(self):
+        """Should combine --cached and --dry-run flags."""
+        mock_repo = Mock()
+        mock_repo.git.rm.return_value = "rm 'data.json'"
+
+        result = git_rm(mock_repo, file="data.json", cached=True, dry_run=True)
+
+        assert "🔍" in result
+        mock_repo.git.rm.assert_called_once_with("--cached", "--dry-run", "--", "data.json")
+
+    def test_git_rm_accepts_nested_path(self):
+        """Should accept deeply nested file paths."""
+        mock_repo = Mock()
+        mock_repo.git.rm.return_value = "rm 'src/core/utils/helper.py'"
+
+        result = git_rm(mock_repo, file="src/core/utils/helper.py")
+
+        assert "✅" in result
+        mock_repo.git.rm.assert_called_once_with("--", "src/core/utils/helper.py")
+
+    def test_git_rm_strips_whitespace_from_file(self):
+        """Should strip leading/trailing whitespace from file path."""
+        mock_repo = Mock()
+        mock_repo.git.rm.return_value = "rm 'file.py'"
+
+        result = git_rm(mock_repo, file="  file.py  ")
+
+        assert "✅" in result
+        mock_repo.git.rm.assert_called_once_with("--", "file.py")
+
+
+class TestGitRmInputValidation:
+    """Test safety guards for git_rm."""
+
+    def test_git_rm_rejects_empty_string(self):
+        """Should reject empty file path."""
+        mock_repo = Mock()
+
+        result = git_rm(mock_repo, file="")
+
+        assert "❌" in result
+        assert "No file specified" in result
+        mock_repo.git.rm.assert_not_called()
+
+    def test_git_rm_rejects_whitespace_only(self):
+        """Should reject whitespace-only file path."""
+        mock_repo = Mock()
+
+        result = git_rm(mock_repo, file="   ")
+
+        assert "❌" in result
+        assert "No file specified" in result
+        mock_repo.git.rm.assert_not_called()
+
+    def test_git_rm_rejects_dot(self):
+        """Should reject '.' as file path."""
+        mock_repo = Mock()
+
+        result = git_rm(mock_repo, file=".")
+
+        assert "❌" in result
+        assert "Refusing" in result
+        mock_repo.git.rm.assert_not_called()
+
+    def test_git_rm_rejects_dotdot(self):
+        """Should reject '..' as file path."""
+        mock_repo = Mock()
+
+        result = git_rm(mock_repo, file="..")
+
+        assert "❌" in result
+        assert "Refusing" in result
+        mock_repo.git.rm.assert_not_called()
+
+    def test_git_rm_rejects_trailing_slash(self):
+        """Should reject directory-style paths ending in '/'."""
+        mock_repo = Mock()
+
+        result = git_rm(mock_repo, file="src/")
+
+        assert "❌" in result
+        assert "Directory removal not supported" in result
+        mock_repo.git.rm.assert_not_called()
+
+    @pytest.mark.parametrize("wildcard", ["*", "?", "[", "]", "{", "}"])
+    def test_git_rm_rejects_wildcards(self, wildcard):
+        """Should reject any wildcard/glob characters."""
+        mock_repo = Mock()
+
+        result = git_rm(mock_repo, file=f"src/{wildcard}.py")
+
+        assert "❌" in result
+        assert "Wildcards" in result
+        mock_repo.git.rm.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "dangerous_char",
+        [";", "|", "&", "`", "$", "(", ")"],
+    )
+    def test_git_rm_rejects_dangerous_chars(self, dangerous_char):
+        """Should reject shell injection characters."""
+        mock_repo = Mock()
+
+        result = git_rm(mock_repo, file=f"file{dangerous_char}evil")
+
+        assert "❌" in result
+        assert "Invalid characters detected" in result
+        mock_repo.git.rm.assert_not_called()
+
+
+class TestGitRmErrorHandling:
+    """Test error handling for git_rm."""
+
+    def test_git_rm_handles_git_command_error_bytes_stderr(self):
+        """Should handle GitCommandError with bytes stderr."""
+        mock_repo = Mock()
+        mock_repo.git.rm.side_effect = GitCommandError(
+            "git rm", 128, b"", b"fatal: pathspec 'missing.py' did not match"
+        )
+
+        result = git_rm(mock_repo, file="missing.py")
+
+        assert "❌" in result
+        assert "git rm failed" in result
+
+    def test_git_rm_handles_git_command_error_string_stderr(self):
+        """Should handle GitCommandError with string stderr."""
+        mock_repo = Mock()
+        error = GitCommandError("git rm", 128, b"", b"fatal: not a git repo")
+        error.stderr = "fatal: not a git repo"
+        mock_repo.git.rm.side_effect = error
+
+        result = git_rm(mock_repo, file="file.py")
+
+        assert "❌" in result
+        assert "git rm failed" in result
+
+    def test_git_rm_handles_general_exception(self):
+        """Should handle unexpected exceptions gracefully."""
+        mock_repo = Mock()
+        mock_repo.git.rm.side_effect = Exception("Unexpected failure")
+
+        result = git_rm(mock_repo, file="file.py")
+
+        assert "❌" in result
+        assert "Error during git rm" in result
+        assert "Unexpected failure" in result

--- a/tests/unit/git/test_git_rm.py
+++ b/tests/unit/git/test_git_rm.py
@@ -82,6 +82,25 @@ class TestGitRmSuccess:
         assert "✅" in result
         mock_repo.git.rm.assert_called_once_with("--", "file.py")
 
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            "docs/résumé.txt",
+            "data/日本語.csv",
+            "notes/über-file.md",
+            "src/café.py",
+        ],
+    )
+    def test_git_rm_accepts_unicode_filenames(self, filename):
+        """Should accept non-ASCII filenames without error."""
+        mock_repo = Mock()
+        mock_repo.git.rm.return_value = f"rm '{filename}'"
+
+        result = git_rm(mock_repo, file=filename)
+
+        assert "✅" in result
+        mock_repo.git.rm.assert_called_once_with("--", filename)
+
 
 class TestGitRmInputValidation:
     """Test safety guards for git_rm."""
@@ -135,6 +154,60 @@ class TestGitRmInputValidation:
         assert "❌" in result
         assert "Directory removal not supported" in result
         mock_repo.git.rm.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "./",       # trailing slash caught first
+            "dir/../",  # trailing slash caught first
+        ],
+    )
+    def test_git_rm_rejects_trailing_slash_variants(self, path):
+        """Should reject paths ending in '/' before normalization."""
+        mock_repo = Mock()
+
+        result = git_rm(mock_repo, file=path)
+
+        assert "❌" in result
+        assert "Directory removal not supported" in result
+        mock_repo.git.rm.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "dir/..",     # normpath collapses to .
+            "a/b/../..",  # normpath collapses to .
+        ],
+    )
+    def test_git_rm_rejects_normalized_dot_paths(self, path):
+        """Should reject paths that normalize to '.' or '..'."""
+        mock_repo = Mock()
+
+        result = git_rm(mock_repo, file=path)
+
+        assert "❌" in result
+        assert "Refusing" in result
+        mock_repo.git.rm.assert_not_called()
+
+    def test_git_rm_normalizes_redundant_separators(self):
+        """Should normalize path before passing to git."""
+        mock_repo = Mock()
+        mock_repo.git.rm.return_value = "rm 'src/file.py'"
+
+        result = git_rm(mock_repo, file="src//file.py")
+
+        assert "✅" in result
+        mock_repo.git.rm.assert_called_once_with("--", "src/file.py")
+
+    def test_git_rm_normalizes_dot_segments(self):
+        """Should normalize ./src/../src/file.py to src/file.py."""
+        mock_repo = Mock()
+        mock_repo.git.rm.return_value = "rm 'src/file.py'"
+
+        result = git_rm(mock_repo, file="./src/../src/file.py")
+
+        assert "✅" in result
+        mock_repo.git.rm.assert_called_once_with("--", "src/file.py")
 
     @pytest.mark.parametrize("wildcard", ["*", "?", "[", "]", "{", "}"])
     def test_git_rm_rejects_wildcards(self, wildcard):

--- a/tests/unit/git/test_git_rm.py
+++ b/tests/unit/git/test_git_rm.py
@@ -175,6 +175,24 @@ class TestGitRmInputValidation:
     @pytest.mark.parametrize(
         "path",
         [
+            "/etc/passwd",
+            "/home/user/file.py",
+            "/tmp/test.txt",
+        ],
+    )
+    def test_git_rm_rejects_absolute_paths(self, path):
+        """Should reject absolute paths to prevent system file removal."""
+        mock_repo = Mock()
+
+        result = git_rm(mock_repo, file=path)
+
+        assert "❌" in result
+        assert "Absolute paths not allowed" in result
+        mock_repo.git.rm.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "path",
+        [
             "dir/..",     # normpath collapses to .
             "a/b/../..",  # normpath collapses to .
         ],


### PR DESCRIPTION
## Summary
- Adds `git_rm` tool with safety-first design for LLM context
- Single file only (string param, not list) — prevents mass deletion
- Rejects wildcards, glob chars, `.`, `..`, trailing `/`, and shell injection characters
- Always inserts `--` separator before file arg to prevent flag injection
- Supports `--cached` (remove from index only) and `--dry-run` (preview)

## Files Changed
- `src/mcp_server_git/git/models.py` — `GitRm` model
- `src/mcp_server_git/git/operations_extended.py` — `git_rm()` implementation
- `src/mcp_server_git/lean/registry_git.py` — tool registration
- `tests/unit/git/test_git_rm.py` — 27 unit tests (7 success, 13 validation, 3 error handling + parametrized)

## Test plan
- [x] 27/27 unit tests passing locally
- [ ] CI passes on all platforms
- [ ] Live test via MCP discover + execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)