### PR TITLE
feat: close branch-list / push-delete / default-branch gaps (#171-#176)

### DIFF
--- a/src/mcp_server_git/git/_branch_ops.py
+++ b/src/mcp_server_git/git/_branch_ops.py
@@ -219,6 +219,50 @@ def _collect_remote_branches(repo: Repo) -> list[dict[str, Any]]:
     return records
 
 
+def _collect_sorted_branches(
+    repo: Repo,
+    effective_type: Literal["local", "remote", "all"],
+    sort: str,
+) -> list[dict[str, Any]]:
+    """Collect branches in sorted order using git for-each-ref."""
+    patterns: list[str]
+    if effective_type == "local":
+        patterns = ["refs/heads"]
+    elif effective_type == "remote":
+        patterns = ["refs/remotes"]
+    else:
+        patterns = ["refs/heads", "refs/remotes"]
+
+    fmt = "%(refname:short)%00%(objectname)%00%(upstream:short)"
+    raw = repo.git.for_each_ref(f"--sort={sort}", f"--format={fmt}", *patterns)
+
+    try:
+        active = repo.active_branch.name
+    except TypeError:
+        active = None  # detached HEAD
+
+    records = []
+    for line in raw.splitlines():
+        if not line:
+            continue
+        parts = line.split("\x00")
+        if len(parts) < 3:  # pragma: no cover
+            continue
+        name, sha, upstream = parts[0], parts[1], parts[2]
+        # Skip remote HEAD symbolic refs
+        if name.endswith("/HEAD"):
+            continue
+        records.append(
+            _build_branch_record(
+                name=name,
+                sha=sha,
+                is_current=(name == active),
+                upstream=upstream if upstream else None,
+            )
+        )
+    return records
+
+
 def _format_branches(records: list[dict[str, Any]]) -> str:
     if not records:
         return "No branches found"
@@ -237,6 +281,7 @@ def git_branch_list(
     pattern: str | None = None,
     contains: str | None = None,
     merged: bool | None = None,
+    sort: str | None = None,
     # Deprecated back-compat aliases — derive branch_type from these if branch_type
     # is at default ("local") and no explicit branch_type was set.
     remote: bool = False,
@@ -250,6 +295,7 @@ def git_branch_list(
         pattern: Optional fnmatch glob to filter branch names, e.g. 'feature/*'
         contains: commit-ish; only branches containing this commit are returned
         merged: True = only merged into HEAD, False = only unmerged, None = no filter
+        sort: Sort key for git for-each-ref, e.g. '-committerdate'. None = legacy path.
         remote: Deprecated. Use branch_type='remote' instead.
         all: Deprecated. Use branch_type='all' instead.
 
@@ -260,7 +306,9 @@ def git_branch_list(
         effective_type = _resolve_branch_type(branch_type, remote, all)
 
         # Collect candidate records
-        if effective_type == "local":
+        if sort is not None:
+            records = _collect_sorted_branches(repo, effective_type, sort)
+        elif effective_type == "local":
             records = _collect_local_branches(repo)
         elif effective_type == "remote":
             records = _collect_remote_branches(repo)

--- a/src/mcp_server_git/git/_branch_ops.py
+++ b/src/mcp_server_git/git/_branch_ops.py
@@ -1,6 +1,8 @@
 """Branch operations for MCP Git Server."""
 
+import fnmatch
 import logging
+from typing import Any, Literal
 
 from ..utils.git_import import GitCommandError, Repo
 
@@ -116,43 +118,173 @@ def git_checkout(repo: Repo, branch_name: str) -> str:
         return f"❌ Checkout error: {str(e)}"
 
 
+def _resolve_branch_type(
+    branch_type: Literal["local", "remote", "all"],
+    remote: bool,
+    all: bool,  # noqa: A002
+) -> Literal["local", "remote", "all"]:
+    """Resolve branch_type from new param or legacy bool aliases."""
+    legacy_used = remote or all
+    explicit_type = branch_type != "local"
+
+    if explicit_type and legacy_used:
+        raise ValueError(
+            "Cannot combine 'branch_type' with legacy 'remote'/'all' flags. "
+            "Use 'branch_type' only."
+        )
+
+    if legacy_used:
+        if all:
+            return "all"
+        return "remote"
+
+    return branch_type
+
+
+def _get_contains_set(repo: Repo, contains: str) -> set[str]:
+    """Return set of branch names (stripped) that contain the given commit-ish."""
+    raw = repo.git.branch("--contains", contains)
+    names = set()
+    for line in raw.splitlines():
+        name = line.lstrip("* ").strip()
+        if name:
+            names.add(name)
+    return names
+
+
+def _get_merged_set(repo: Repo, *, merged: bool) -> set[str]:
+    """Return set of branch names filtered by --merged or --no-merged."""
+    flag = "--merged" if merged else "--no-merged"
+    raw = repo.git.branch(flag)
+    names = set()
+    for line in raw.splitlines():
+        name = line.lstrip("* ").strip()
+        if name:
+            names.add(name)
+    return names
+
+
+def _build_branch_record(
+    name: str,
+    sha: str,
+    is_current: bool,
+    upstream: str | None,
+) -> dict[str, Any]:
+    return {"name": name, "sha": sha, "is_current": is_current, "upstream": upstream}
+
+
+def _collect_local_branches(repo: Repo) -> list[dict[str, Any]]:
+    """Collect local branch records."""
+    try:
+        active = repo.active_branch.name
+    except TypeError:
+        active = None  # detached HEAD
+
+    records = []
+    for head in repo.branches:
+        try:
+            upstream = (
+                head.tracking_branch().name
+                if head.tracking_branch() is not None
+                else None
+            )
+        except Exception:
+            upstream = None
+        records.append(
+            _build_branch_record(
+                name=head.name,
+                sha=head.commit.hexsha,
+                is_current=(head.name == active),
+                upstream=upstream,
+            )
+        )
+    return records
+
+
+def _collect_remote_branches(repo: Repo) -> list[dict[str, Any]]:
+    """Collect remote branch records (remotes/origin/... style names)."""
+    records = []
+    for remote in repo.remotes:
+        for ref in remote.refs:
+            if ref.name.endswith("/HEAD"):
+                continue
+            records.append(
+                _build_branch_record(
+                    name=ref.name,
+                    sha=ref.commit.hexsha,
+                    is_current=False,
+                    upstream=None,
+                )
+            )
+    return records
+
+
+def _format_branches(records: list[dict[str, Any]]) -> str:
+    if not records:
+        return "No branches found"
+    lines = []
+    for r in records:
+        marker = "* " if r["is_current"] else "  "
+        sha_short = r["sha"][:8]
+        upstream_info = f" -> {r['upstream']}" if r["upstream"] else ""
+        lines.append(f"{marker}{r['name']} [{sha_short}]{upstream_info}")
+    return "Branches:\n" + "\n".join(lines)
+
+
 def git_branch_list(
     repo: Repo,
-    remote: bool = False,
-    all: bool = False,
+    branch_type: Literal["local", "remote", "all"] = "local",
     pattern: str | None = None,
+    contains: str | None = None,
+    merged: bool | None = None,
+    # Deprecated back-compat aliases — derive branch_type from these if branch_type
+    # is at default ("local") and no explicit branch_type was set.
+    remote: bool = False,
+    all: bool = False,  # noqa: A002
 ) -> str:
-    """List branches in the repository
+    """List branches in the repository.
 
     Args:
         repo: Repository object
-        remote: If True, list remote branches (git branch -r)
-        all: If True, list all branches including remote (git branch -a)
-        pattern: Optional pattern to filter branches (supports glob patterns like 'feature/*')
+        branch_type: Which branches to list — "local" (default), "remote", or "all"
+        pattern: Optional fnmatch glob to filter branch names, e.g. 'feature/*'
+        contains: commit-ish; only branches containing this commit are returned
+        merged: True = only merged into HEAD, False = only unmerged, None = no filter
+        remote: Deprecated. Use branch_type='remote' instead.
+        all: Deprecated. Use branch_type='all' instead.
 
     Returns:
-        String containing the list of branches
+        Formatted string listing branches with sha and upstream info.
     """
     try:
-        args = []
+        effective_type = _resolve_branch_type(branch_type, remote, all)
 
-        # Add branch listing flags
-        if all:
-            args.append("-a")
-        elif remote:
-            args.append("-r")
+        # Collect candidate records
+        if effective_type == "local":
+            records = _collect_local_branches(repo)
+        elif effective_type == "remote":
+            records = _collect_remote_branches(repo)
+        else:  # "all"
+            records = _collect_local_branches(repo) + _collect_remote_branches(repo)
 
-        # When using pattern, we need to add --list flag
+        # Apply pattern filter
         if pattern and pattern.strip():
-            args.append("--list")
-            args.append(pattern)
+            records = [r for r in records if fnmatch.fnmatch(r["name"], pattern)]
 
-        branch_output = repo.git.branch(*args)
+        # Apply contains filter
+        if contains is not None:
+            allowed = _get_contains_set(repo, contains)
+            records = [r for r in records if r["name"] in allowed]
 
-        if not branch_output.strip():
-            return "No branches found"
+        # Apply merged filter
+        if merged is not None:
+            allowed = _get_merged_set(repo, merged=merged)
+            records = [r for r in records if r["name"] in allowed]
 
-        return f"Branches:\n{branch_output}"
+        return _format_branches(records)
+
+    except ValueError as e:
+        return f"❌ Branch list error: {str(e)}"
     except GitCommandError as e:
         return f"❌ Branch list failed: {str(e)}"
     except Exception as e:

--- a/src/mcp_server_git/git/_remote_ops.py
+++ b/src/mcp_server_git/git/_remote_ops.py
@@ -69,6 +69,7 @@ def git_push(
     force_if_includes: bool = False,
     delete: bool = False,
     refspec: str | None = None,
+    dry_run: bool = False,
 ) -> str:
     """Push with comprehensive authentication including fallback to system git credentials.
 
@@ -89,6 +90,10 @@ def git_push(
         Requires ``branch``; mutually exclusive with force/refspec.
       - ``refspec``: raw push refspec (e.g. ``src:dst`` or ``:branch``).
         Mutually exclusive with ``branch``/``delete``.
+
+    Dry-run control (issue #176):
+      - ``dry_run``: maps to ``--dry-run``. Compatible with all push modes.
+        When True, git reports what would be pushed without modifying remote state.
     """
     try:
         # Validate force-push parameter combinations (issue #161)
@@ -118,13 +123,17 @@ def git_push(
 
         # Handle raw refspec push
         if refspec is not None:
-            repo.git.push(remote, refspec)
-            return f"✅ Successfully pushed refspec '{refspec}' to {remote}"
+            extra = ["--dry-run"] if dry_run else []
+            repo.git.push(remote, refspec, *extra)
+            suffix = " (dry-run; no remote state modified)" if dry_run else ""
+            return f"✅ Successfully pushed refspec '{refspec}' to {remote}{suffix}"
 
         # Handle delete remote branch
         if delete:
-            repo.git.push(remote, "--delete", branch)
-            return f"✅ Successfully deleted remote branch '{branch}' from {remote}"
+            extra = ["--dry-run"] if dry_run else []
+            repo.git.push(remote, "--delete", branch, *extra)
+            suffix = " (dry-run; no remote state modified)" if dry_run else ""
+            return f"✅ Successfully deleted remote branch '{branch}' from {remote}{suffix}"
 
         # Get current branch if not specified
         if not branch:
@@ -155,6 +164,8 @@ def git_push(
         if force_if_includes:
             # Compatible with --force-with-lease; harmless without it on git 2.30+.
             push_args.insert(0, "--force-if-includes")
+        if dry_run:
+            push_args.append("--dry-run")
 
         # Get remote URL for GitHub authentication handling (cache for reuse)
         remote_url = ""
@@ -210,6 +221,8 @@ def git_push(
                         success_msg = f"✅ Successfully pushed {branch} to {remote}"
                         if set_upstream:
                             success_msg += " (set upstream tracking)"
+                        if dry_run:
+                            success_msg += " (dry-run; no remote state modified)"
 
                         # Indicate which authentication method was used
                         if os.getenv("GITHUB_TOKEN"):
@@ -251,6 +264,8 @@ def git_push(
                         success_msg = f"✅ Successfully pushed {branch} to {remote}"
                         if set_upstream:
                             success_msg += " (set upstream tracking)"
+                        if dry_run:
+                            success_msg += " (dry-run; no remote state modified)"
                         success_msg += "\n🔐 Used system git authentication"
                         return success_msg
                     else:
@@ -292,6 +307,8 @@ def git_push(
             success_msg = f"✅ Successfully pushed {branch} to {remote}"
             if set_upstream:
                 success_msg += " (set upstream tracking)"
+            if dry_run:
+                success_msg += " (dry-run; no remote state modified)"
             return success_msg
         except GitCommandError as e:
             # If regular push fails and this is GitHub HTTPS, suggest auth options

--- a/src/mcp_server_git/git/_remote_ops.py
+++ b/src/mcp_server_git/git/_remote_ops.py
@@ -67,6 +67,8 @@ def git_push(
     force_with_lease: bool = False,
     force_with_lease_expect: str | None = None,
     force_if_includes: bool = False,
+    delete: bool = False,
+    refspec: str | None = None,
 ) -> str:
     """Push with comprehensive authentication including fallback to system git credentials.
 
@@ -81,6 +83,12 @@ def git_push(
         Composes with ``--force-with-lease`` to also detect rebase-on-stale-base.
 
     ``force`` and ``force_with_lease`` are mutually exclusive.
+
+    Delete / refspec controls (issue #173):
+      - ``delete``: maps to ``--delete <branch>`` (delete remote branch).
+        Requires ``branch``; mutually exclusive with force/refspec.
+      - ``refspec``: raw push refspec (e.g. ``src:dst`` or ``:branch``).
+        Mutually exclusive with ``branch``/``delete``.
     """
     try:
         # Validate force-push parameter combinations (issue #161)
@@ -91,6 +99,32 @@ def git_push(
             )
         if force_with_lease_expect is not None and not force_with_lease:
             return "❌ force_with_lease_expect requires force_with_lease=True"
+
+        # Validate delete/refspec combinations (issue #173)
+        if delete:
+            if not branch:
+                return "❌ delete=True requires branch to be set"
+            if force or force_with_lease or force_if_includes:
+                return "❌ delete=True cannot be combined with force/force_with_lease/force_if_includes"
+            if set_upstream:
+                return "❌ delete=True cannot be combined with set_upstream"
+            if refspec is not None:
+                return "❌ delete=True cannot be combined with refspec"
+        if refspec is not None:
+            if branch is not None:
+                return "❌ refspec cannot be combined with branch"
+            if set_upstream:
+                return "❌ refspec cannot be combined with set_upstream"
+
+        # Handle raw refspec push
+        if refspec is not None:
+            repo.git.push(remote, refspec)
+            return f"✅ Successfully pushed refspec '{refspec}' to {remote}"
+
+        # Handle delete remote branch
+        if delete:
+            repo.git.push(remote, "--delete", branch)
+            return f"✅ Successfully deleted remote branch '{branch}' from {remote}"
 
         # Get current branch if not specified
         if not branch:

--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -130,6 +130,13 @@ class GitPush(BaseModel):
             "Mutually exclusive with branch/delete."
         ),
     )
+    dry_run: bool = Field(
+        False,
+        description=(
+            "Show what would be pushed without actually pushing (git push --dry-run). "
+            "Compatible with all push modes including delete and refspec."
+        ),
+    )
 
     @model_validator(mode="after")
     def _validate_delete_and_refspec(self) -> "GitPush":
@@ -234,6 +241,11 @@ class GitBranchList(BaseModel):
     )
     merged: bool | None = Field(
         None, description="True=only merged into HEAD, False=only unmerged, None=no filter"
+    )
+    sort: str | None = Field(
+        None,
+        description="Sort key, e.g. '-committerdate' (most-recent first), 'refname', 'authordate'. "
+                    "Mirrors `git for-each-ref --sort=<key>` semantics. None = no ordering guarantee.",
     )
 
 

--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -1,6 +1,8 @@
 """Pydantic models for Git operations"""
 
-from pydantic import AliasChoices, BaseModel, Field
+from typing import Literal
+
+from pydantic import AliasChoices, BaseModel, Field, model_validator
 
 
 class GitStatus(BaseModel):
@@ -113,6 +115,43 @@ class GitPush(BaseModel):
     force_with_lease: bool = False
     force_with_lease_expect: str | None = None  # "<refname>:<sha>" or "<sha>"
     force_if_includes: bool = False  # git 2.30+, composes with force_with_lease
+    # Issue #173: delete remote branch and raw refspec support
+    delete: bool = Field(
+        False,
+        description=(
+            "Delete the remote branch (git push <remote> --delete <branch>). "
+            "Mutually exclusive with force/refspec."
+        ),
+    )
+    refspec: str | None = Field(
+        None,
+        description=(
+            "Raw push refspec (e.g., 'src:dst' or ':branch' to delete). "
+            "Mutually exclusive with branch/delete."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def _validate_delete_and_refspec(self) -> "GitPush":
+        if self.delete:
+            if not self.branch:
+                raise ValueError("delete=True requires branch to be set")
+            if self.force or self.force_with_lease or self.force_if_includes:
+                raise ValueError(
+                    "delete=True cannot be combined with force/force_with_lease/force_if_includes"
+                )
+            if self.set_upstream:
+                raise ValueError("delete=True cannot be combined with set_upstream")
+            if self.refspec is not None:
+                raise ValueError("delete=True cannot be combined with refspec")
+        if self.refspec is not None:
+            if self.branch is not None:
+                raise ValueError("refspec cannot be combined with branch")
+            if self.delete:
+                raise ValueError("refspec cannot be combined with delete")
+            if self.set_upstream:
+                raise ValueError("refspec cannot be combined with set_upstream")
+        return self
 
 
 class GitPull(BaseModel):
@@ -184,9 +223,18 @@ class GitSecurityEnforce(BaseModel):
 
 class GitBranchList(BaseModel):
     repo_path: str
-    remote: bool = False
-    all: bool = False
-    pattern: str | None = None
+    branch_type: Literal["local", "remote", "all"] = Field(
+        "local", description="Which branches to list: local, remote, or all"
+    )
+    pattern: str | None = Field(
+        None, description="fnmatch glob filter, e.g. 'feature/*'"
+    )
+    contains: str | None = Field(
+        None, description="commit-ish; only branches containing this commit"
+    )
+    merged: bool | None = Field(
+        None, description="True=only merged into HEAD, False=only unmerged, None=no filter"
+    )
 
 
 class GitMergeBase(BaseModel):

--- a/src/mcp_server_git/github/models.py
+++ b/src/mcp_server_git/github/models.py
@@ -419,6 +419,7 @@ class GitHubUpdateRepoSettings(BaseModel):
     homepage: str | None = None
     private: bool | None = None
     visibility: str | None = None  # public, private, internal
+    default_branch: str | None = None
     # Feature toggles
     has_issues: bool | None = None
     has_projects: bool | None = None

--- a/src/mcp_server_git/github/repos.py
+++ b/src/mcp_server_git/github/repos.py
@@ -102,6 +102,7 @@ async def github_update_repo_settings(
     homepage: str | None = None,
     private: bool | None = None,
     visibility: str | None = None,
+    default_branch: str | None = None,
     has_issues: bool | None = None,
     has_projects: bool | None = None,
     has_wiki: bool | None = None,
@@ -135,6 +136,8 @@ async def github_update_repo_settings(
                 payload["private"] = private
             if visibility is not None:
                 payload["visibility"] = visibility
+            if default_branch is not None:
+                payload["default_branch"] = default_branch
             if has_issues is not None:
                 payload["has_issues"] = has_issues
             if has_projects is not None:

--- a/src/mcp_server_git/lean/registry_git.py
+++ b/src/mcp_server_git/lean/registry_git.py
@@ -7,6 +7,7 @@ from ..git import operations as git_ops
 from ..git.models import (
     GitAbort,
     GitAdd,
+    GitBranchList,
     GitBranchUpdate,
     GitCheckout,
     GitCherryPick,
@@ -446,6 +447,14 @@ def _register_git_tools(interface: Any, git_service: Any):
             schema=GitRestore.model_json_schema(),
             domain="git",
             complexity="core",
+        ),
+        ToolDefinition(
+            name="git_branch_list",
+            implementation=wrap_repo_op(git_ops.git_branch_list),
+            description="List branches (local, remote, or all) with optional pattern, contains, and merged filters",
+            schema=GitBranchList.model_json_schema(),
+            domain="git",
+            complexity="focused",
         ),
         ToolDefinition(
             name="git_branch_update",

--- a/tests/unit/git/test_git_branch_list.py
+++ b/tests/unit/git/test_git_branch_list.py
@@ -5,7 +5,7 @@ These tests verify the git_branch_list function that lists local and remote bran
 with optional filtering capabilities.
 """
 
-from unittest.mock import Mock
+from unittest.mock import MagicMock, Mock, PropertyMock
 
 import pytest
 
@@ -13,159 +13,326 @@ from mcp_server_git.git.operations import git_branch_list
 from mcp_server_git.utils.git_import import GitCommandError
 
 
-class TestGitBranchList:
-    """Test git_branch_list operations with comprehensive validation."""
+def _make_head(name: str, sha: str, is_active: bool = False, tracking: str | None = None) -> Mock:
+    """Build a mock GitPython Head object."""
+    head = Mock()
+    head.name = name
+    head.commit.hexsha = sha
+    if tracking:
+        tb = Mock()
+        tb.name = tracking
+        head.tracking_branch.return_value = tb
+    else:
+        head.tracking_branch.return_value = None
+    return head
 
-    def test_git_branch_list_local_branches_successfully(self):
-        """Should list local branches successfully (default behavior)."""
-        # Arrange
-        mock_repo = Mock()
-        mock_repo.git.branch.return_value = "  develop\n* main\n  feature/new-feature"
 
-        # Act
-        result = git_branch_list(mock_repo)
+def _make_remote_ref(name: str, sha: str) -> Mock:
+    ref = Mock()
+    ref.name = name
+    ref.commit.hexsha = sha
+    return ref
 
-        # Assert
+
+def _make_repo(
+    local_heads: list[Mock],
+    active_name: str | None = None,
+    remotes: list[list[Mock]] | None = None,
+) -> Mock:
+    """Build a minimal mock Repo."""
+    repo = Mock()
+
+    # repo.branches → list of local head mocks
+    type(repo).branches = PropertyMock(return_value=local_heads)
+
+    # repo.active_branch
+    if active_name is not None:
+        active = Mock()
+        active.name = active_name
+        type(repo).active_branch = PropertyMock(return_value=active)
+    else:
+        # Simulate detached HEAD
+        active_prop = PropertyMock(side_effect=TypeError("detached HEAD"))
+        type(repo).active_branch = active_prop
+
+    # repo.remotes
+    remote_mocks = []
+    for ref_list in (remotes or []):
+        remote = Mock()
+        remote.refs = ref_list
+        remote_mocks.append(remote)
+    type(repo).remotes = PropertyMock(return_value=remote_mocks)
+
+    return repo
+
+
+class TestGitBranchListLocal:
+    """Tests for local branch listing (default behavior)."""
+
+    def test_lists_local_branches_returns_structured_output(self):
+        """Should list local branches with sha and marker."""
+        heads = [
+            _make_head("develop", "aaa" * 14, is_active=False),
+            _make_head("main", "bbb" * 14, is_active=True),
+            _make_head("feature/new-feature", "ccc" * 14),
+        ]
+        repo = _make_repo(heads, active_name="main")
+
+        result = git_branch_list(repo)
+
         assert "Branches:" in result
         assert "develop" in result
-        assert "main" in result
+        assert "* main" in result
         assert "feature/new-feature" in result
-        mock_repo.git.branch.assert_called_once_with()
 
-    def test_git_branch_list_remote_branches_successfully(self):
-        """Should list remote branches when remote=True."""
-        # Arrange
-        mock_repo = Mock()
-        mock_repo.git.branch.return_value = (
-            "  origin/develop\n  origin/main\n  origin/feature/task-1"
-        )
+    def test_lists_local_branches_with_upstream(self):
+        """Should include upstream tracking info when present."""
+        heads = [
+            _make_head("main", "aaa" * 14, is_active=True, tracking="origin/main"),
+        ]
+        repo = _make_repo(heads, active_name="main")
 
-        # Act
-        result = git_branch_list(mock_repo, remote=True)
+        result = git_branch_list(repo)
 
-        # Assert
-        assert "Branches:" in result
-        assert "origin/develop" in result
-        assert "origin/main" in result
-        assert "origin/feature/task-1" in result
-        mock_repo.git.branch.assert_called_once_with("-r")
+        assert "-> origin/main" in result
 
-    def test_git_branch_list_all_branches_successfully(self):
-        """Should list all branches (local and remote) when all=True."""
-        # Arrange
-        mock_repo = Mock()
-        mock_repo.git.branch.return_value = (
-            "  develop\n* main\n  remotes/origin/develop\n  remotes/origin/main"
-        )
+    def test_no_branches_returns_no_branches_found(self):
+        """Should return 'No branches found' when repo has no local branches."""
+        repo = _make_repo([], active_name=None)
 
-        # Act
-        result = git_branch_list(mock_repo, all=True)
+        result = git_branch_list(repo)
 
-        # Assert
-        assert "Branches:" in result
-        assert "develop" in result
-        assert "main" in result
-        assert "remotes/origin/develop" in result
-        assert "remotes/origin/main" in result
-        mock_repo.git.branch.assert_called_once_with("-a")
-
-    def test_git_branch_list_with_pattern_filter(self):
-        """Should filter branches by pattern when pattern is provided."""
-        # Arrange
-        mock_repo = Mock()
-        mock_repo.git.branch.return_value = "  feature/task-1\n  feature/task-2"
-
-        # Act
-        result = git_branch_list(mock_repo, pattern="feature/*")
-
-        # Assert
-        assert "Branches:" in result
-        assert "feature/task-1" in result
-        assert "feature/task-2" in result
-        mock_repo.git.branch.assert_called_once_with("--list", "feature/*")
-
-    def test_git_branch_list_all_with_pattern(self):
-        """Should combine all flag with pattern filtering."""
-        # Arrange
-        mock_repo = Mock()
-        mock_repo.git.branch.return_value = (
-            "  feature/task-1\n  remotes/origin/feature/task-1"
-        )
-
-        # Act
-        result = git_branch_list(mock_repo, all=True, pattern="feature/*")
-
-        # Assert
-        assert "Branches:" in result
-        assert "feature/task-1" in result
-        mock_repo.git.branch.assert_called_once_with("-a", "--list", "feature/*")
-
-    def test_git_branch_list_no_branches_found(self):
-        """Should return appropriate message when no branches are found."""
-        # Arrange
-        mock_repo = Mock()
-        mock_repo.git.branch.return_value = ""
-
-        # Act
-        result = git_branch_list(mock_repo, pattern="nonexistent/*")
-
-        # Assert
         assert "No branches found" in result
 
-    def test_git_branch_list_handles_git_command_error(self):
-        """Should handle GitCommandError gracefully."""
-        # Arrange
-        mock_repo = Mock()
-        mock_repo.git.branch.side_effect = GitCommandError(
-            "branch", "fatal: not a git repository"
+    def test_pattern_filters_branches(self):
+        """Pattern glob should filter branch names."""
+        heads = [
+            _make_head("feature/task-1", "aaa" * 14),
+            _make_head("feature/task-2", "bbb" * 14),
+            _make_head("main", "ccc" * 14, is_active=True),
+        ]
+        repo = _make_repo(heads, active_name="main")
+
+        result = git_branch_list(repo, pattern="feature/*")
+
+        assert "feature/task-1" in result
+        assert "feature/task-2" in result
+        assert "main" not in result
+
+    def test_empty_pattern_is_ignored(self):
+        """Empty pattern string should not filter branches."""
+        heads = [_make_head("main", "aaa" * 14, is_active=True)]
+        repo = _make_repo(heads, active_name="main")
+
+        result = git_branch_list(repo, pattern="")
+
+        assert "main" in result
+
+    def test_pattern_no_match_returns_no_branches_found(self):
+        """Pattern that matches nothing returns 'No branches found'."""
+        heads = [_make_head("main", "aaa" * 14, is_active=True)]
+        repo = _make_repo(heads, active_name="main")
+
+        result = git_branch_list(repo, pattern="nonexistent/*")
+
+        assert "No branches found" in result
+
+
+class TestGitBranchListRemote:
+    """Tests for remote branch listing via branch_type='remote'."""
+
+    def test_lists_remote_branches(self):
+        """branch_type='remote' lists remote refs."""
+        refs = [
+            _make_remote_ref("origin/develop", "aaa" * 14),
+            _make_remote_ref("origin/main", "bbb" * 14),
+        ]
+        repo = _make_repo([], active_name=None, remotes=[refs])
+
+        result = git_branch_list(repo, branch_type="remote")
+
+        assert "origin/develop" in result
+        assert "origin/main" in result
+
+    def test_remote_skips_head_ref(self):
+        """Remote HEAD refs (origin/HEAD) should not appear in output."""
+        refs = [
+            _make_remote_ref("origin/HEAD", "aaa" * 14),
+            _make_remote_ref("origin/main", "bbb" * 14),
+        ]
+        repo = _make_repo([], active_name=None, remotes=[refs])
+
+        result = git_branch_list(repo, branch_type="remote")
+
+        assert "origin/HEAD" not in result
+        assert "origin/main" in result
+
+
+class TestGitBranchListAll:
+    """Tests for all-branches listing via branch_type='all'."""
+
+    def test_lists_local_and_remote(self):
+        """branch_type='all' includes both local and remote branches."""
+        heads = [_make_head("main", "aaa" * 14, is_active=True)]
+        refs = [_make_remote_ref("origin/main", "aaa" * 14)]
+        repo = _make_repo(heads, active_name="main", remotes=[refs])
+
+        result = git_branch_list(repo, branch_type="all")
+
+        assert "* main" in result
+        assert "origin/main" in result
+
+
+class TestGitBranchListContains:
+    """Tests for 'contains' commit-ish filter."""
+
+    def test_contains_filters_to_matching_branches(self):
+        """Only branches containing the given commit should appear."""
+        heads = [
+            _make_head("feature/x", "aaa" * 14),
+            _make_head("main", "bbb" * 14, is_active=True),
+        ]
+        repo = _make_repo(heads, active_name="main")
+        # git branch --contains abc123 returns only 'feature/x'
+        repo.git.branch.return_value = "  feature/x"
+
+        result = git_branch_list(repo, contains="abc123")
+
+        assert "feature/x" in result
+        assert "main" not in result
+        repo.git.branch.assert_called_once_with("--contains", "abc123")
+
+    def test_contains_no_match_returns_no_branches_found(self):
+        """If no branches contain the commit, return 'No branches found'."""
+        heads = [_make_head("main", "aaa" * 14, is_active=True)]
+        repo = _make_repo(heads, active_name="main")
+        repo.git.branch.return_value = ""
+
+        result = git_branch_list(repo, contains="deadbeef")
+
+        assert "No branches found" in result
+
+
+class TestGitBranchListMerged:
+    """Tests for 'merged' filter."""
+
+    def test_merged_true_filters_to_merged_branches(self):
+        """merged=True should keep only branches in --merged output."""
+        heads = [
+            _make_head("merged-feat", "aaa" * 14),
+            _make_head("main", "bbb" * 14, is_active=True),
+        ]
+        repo = _make_repo(heads, active_name="main")
+        repo.git.branch.return_value = "  merged-feat\n* main"
+
+        result = git_branch_list(repo, merged=True)
+
+        assert "merged-feat" in result
+        assert "* main" in result
+        repo.git.branch.assert_called_once_with("--merged")
+
+    def test_merged_false_filters_to_unmerged_branches(self):
+        """merged=False should keep only branches in --no-merged output."""
+        heads = [
+            _make_head("unmerged-feat", "aaa" * 14),
+            _make_head("main", "bbb" * 14, is_active=True),
+        ]
+        repo = _make_repo(heads, active_name="main")
+        repo.git.branch.return_value = "  unmerged-feat"
+
+        result = git_branch_list(repo, merged=False)
+
+        assert "unmerged-feat" in result
+        assert "main" not in result
+        repo.git.branch.assert_called_once_with("--no-merged")
+
+    def test_merged_none_does_not_filter(self):
+        """merged=None (default) should not call --merged/--no-merged."""
+        heads = [_make_head("main", "aaa" * 14, is_active=True)]
+        repo = _make_repo(heads, active_name="main")
+
+        git_branch_list(repo, merged=None)
+
+        repo.git.branch.assert_not_called()
+
+
+class TestGitBranchListBackCompat:
+    """Tests for deprecated remote/all bool aliases (back-compat)."""
+
+    def test_legacy_remote_true_maps_to_branch_type_remote(self):
+        """remote=True should behave like branch_type='remote'."""
+        refs = [_make_remote_ref("origin/main", "aaa" * 14)]
+        repo = _make_repo([], active_name=None, remotes=[refs])
+
+        result = git_branch_list(repo, remote=True)
+
+        assert "origin/main" in result
+
+    def test_legacy_all_true_maps_to_branch_type_all(self):
+        """all=True should behave like branch_type='all'."""
+        heads = [_make_head("main", "aaa" * 14, is_active=True)]
+        refs = [_make_remote_ref("origin/main", "aaa" * 14)]
+        repo = _make_repo(heads, active_name="main", remotes=[refs])
+
+        result = git_branch_list(repo, all=True)
+
+        assert "main" in result
+        assert "origin/main" in result
+
+    def test_legacy_all_takes_precedence_over_remote(self):
+        """When both all=True and remote=True, all wins."""
+        heads = [_make_head("main", "aaa" * 14, is_active=True)]
+        refs = [_make_remote_ref("origin/main", "aaa" * 14)]
+        repo = _make_repo(heads, active_name="main", remotes=[refs])
+
+        result = git_branch_list(repo, all=True, remote=True)
+
+        assert "main" in result
+        assert "origin/main" in result
+
+    def test_branch_type_conflicts_with_legacy_remote_raises_error(self):
+        """Mixing branch_type (non-default) with remote=True → ❌ error."""
+        repo = _make_repo([], active_name=None)
+
+        result = git_branch_list(repo, branch_type="remote", remote=True)
+
+        assert "❌ Branch list error:" in result
+        assert "Cannot combine" in result
+
+    def test_branch_type_conflicts_with_legacy_all_raises_error(self):
+        """Mixing branch_type (non-default) with all=True → ❌ error."""
+        repo = _make_repo([], active_name=None)
+
+        result = git_branch_list(repo, branch_type="all", all=True)
+
+        assert "❌ Branch list error:" in result
+        assert "Cannot combine" in result
+
+
+class TestGitBranchListErrors:
+    """Tests for error handling."""
+
+    def test_handles_git_command_error(self):
+        """GitCommandError during branch listing returns ❌ message."""
+        repo = Mock()
+        type(repo).branches = PropertyMock(
+            side_effect=GitCommandError("branch", "fatal: not a git repository")
         )
+        type(repo).active_branch = PropertyMock(return_value=Mock(name="main"))
+        type(repo).remotes = PropertyMock(return_value=[])
 
-        # Act
-        result = git_branch_list(mock_repo)
+        result = git_branch_list(repo)
 
-        # Assert
         assert "❌ Branch list failed:" in result
-        assert "fatal: not a git repository" in result
 
-    def test_git_branch_list_handles_generic_exception(self):
-        """Should handle generic exceptions gracefully."""
-        # Arrange
-        mock_repo = Mock()
-        mock_repo.git.branch.side_effect = Exception("Unexpected error")
+    def test_handles_generic_exception(self):
+        """Unexpected exceptions return ❌ message."""
+        repo = Mock()
+        type(repo).branches = PropertyMock(side_effect=Exception("Unexpected error"))
+        type(repo).active_branch = PropertyMock(return_value=Mock(name="main"))
+        type(repo).remotes = PropertyMock(return_value=[])
 
-        # Act
-        result = git_branch_list(mock_repo)
+        result = git_branch_list(repo)
 
-        # Assert
         assert "❌ Branch list error:" in result
         assert "Unexpected error" in result
-
-    def test_git_branch_list_precedence_all_over_remote(self):
-        """Should give precedence to 'all' flag when both all and remote are True."""
-        # Arrange
-        mock_repo = Mock()
-        mock_repo.git.branch.return_value = (
-            "  develop\n* main\n  remotes/origin/develop"
-        )
-
-        # Act
-        result = git_branch_list(mock_repo, all=True, remote=True)
-
-        # Assert
-        # When both are specified, 'all' should take precedence
-        assert "Branches:" in result
-        mock_repo.git.branch.assert_called_once_with("-a")
-
-    def test_git_branch_list_empty_pattern_ignored(self):
-        """Should ignore empty pattern string."""
-        # Arrange
-        mock_repo = Mock()
-        mock_repo.git.branch.return_value = "  develop\n* main"
-
-        # Act
-        result = git_branch_list(mock_repo, pattern="")
-
-        # Assert
-        assert "Branches:" in result
-        # Empty pattern should not be passed to git branch
-        mock_repo.git.branch.assert_called_once_with()

--- a/tests/unit/git/test_git_branch_list.py
+++ b/tests/unit/git/test_git_branch_list.py
@@ -309,6 +309,142 @@ class TestGitBranchListBackCompat:
         assert "Cannot combine" in result
 
 
+class TestGitBranchListSort:
+    """Tests for the 'sort' parameter (git for-each-ref path)."""
+
+    # NUL-separated format: name\x00sha\x00upstream
+    _FEI_TWO_BRANCHES = (
+        "feature/z\x00aaa" + "a" * 37 + "\x00\n"
+        "feature/a\x00bbb" + "b" * 37 + "\x00\n"
+    )
+
+    def _make_sort_repo(
+        self,
+        for_each_ref_output: str = "",
+        active_name: str | None = "main",
+        for_each_ref_error: Exception | None = None,
+    ) -> MagicMock:
+        repo = MagicMock()
+        if for_each_ref_error is not None:
+            repo.git.for_each_ref.side_effect = for_each_ref_error
+        else:
+            repo.git.for_each_ref.return_value = for_each_ref_output
+        if active_name is not None:
+            active = MagicMock()
+            active.name = active_name
+            type(repo).active_branch = PropertyMock(return_value=active)
+        else:
+            type(repo).active_branch = PropertyMock(
+                side_effect=TypeError("detached HEAD")
+            )
+        return repo
+
+    def test_sort_by_committerdate_descending_preserves_order(self):
+        """for-each-ref output order is preserved in formatter output."""
+        repo = self._make_sort_repo(for_each_ref_output=self._FEI_TWO_BRANCHES)
+
+        result = git_branch_list(repo, sort="-committerdate")
+
+        assert "Branches:" in result
+        # feature/z should appear before feature/a (order from for-each-ref)
+        idx_z = result.index("feature/z")
+        idx_a = result.index("feature/a")
+        assert idx_z < idx_a
+
+    def test_sort_by_committerdate_passes_correct_flag(self):
+        """--sort=-committerdate is forwarded to for_each_ref."""
+        repo = self._make_sort_repo(for_each_ref_output=self._FEI_TWO_BRANCHES)
+
+        git_branch_list(repo, sort="-committerdate")
+
+        call_args = repo.git.for_each_ref.call_args
+        assert "--sort=-committerdate" in call_args.args
+
+    def test_sort_by_refname_passes_correct_flag(self):
+        """--sort=refname is forwarded to for_each_ref."""
+        repo = self._make_sort_repo(for_each_ref_output=self._FEI_TWO_BRANCHES)
+
+        git_branch_list(repo, sort="refname")
+
+        call_args = repo.git.for_each_ref.call_args
+        assert "--sort=refname" in call_args.args
+
+    def test_sort_local_uses_refs_heads_pattern(self):
+        """branch_type='local' (default) scopes for-each-ref to refs/heads."""
+        repo = self._make_sort_repo(for_each_ref_output="")
+
+        git_branch_list(repo, sort="-committerdate")
+
+        call_args = repo.git.for_each_ref.call_args
+        assert "refs/heads" in call_args.args
+        assert "refs/remotes" not in call_args.args
+
+    def test_sort_remote_uses_refs_remotes_pattern(self):
+        """branch_type='remote' scopes for-each-ref to refs/remotes."""
+        repo = self._make_sort_repo(for_each_ref_output="")
+
+        git_branch_list(repo, branch_type="remote", sort="-committerdate")
+
+        call_args = repo.git.for_each_ref.call_args
+        assert "refs/remotes" in call_args.args
+        assert "refs/heads" not in call_args.args
+
+    def test_sort_all_uses_both_patterns(self):
+        """branch_type='all' passes both refs/heads and refs/remotes."""
+        repo = self._make_sort_repo(for_each_ref_output="")
+
+        git_branch_list(repo, branch_type="all", sort="-committerdate")
+
+        call_args = repo.git.for_each_ref.call_args
+        assert "refs/heads" in call_args.args
+        assert "refs/remotes" in call_args.args
+
+    def test_sort_with_pattern_filter_applied_after_sort(self):
+        """Pattern filter is applied to for-each-ref results."""
+        output = (
+            "feature/z\x00aaa" + "a" * 37 + "\x00\n"
+            "main\x00bbb" + "b" * 37 + "\x00\n"
+        )
+        repo = self._make_sort_repo(for_each_ref_output=output)
+
+        result = git_branch_list(repo, sort="-committerdate", pattern="feature/*")
+
+        assert "feature/z" in result
+        assert "main" not in result
+
+    def test_sort_with_merged_filter_applied_after_sort(self):
+        """merged=True filter is applied to for-each-ref results."""
+        output = (
+            "feature/z\x00aaa" + "a" * 37 + "\x00\n"
+            "main\x00bbb" + "b" * 37 + "\x00\n"
+        )
+        repo = self._make_sort_repo(for_each_ref_output=output)
+        repo.git.branch.return_value = "  main"  # only main is merged
+
+        result = git_branch_list(repo, sort="-committerdate", merged=True)
+
+        assert "main" in result
+        assert "feature/z" not in result
+
+    def test_invalid_sort_key_surfaces_error(self):
+        """GitCommandError from invalid sort key bubbles up as ❌ message."""
+        err = GitCommandError("for-each-ref", "fatal: unknown fieldname: bad")
+        repo = self._make_sort_repo(for_each_ref_error=err)
+
+        result = git_branch_list(repo, sort="bad-key")
+
+        assert "❌ Branch list failed:" in result
+
+    def test_sort_none_does_not_call_for_each_ref(self):
+        """When sort=None, the legacy collection path is used (no for-each-ref)."""
+        heads = [_make_head("main", "aaa" * 14, is_active=True)]
+        repo = _make_repo(heads, active_name="main")
+
+        git_branch_list(repo, sort=None)
+
+        repo.git.for_each_ref.assert_not_called()
+
+
 class TestGitBranchListErrors:
     """Tests for error handling."""
 

--- a/tests/unit/git/test_git_push_delete.py
+++ b/tests/unit/git/test_git_push_delete.py
@@ -1,0 +1,170 @@
+"""
+Unit tests for git_push delete and refspec options (issue #173).
+
+Verifies mutual-exclusion guards and flag construction for remote branch
+deletion and raw refspec forms. The implementation in _remote_ops.py is
+the source of truth.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_server_git.git.models import GitPush
+from mcp_server_git.git.operations import git_push
+
+
+@pytest.fixture()
+def mock_repo() -> MagicMock:
+    """Minimal repo mock: SSH remote URL bypasses GitHub HTTPS auth branch."""
+    repo = MagicMock()
+    repo.active_branch.name = "feature/x"
+    repo.remote.return_value.url = "git@github.com:owner/repo.git"
+    repo.git.push.return_value = ""
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# delete=True — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_delete_remote_branch_calls_push_with_delete_flag(
+    mock_repo: MagicMock,
+) -> None:
+    result = git_push(mock_repo, branch="feature-branch", delete=True)
+
+    mock_repo.git.push.assert_called_with("origin", "--delete", "feature-branch")
+    assert result.startswith("✅")
+    assert "feature-branch" in result
+
+
+# ---------------------------------------------------------------------------
+# delete=True — validation errors
+# ---------------------------------------------------------------------------
+
+
+def test_delete_with_force_raises_validation_error(mock_repo: MagicMock) -> None:
+    result = git_push(mock_repo, branch="feature-branch", delete=True, force=True)
+
+    assert result.startswith("❌")
+    assert "force" in result
+    mock_repo.git.push.assert_not_called()
+
+
+def test_delete_with_force_with_lease_raises_validation_error(
+    mock_repo: MagicMock,
+) -> None:
+    result = git_push(
+        mock_repo, branch="feature-branch", delete=True, force_with_lease=True
+    )
+
+    assert result.startswith("❌")
+    assert "force" in result
+    mock_repo.git.push.assert_not_called()
+
+
+def test_delete_without_branch_raises_validation_error(mock_repo: MagicMock) -> None:
+    result = git_push(mock_repo, delete=True)
+
+    assert result.startswith("❌")
+    assert "branch" in result
+    mock_repo.git.push.assert_not_called()
+
+
+def test_delete_with_set_upstream_raises_validation_error(
+    mock_repo: MagicMock,
+) -> None:
+    result = git_push(
+        mock_repo, branch="feature-branch", delete=True, set_upstream=True
+    )
+
+    assert result.startswith("❌")
+    mock_repo.git.push.assert_not_called()
+
+
+def test_delete_with_refspec_raises_validation_error(mock_repo: MagicMock) -> None:
+    result = git_push(
+        mock_repo, branch="feature-branch", delete=True, refspec=":feature-branch"
+    )
+
+    assert result.startswith("❌")
+    mock_repo.git.push.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# refspec form — happy path
+# ---------------------------------------------------------------------------
+
+
+def test_refspec_form_calls_push_with_raw_refspec(mock_repo: MagicMock) -> None:
+    result = git_push(mock_repo, refspec="src:dst")
+
+    mock_repo.git.push.assert_called_with("origin", "src:dst")
+    assert result.startswith("✅")
+    assert "src:dst" in result
+
+
+def test_refspec_delete_colon_form_calls_push(mock_repo: MagicMock) -> None:
+    result = git_push(mock_repo, refspec=":old-branch")
+
+    mock_repo.git.push.assert_called_with("origin", ":old-branch")
+    assert result.startswith("✅")
+
+
+# ---------------------------------------------------------------------------
+# refspec — validation errors
+# ---------------------------------------------------------------------------
+
+
+def test_refspec_with_branch_raises_validation_error(mock_repo: MagicMock) -> None:
+    result = git_push(mock_repo, branch="feature-branch", refspec="src:dst")
+
+    assert result.startswith("❌")
+    assert "branch" in result
+    mock_repo.git.push.assert_not_called()
+
+
+def test_refspec_with_set_upstream_raises_validation_error(
+    mock_repo: MagicMock,
+) -> None:
+    result = git_push(mock_repo, refspec="src:dst", set_upstream=True)
+
+    assert result.startswith("❌")
+    mock_repo.git.push.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Pydantic model validator — matches handler behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_model_delete_requires_branch() -> None:
+    with pytest.raises(ValueError, match="branch"):
+        GitPush(repo_path="/repo", delete=True)
+
+
+def test_model_delete_with_force_raises() -> None:
+    with pytest.raises(ValueError, match="force"):
+        GitPush(repo_path="/repo", branch="feat", delete=True, force=True)
+
+
+def test_model_refspec_with_branch_raises() -> None:
+    with pytest.raises(ValueError, match="branch"):
+        GitPush(repo_path="/repo", branch="feat", refspec="src:dst")
+
+
+def test_model_refspec_with_set_upstream_raises() -> None:
+    with pytest.raises(ValueError, match="set_upstream"):
+        GitPush(repo_path="/repo", refspec="src:dst", set_upstream=True)
+
+
+def test_model_valid_delete() -> None:
+    model = GitPush(repo_path="/repo", branch="feat", delete=True)
+    assert model.delete is True
+    assert model.branch == "feat"
+
+
+def test_model_valid_refspec() -> None:
+    model = GitPush(repo_path="/repo", refspec="src:dst")
+    assert model.refspec == "src:dst"

--- a/tests/unit/git/test_git_push_delete.py
+++ b/tests/unit/git/test_git_push_delete.py
@@ -168,3 +168,73 @@ def test_model_valid_delete() -> None:
 def test_model_valid_refspec() -> None:
     model = GitPush(repo_path="/repo", refspec="src:dst")
     assert model.refspec == "src:dst"
+
+
+# ---------------------------------------------------------------------------
+# dry_run=True — all push modes (issue #176)
+# ---------------------------------------------------------------------------
+
+
+class TestGitPushDryRun:
+    def test_dry_run_false_does_not_append_flag(self, mock_repo: MagicMock) -> None:
+        git_push(mock_repo, branch="feature", dry_run=False)
+
+        mock_repo.git.push.assert_called_with("origin", "feature")
+
+    def test_dry_run_with_normal_push_appends_flag(self, mock_repo: MagicMock) -> None:
+        git_push(mock_repo, branch="feature", dry_run=True)
+
+        mock_repo.git.push.assert_called_with("origin", "feature", "--dry-run")
+
+    def test_dry_run_with_delete_appends_flag(self, mock_repo: MagicMock) -> None:
+        git_push(mock_repo, branch="feature", delete=True, dry_run=True)
+
+        mock_repo.git.push.assert_called_with("origin", "--delete", "feature", "--dry-run")
+
+    def test_dry_run_with_refspec_appends_flag(self, mock_repo: MagicMock) -> None:
+        git_push(mock_repo, refspec=":feature", dry_run=True)
+
+        mock_repo.git.push.assert_called_with("origin", ":feature", "--dry-run")
+
+    def test_dry_run_with_force_appends_flag(self, mock_repo: MagicMock) -> None:
+        git_push(mock_repo, branch="feature", force=True, dry_run=True)
+
+        call_args = mock_repo.git.push.call_args
+        args = call_args.args
+        assert "--force" in args
+        assert "--dry-run" in args
+
+    def test_dry_run_return_message_indicates_no_state_change(
+        self, mock_repo: MagicMock
+    ) -> None:
+        result = git_push(mock_repo, branch="feature", dry_run=True)
+
+        assert "dry-run" in result
+
+    def test_dry_run_delete_return_message_indicates_no_state_change(
+        self, mock_repo: MagicMock
+    ) -> None:
+        result = git_push(mock_repo, branch="feature", delete=True, dry_run=True)
+
+        assert "dry-run" in result
+
+    def test_dry_run_refspec_return_message_indicates_no_state_change(
+        self, mock_repo: MagicMock
+    ) -> None:
+        result = git_push(mock_repo, refspec=":feature", dry_run=True)
+
+        assert "dry-run" in result
+
+    def test_model_dry_run_field_defaults_false(self) -> None:
+        model = GitPush(repo_path="/repo", branch="feature")
+        assert model.dry_run is False
+
+    def test_model_dry_run_compatible_with_delete(self) -> None:
+        model = GitPush(repo_path="/repo", branch="feature", delete=True, dry_run=True)
+        assert model.dry_run is True
+        assert model.delete is True
+
+    def test_model_dry_run_compatible_with_refspec(self) -> None:
+        model = GitPush(repo_path="/repo", refspec=":feature", dry_run=True)
+        assert model.dry_run is True
+        assert model.refspec == ":feature"

--- a/tests/unit/github/test_github_repo_settings.py
+++ b/tests/unit/github/test_github_repo_settings.py
@@ -298,6 +298,35 @@ class TestGitHubUpdateRepoSettings:
             assert "visibility" in result
 
     @pytest.mark.asyncio
+    async def test_successful_default_branch_update(self):
+        """Test updating repository default branch."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "full_name": "testowner/test-repo",
+                "default_branch": "development",
+            }
+        )
+        mock_client.patch = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.repos.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_update_repo_settings(
+                repo_owner="testowner",
+                repo_name="test-repo",
+                default_branch="development",
+            )
+
+            assert "✅ Successfully updated repository settings" in result
+            assert "default_branch" in result
+
+    @pytest.mark.asyncio
     async def test_successful_feature_toggles_update(self):
         """Test updating repository feature toggles (issues, wiki, projects)."""
         mock_client = MagicMock()


### PR DESCRIPTION
## Summary

Six small missing-capability issues bundled into one change. Originally three (#171/#172/#173); #175 and #176 were rolled in during review to avoid staggering MCP server restarts.

- **Closes #171** — register `git_branch_list` as a lean MCP tool; extend schema with `branch_type` (local/remote/all), `pattern`, `contains`, `merged`. Legacy `remote=`/`all=` bools preserved as aliases.
- **Closes #172** — add `default_branch: str | None` passthrough on `github_update_repo_settings` so callers can flip the repo default branch without falling back to the GitHub UI.
- **Closes #173** — add `delete: bool` and `refspec: str | None` fields to `git_push` with a pydantic `model_validator` enforcing five mutual-exclusion rules. Resolves the circular dead-end where the shell-runner refused `git push --delete` and the MCP tool didn't support it.
- **Closes #175** — add `sort: str | None` to `git_branch_list` (e.g. `'-committerdate'`, `'refname'`); when set, branches are collected via `git for-each-ref` with the sort key applied natively. Filters (`pattern`/`contains`/`merged`) apply post-fetch. `sort=None` preserves the legacy collection path.
- **Closes #176** — add `dry_run: bool = False` to `git_push`, orthogonal to every existing flag. Appends `--dry-run` to all four push paths (normal/force/delete/refspec) and surfaces a marker in the return string.

## Files changed

| Area | Files |
|------|-------|
| Models | `git/models.py`, `github/models.py` |
| Ops | `git/_branch_ops.py`, `git/_remote_ops.py`, `github/repos.py` |
| Registry | `lean/registry_git.py` (registers `git_branch_list`) |
| Tests | `tests/unit/git/test_git_branch_list.py` (rewritten + sort suite, 31 tests), `tests/unit/git/test_git_push_delete.py` (new, +dry_run suite, 27 tests), `tests/unit/github/test_github_repo_settings.py` (+1 test) |

## Test plan

- [x] `pixi run -e quality test-unit tests/unit/git/test_git_branch_list.py` — 31 pass (21 original + 10 sort)
- [x] `pixi run -e quality test-unit tests/unit/git/test_git_push_delete.py tests/unit/git/test_git_push_force_with_lease.py` — 35 pass (8 force_with_lease + 16 delete + 11 dry_run)
- [x] `pixi run -e quality test-unit tests/unit/github/test_github_repo_settings.py` — 43 pass (1 new)
- [ ] CI green on all platforms

## Design notes

- **#171 back-compat**: `git_branch_list` already had a partial implementation (3-field model: `repo_path`, `remote`, `all`, `pattern`) that wasn't registered. Old bools kept as aliases; conflict with explicit `branch_type` surfaces as an error string (matches the tool's existing error-return style rather than raising).
- **#173 validator placement**: the pydantic validator is the source of truth, but the same guards are mirrored at handler entry — the lean dispatch path doesn't uniformly coerce via the model, so handler-level checks are belt-and-suspenders.
- **#175 sort path**: only triggers `for-each-ref` when `sort` is non-None; the legacy `repo.branches` / `repo.remote().refs` iteration path is untouched, so unsorted callers see zero perf delta.
- **#176 dry_run**: deliberately orthogonal — no new mutual-exclusion rules. `--dry-run` is a general `git push` flag that works with every other push mode, so coupling it to delete-only would be artificial.
- The `44 vs 30 tool count inconsistency` mentioned as an aside in #171 is **not** addressed here — separate bug worth its own issue.