### PR TITLE
fix(github): expand bot template placeholders in PR review/comment fetches

### DIFF
--- a/src/mcp_server_git/github/client.py
+++ b/src/mcp_server_git/github/client.py
@@ -40,12 +40,18 @@ class GitHubClient:
 
         return any(re.match(pattern, token.strip()) for pattern in patterns)
 
-    async def get(self, endpoint: str, **kwargs) -> aiohttp.ClientResponse:
+    async def get(
+        self,
+        endpoint: str,
+        *,
+        accept: str = "application/vnd.github.v3+json",
+        **kwargs,
+    ) -> aiohttp.ClientResponse:
         """Make GET request to GitHub API"""
         url = f"{self.base_url}/{endpoint.lstrip('/')}"
         headers = {
             "Authorization": f"Bearer {self.token}",
-            "Accept": "application/vnd.github.v3+json",
+            "Accept": accept,
             "User-Agent": "MCP-Git-Server/1.1.0",
         }
 

--- a/src/mcp_server_git/github/pr_actions.py
+++ b/src/mcp_server_git/github/pr_actions.py
@@ -8,6 +8,25 @@ from mcp_server_git.github.client import github_client_context
 
 logger = logging.getLogger(__name__)
 
+_BOT_TEMPLATE_MARKER = "${{"
+
+
+def _select_rendered_body(comment: dict[str, Any]) -> str:
+    """Pick the most useful body field from a GitHub comment object.
+
+    GitHub renders bot template placeholders (e.g. ``${{ metadata.patch }}``)
+    server-side only when the response includes ``body_html`` / ``body_text``
+    (requested via ``application/vnd.github.full+json``). When the markdown
+    ``body`` contains template syntax we fall back to the rendered ``body_text``;
+    otherwise we keep the markdown ``body`` to preserve links and formatting.
+    """
+    body = (comment.get("body") or "").strip()
+    if _BOT_TEMPLATE_MARKER in body:
+        body_text = (comment.get("body_text") or "").strip()
+        if body_text:
+            return body_text
+    return body
+
 
 async def github_update_pr(
     repo_owner: str,
@@ -216,6 +235,7 @@ async def github_get_pr_comments(
         async with github_client_context() as client:
             response = await client.get(
                 f"/repos/{repo_owner}/{repo_name}/issues/{pr_number}/comments",
+                accept="application/vnd.github.full+json",
                 params={"per_page": 100},
             )
 
@@ -232,7 +252,7 @@ async def github_get_pr_comments(
         for c in comments:
             author = c.get("user", {}).get("login", "unknown")
             created = c.get("created_at", "")
-            body = (c.get("body") or "").strip()
+            body = _select_rendered_body(c)
             comment_id = c.get("id", "")
             lines.append(f"  #{comment_id} by {author} ({created}):")
             lines.append(f"    {body}\n")
@@ -263,6 +283,7 @@ async def github_get_pr_reviews(repo_owner: str, repo_name: str, pr_number: int)
         async with github_client_context() as client:
             response = await client.get(
                 f"/repos/{repo_owner}/{repo_name}/pulls/{pr_number}/comments",
+                accept="application/vnd.github.full+json",
                 params={"per_page": 100},
             )
 
@@ -279,16 +300,23 @@ async def github_get_pr_reviews(repo_owner: str, repo_name: str, pr_number: int)
         for c in comments:
             author = c.get("user", {}).get("login", "unknown")
             created = c.get("created_at", "")
-            body = (c.get("body") or "").strip()
+            body = _select_rendered_body(c)
             path = c.get("path", "")
             line = c.get("line") or c.get("original_line", "")
             comment_id = c.get("id", "")
             in_reply_to = c.get("in_reply_to_id", "")
             reply_info = f" (reply to #{in_reply_to})" if in_reply_to else ""
+            diff_hunk = (c.get("diff_hunk") or "").strip()
 
             lines.append(f"  #{comment_id} by {author} ({created}){reply_info}:")
             lines.append(f"    File: {path}:{line}")
-            lines.append(f"    {body}\n")
+            lines.append(f"    {body}")
+            if diff_hunk:
+                lines.append("    Diff hunk:")
+                lines.append("    ```diff")
+                lines.append(diff_hunk)
+                lines.append("    ```")
+            lines.append("")
 
         return "\n".join(lines)
 

--- a/src/mcp_server_git/lean/registry_github.py
+++ b/src/mcp_server_git/lean/registry_github.py
@@ -246,7 +246,7 @@ def _register_github_tools(interface: Any, github_service: Any):
         ToolDefinition(
             name="github_get_pr_comments",
             implementation=github_ops.github_get_pr_comments,
-            description="Get top-level conversation comments on a pull request",
+            description="Get top-level conversation comments on a pull request. Bot template placeholders (e.g. ${{ metadata.patch }}) are auto-expanded via the rendered body.",
             schema={
                 "type": "object",
                 "properties": {
@@ -261,7 +261,7 @@ def _register_github_tools(interface: Any, github_service: Any):
         ToolDefinition(
             name="github_get_pr_reviews",
             implementation=github_ops.github_get_pr_reviews,
-            description="Get inline code review comments on a pull request",
+            description="Get inline code review comments on a pull request. Bot template placeholders (e.g. ${{ metadata.patch }}) are auto-expanded via the rendered body. Diff hunks are included for each comment.",
             schema={
                 "type": "object",
                 "properties": {

--- a/tests/unit/github/test_pr_actions.py
+++ b/tests/unit/github/test_pr_actions.py
@@ -1,0 +1,203 @@
+"""
+Unit tests for github_get_pr_comments and github_get_pr_reviews functions.
+
+Tests bot-template placeholder expansion via rendered body_text and diff_hunk
+inclusion in review comment output.
+"""
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.mcp_server_git.github.pr_actions import (
+    github_get_pr_comments,
+    github_get_pr_reviews,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FULL_MEDIA_TYPE = "application/vnd.github.full+json"
+
+
+def _make_client(get_return):
+    client = MagicMock()
+    client.get = AsyncMock(return_value=get_return)
+    return client
+
+
+@asynccontextmanager
+async def _client_ctx(client):
+    yield client
+
+
+def _patch_client(client):
+    return patch(
+        "src.mcp_server_git.github.pr_actions.github_client_context",
+        return_value=_client_ctx(client),
+    )
+
+
+def _make_response(data: list, status: int = 200):
+    response = MagicMock()
+    response.status = status
+    response.json = AsyncMock(return_value=data)
+    response.text = AsyncMock(return_value="error")
+    return response
+
+
+def _review_comment(**overrides) -> dict:
+    base: dict = {
+        "id": 1,
+        "user": {"login": "bot"},
+        "created_at": "2024-01-01T00:00:00Z",
+        "body": "Plain comment",
+        "body_text": "",
+        "path": "src/foo.py",
+        "line": 42,
+        "in_reply_to_id": None,
+        "diff_hunk": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def _issue_comment(**overrides) -> dict:
+    base: dict = {
+        "id": 1,
+        "user": {"login": "bot"},
+        "created_at": "2024-01-01T00:00:00Z",
+        "body": "Plain comment",
+        "body_text": "",
+    }
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# github_get_pr_reviews tests
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubGetPrReviews:
+    @pytest.mark.asyncio
+    async def test_get_pr_reviews_returns_rendered_body_text_when_body_contains_template_placeholder(
+        self,
+    ):
+        """body_text is used when body contains ${{ template syntax }}."""
+        comment = _review_comment(
+            body="Suggestion:\n\n```yml\n${{ metadata.patch }}\n```",
+            body_text="Suggestion:\n\n```yml\n- old: foo\n+ new: bar\n```",
+        )
+        client = _make_client(_make_response([comment]))
+
+        with _patch_client(client):
+            result = await github_get_pr_reviews("owner", "repo", 1)
+
+        assert "old: foo" in result
+        assert "new: bar" in result
+        assert "${{" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_pr_reviews_keeps_markdown_body_when_no_template_placeholder(
+        self,
+    ):
+        """Markdown body is preserved when no template placeholders present."""
+        comment = _review_comment(body="**Bold** comment with [link](http://x)")
+        client = _make_client(_make_response([comment]))
+
+        with _patch_client(client):
+            result = await github_get_pr_reviews("owner", "repo", 1)
+
+        assert "**Bold**" in result
+
+    @pytest.mark.asyncio
+    async def test_get_pr_reviews_includes_diff_hunk_when_present(self):
+        """Diff hunk block is appended to output when diff_hunk is non-empty."""
+        hunk = "@@ -1,3 +1,3 @@\n-old\n+new"
+        comment = _review_comment(diff_hunk=hunk)
+        client = _make_client(_make_response([comment]))
+
+        with _patch_client(client):
+            result = await github_get_pr_reviews("owner", "repo", 1)
+
+        assert "Diff hunk:" in result
+        assert "-old" in result
+        assert "+new" in result
+
+    @pytest.mark.asyncio
+    async def test_get_pr_reviews_omits_diff_hunk_when_empty(self):
+        """Diff hunk block is absent when diff_hunk is empty."""
+        comment = _review_comment(diff_hunk="")
+        client = _make_client(_make_response([comment]))
+
+        with _patch_client(client):
+            result = await github_get_pr_reviews("owner", "repo", 1)
+
+        assert "Diff hunk:" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_pr_reviews_requests_full_media_type(self):
+        """client.get is called with accept=application/vnd.github.full+json."""
+        comment = _review_comment()
+        client = _make_client(_make_response([comment]))
+
+        with _patch_client(client):
+            await github_get_pr_reviews("owner", "repo", 1)
+
+        client.get.assert_awaited_once()
+        _, kwargs = client.get.call_args
+        assert kwargs.get("accept") == _FULL_MEDIA_TYPE
+
+    @pytest.mark.asyncio
+    async def test_get_pr_reviews_handles_empty_response_returns_no_comments_message(
+        self,
+    ):
+        """Empty list from API returns a 'no review comments' message."""
+        client = _make_client(_make_response([]))
+
+        with _patch_client(client):
+            result = await github_get_pr_reviews("owner", "repo", 1)
+
+        assert "No review comments" in result
+
+
+# ---------------------------------------------------------------------------
+# github_get_pr_comments tests
+# ---------------------------------------------------------------------------
+
+
+class TestGitHubGetPrComments:
+    @pytest.mark.asyncio
+    async def test_get_pr_comments_returns_rendered_body_text_when_body_contains_template_placeholder(
+        self,
+    ):
+        """body_text is used when body contains ${{ template syntax }}."""
+        comment = _issue_comment(
+            body="Suggestion:\n\n```yml\n${{ metadata.patch }}\n```",
+            body_text="Suggestion:\n\n```yml\n- old: foo\n+ new: bar\n```",
+        )
+        client = _make_client(_make_response([comment]))
+
+        with _patch_client(client):
+            result = await github_get_pr_comments("owner", "repo", 1)
+
+        assert "old: foo" in result
+        assert "new: bar" in result
+        assert "${{" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_pr_comments_requests_full_media_type(self):
+        """client.get is called with accept=application/vnd.github.full+json."""
+        comment = _issue_comment()
+        client = _make_client(_make_response([comment]))
+
+        with _patch_client(client):
+            await github_get_pr_comments("owner", "repo", 1)
+
+        client.get.assert_awaited_once()
+        _, kwargs = client.get.call_args
+        assert kwargs.get("accept") == _FULL_MEDIA_TYPE


### PR DESCRIPTION
## Summary

`github_get_pr_reviews` and `github_get_pr_comments` returned the raw markdown `body` from the GitHub REST API. When a bot (Copilot review, custom GitHub App) posts a comment whose body contains template placeholders such as `${{ metadata.patch }}`, GitHub renders those server-side **only** when the response is requested with the `application/vnd.github.full+json` media type (which adds `body_html` and `body_text` to the payload). Until now we always sent `application/vnd.github.v3+json`, so callers received the un-expanded template and had no way to recover the actual diff suggestion content.

## Changes

- **`client.py`** — `GitHubClient.get()` gains a keyword-only `accept` parameter (default unchanged). Backward-compatible per-call override; other HTTP methods untouched.
- **`pr_actions.py`** — both PR comment fetches request `application/vnd.github.full+json`. New `_select_rendered_body()` helper returns `body_text` when the markdown body contains `${{` template syntax, otherwise preserves the markdown `body` so links and code formatting survive for normal human-authored comments.
- **`pr_actions.py`** — `github_get_pr_reviews` now surfaces the comment's `diff_hunk` in a fenced ```diff block (omitted when empty), giving callers the code context for inline suggestions.
- **`registry_github.py`** — tool descriptions document the placeholder expansion and diff-hunk inclusion.
- **`tests/unit/github/test_pr_actions.py`** — new test module (8 tests) covering placeholder→body_text fallback, markdown preservation, diff_hunk inclusion/omission, accept-header propagation, and empty-response handling for both functions.

## Why this matters

Users running PR review automation against PRs that include bot-authored review suggestions previously saw `${{ metadata.patch }}` verbatim in the response, which is unusable. The fix recovers the rendered patch and adds the diff hunk so the agent driving the review has enough context to act on the suggestion.

## Test plan

- [x] `pixi run -e quality lint` — clean (ruff F/E9 zero violations on touched files)
- [x] `pixi run -e quality test tests/unit/github/test_pr_actions.py` — 8/8 pass
- [x] `pixi run -e quality test` — full suite green, no regressions
- [ ] Manual verification against a real PR containing a Copilot review suggestion (recommended for reviewer)

## Backward compatibility

- `GitHubClient.get()` keyword-only `accept` defaults to the existing media type, so all other call sites are unaffected.
- Output format for `github_get_pr_comments` is unchanged for non-bot comments (markdown body preserved).
- Output format for `github_get_pr_reviews` adds an optional `Diff hunk:` block per comment when the API returns one. Existing parsers reading the human-readable text will see additional lines but no removed fields.