### PR TITLE
fix(azure): 401 fallback to anonymous for read-only requests

### DIFF
--- a/src/mcp_server_git/azure/client.py
+++ b/src/mcp_server_git/azure/client.py
@@ -71,7 +71,16 @@ class AzureClient:
         # Only pass auth kwarg when we have credentials; passing auth=None
         # still causes aiohttp to omit the header, but being explicit is safer.
         if auth is not None:
-            return await self.session.get(url, auth=auth, headers=headers, **kwargs)
+            response = await self.session.get(url, auth=auth, headers=headers, **kwargs)
+            if response.status == 401:
+                # Stale or expired PAT — retry without auth so public projects
+                # can still be reached anonymously.
+                await response.release()
+                logger.warning(
+                    "Azure 401 with auth — retrying anonymously for public project access"
+                )
+                response = await self.session.get(url, headers=headers, **kwargs)
+            return response
         return await self.session.get(url, headers=headers, **kwargs)
 
     async def post(self, endpoint: str, **kwargs) -> aiohttp.ClientResponse:

--- a/tests/unit/azure/test_azure_client.py
+++ b/tests/unit/azure/test_azure_client.py
@@ -151,3 +151,87 @@ class TestAzureClientMethods:
             call_args[0][0]
             == "https://dev.azure.com/myorg/myproject/_apis/build/builds"
         )
+
+
+class TestAzureClient401Fallback:
+    """Test GET 401 anonymous fallback behaviour."""
+
+    @pytest.mark.asyncio
+    async def test_get_retries_without_auth_on_401_when_token_present(self):
+        """GET with auth that returns 401 is retried anonymously; second response returned."""
+        session = MagicMock()
+
+        mock_401 = MagicMock()
+        mock_401.status = 401
+        mock_401.release = AsyncMock()
+
+        mock_200 = MagicMock()
+        mock_200.status = 200
+
+        session.get = AsyncMock(side_effect=[mock_401, mock_200])
+
+        client = AzureClient(token="a" * 52, organization="myorg", session=session)
+
+        result = await client.get("myproject/_apis/build/builds/1")
+
+        assert session.get.call_count == 2
+        mock_401.release.assert_awaited_once()
+
+        # Second call must NOT carry an auth kwarg
+        second_call_kwargs = session.get.call_args_list[1][1]
+        assert "auth" not in second_call_kwargs
+
+        assert result is mock_200
+
+    @pytest.mark.asyncio
+    async def test_get_does_not_retry_on_401_when_anonymous(self):
+        """GET without a token returns the 401 directly — already anonymous, no retry."""
+        session = MagicMock()
+
+        mock_401 = MagicMock()
+        mock_401.status = 401
+
+        session.get = AsyncMock(return_value=mock_401)
+
+        client = AzureClient(token=None, organization="myorg", session=session)
+
+        result = await client.get("myproject/_apis/build/builds/1")
+
+        assert session.get.call_count == 1
+        assert result is mock_401
+
+    @pytest.mark.asyncio
+    async def test_get_returns_first_response_on_200(self):
+        """GET with auth that returns 200 is returned directly without a retry."""
+        session = MagicMock()
+
+        mock_200 = MagicMock()
+        mock_200.status = 200
+
+        session.get = AsyncMock(return_value=mock_200)
+
+        client = AzureClient(token="a" * 52, organization="myorg", session=session)
+
+        result = await client.get("myproject/_apis/build/builds/1")
+
+        assert session.get.call_count == 1
+        assert result is mock_200
+
+    @pytest.mark.asyncio
+    async def test_post_does_not_retry_on_401(self):
+        """POST 401 is propagated unchanged — writes require valid auth."""
+        session = MagicMock()
+
+        mock_401 = MagicMock()
+        mock_401.status = 401
+
+        session.post = AsyncMock(return_value=mock_401)
+
+        client = AzureClient(token="a" * 52, organization="myorg", session=session)
+
+        result = await client.post("myproject/_apis/build/builds")
+
+        session.post.assert_called_once()
+        # Confirm GET was never called
+        session.get.assert_not_called()
+        assert result is mock_401


### PR DESCRIPTION
## Summary

PR #165 enabled anonymous access to public Azure DevOps projects when `AZURE_DEVOPS_TOKEN` is unset. However, live testing against build 1517588 exposed a remaining gap: when a **stale or expired PAT** is present in the environment, the client still attaches `BasicAuth` and Azure returns `401 ("Personal Access Token has expired")` before the anonymous code path can engage.

This patch makes GET requests robust to stale credentials by transparently retrying without auth on 401.

## Gap Left by PR #165

The anonymous path in #165 is gated on `token is None`. If `AZURE_DEVOPS_TOKEN` is set (even to an expired value), `_auth()` returns a `BasicAuth` object and the request is sent with credentials. Azure then rejects it at the auth layer — the public-project anonymous path is never tried.

Build 1517588 returned 401 from the merged code precisely because an expired PAT was still set in the env.

## Fix

In `AzureClient.get()`, after a first-attempt 401 with auth attached:
1. Release the 401 response.
2. Log a warning.
3. Retry the GET without the auth header.
4. Return the second response (success for public projects; 401 for private).

POST and PATCH are unchanged — writes require valid auth.

## Behavior Table

| Scenario | Behaviour |
|---|---|
| GET with auth -> 200 | Returned directly, no retry |
| GET with auth -> 401 (expired/stale PAT) | Retried anonymously; second response returned |
| GET without auth -> 401 | Returned directly (already anonymous, no retry) |
| POST/PATCH -> 401 | Propagated unchanged (writes require valid auth) |

## Test Coverage

New class `TestAzureClient401Fallback` in `tests/unit/azure/test_azure_client.py` covers all four paths:

- `test_get_retries_without_auth_on_401_when_token_present` — verifies 2 calls, release awaited, second call has no `auth` kwarg, returns 200 response
- `test_get_does_not_retry_on_401_when_anonymous` — verifies only 1 call when token is None
- `test_get_returns_first_response_on_200` — verifies no retry when first response is 200
- `test_post_does_not_retry_on_401` — verifies POST 401 propagated, GET never called

## Files Changed

- `src/mcp_server_git/azure/client.py` — GET retry logic (6 lines added)
- `tests/unit/azure/test_azure_client.py` — `TestAzureClient401Fallback` class (4 tests)