### PR TITLE
feat(git): add git_clone tool to lean interface (#177)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The server provides Azure DevOps integration for monitoring and analyzing Azure 
 
 ### Lean MCP Interface (Context-Optimized)
 
-The server provides an alternative **lean interface** that reduces context consumption by ~97% (from ~30k tokens to ~900 tokens). Instead of exposing all 51 tools upfront, it uses a 3-meta-tool pattern:
+The server provides an alternative **lean interface** that reduces context consumption by ~97% (from ~30k tokens to ~900 tokens). Instead of exposing all 52 tools upfront, it uses a 3-meta-tool pattern:
 
 | Meta-Tool | Purpose |
 |-----------|---------|
@@ -145,7 +145,7 @@ The server provides an alternative **lean interface** that reduces context consu
 | `get_tool_spec(tool_name)` | Get full schema for a specific tool on-demand |
 | `execute_tool(tool_name, params)` | Execute any tool dynamically |
 
-**Tool Coverage**: All 50 tools remain accessible (25 git, 22 GitHub, 3 Azure DevOps).
+**Tool Coverage**: All 51 tools remain accessible (26 git, 22 GitHub, 3 Azure DevOps).
 
 **Usage Example**:
 ```python

--- a/src/mcp_server_git/git/_remote_ops.py
+++ b/src/mcp_server_git/git/_remote_ops.py
@@ -15,6 +15,7 @@ MIN_TOKEN_LENGTH = 10  # minimum length for a valid GitHub token
 
 __all__ = [
     "_get_github_token_from_cli",
+    "git_clone",
     "git_push",
     "git_pull",
     "git_remote_list",
@@ -457,6 +458,45 @@ def git_remote_get_url(repo: Repo, name: str) -> str:
         return f"❌ Remote get-url failed: {str(e)}"
     except Exception as e:
         return f"❌ Remote get-url error: {str(e)}"
+
+
+def git_clone(
+    repo_url: str,
+    target_path: str,
+    branch: str | None = None,
+    depth: int | None = None,
+    single_branch: bool = False,
+    recurse_submodules: bool = False,
+) -> str:
+    """Clone a remote repository to a local path"""
+    try:
+        target = Path(target_path)
+        if not target.parent.exists():
+            raise ValueError(f"Parent directory does not exist: {target.parent}")
+        if target.exists() and any(target.iterdir()):
+            raise ValueError(
+                f"Target path already exists and is not empty: {target_path}"
+            )
+
+        multi_options = []
+        if branch:
+            multi_options.append(f"--branch={branch}")
+        if depth is not None:
+            multi_options.append(f"--depth={depth}")
+        if single_branch:
+            multi_options.append("--single-branch")
+        if recurse_submodules:
+            multi_options.append("--recurse-submodules")
+
+        Repo.clone_from(repo_url, target_path, multi_options=multi_options)
+
+        return f"✅ Cloned {repo_url} to {target_path}"
+    except ValueError:
+        raise
+    except GitCommandError as e:
+        return f"❌ Clone failed: {str(e)}"
+    except Exception as e:
+        return f"❌ Clone error: {str(e)}"
 
 
 def git_fetch(

--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -105,6 +105,15 @@ class GitInit(BaseModel):
     repo_path: str
 
 
+class GitClone(BaseModel):
+    repo_url: str
+    target_path: str
+    branch: str | None = None
+    depth: int | None = None
+    single_branch: bool = False
+    recurse_submodules: bool = False
+
+
 class GitPush(BaseModel):
     repo_path: str
     remote: str = "origin"
@@ -240,12 +249,13 @@ class GitBranchList(BaseModel):
         None, description="commit-ish; only branches containing this commit"
     )
     merged: bool | None = Field(
-        None, description="True=only merged into HEAD, False=only unmerged, None=no filter"
+        None,
+        description="True=only merged into HEAD, False=only unmerged, None=no filter",
     )
     sort: str | None = Field(
         None,
         description="Sort key, e.g. '-committerdate' (most-recent first), 'refname', 'authordate'. "
-                    "Mirrors `git for-each-ref --sort=<key>` semantics. None = no ordering guarantee.",
+        "Mirrors `git for-each-ref --sort=<key>` semantics. None = no ordering guarantee.",
     )
 
 

--- a/src/mcp_server_git/git/operations.py
+++ b/src/mcp_server_git/git/operations.py
@@ -29,6 +29,7 @@ from ._branch_ops import (
 )
 from ._init_ops import git_init
 from ._remote_ops import (
+    git_clone,
     git_fetch,
     git_pull,
     git_push,
@@ -68,6 +69,7 @@ from ._config_ops import (
 )
 
 __all__ = [
+    "git_clone",
     "git_status",
     "git_diff_unstaged",
     "git_diff_staged",

--- a/src/mcp_server_git/lean/registry_git.py
+++ b/src/mcp_server_git/lean/registry_git.py
@@ -11,6 +11,7 @@ from ..git.models import (
     GitBranchUpdate,
     GitCheckout,
     GitCherryPick,
+    GitClone,
     GitCommit,
     GitConfigGet,
     GitConfigList,
@@ -165,6 +166,14 @@ def _register_git_tools(interface: Any, git_service: Any):
             implementation=git_ops.git_init,  # git_init takes path directly, not Repo
             description="Initialize a new Git repository",
             schema=GitInit.model_json_schema(),
+            domain="git",
+            complexity="core",
+        ),
+        ToolDefinition(
+            name="git_clone",
+            implementation=git_ops.git_clone,  # git_clone takes no Repo, operates directly
+            description="Clone a remote repository to a local path",
+            schema=GitClone.model_json_schema(),
             domain="git",
             complexity="core",
         ),

--- a/tests/unit/git/test_git_clone.py
+++ b/tests/unit/git/test_git_clone.py
@@ -1,0 +1,166 @@
+"""Tests for git_clone operation"""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.mcp_server_git.utils.git_import import Repo
+
+
+def _make_source_repo(
+    path: Path, num_commits: int = 1, branch: str | None = None
+) -> Repo:
+    """Helper: initialise a bare-ish source repo with commits for use as a local remote."""
+    repo = Repo.init(str(path))
+
+    # Configure a minimal identity so commits work without system config
+    with repo.config_writer() as cw:
+        cw.set_value("user", "name", "Test User")
+        cw.set_value("user", "email", "test@example.com")
+
+    # Write and commit files
+    for i in range(num_commits):
+        dummy = path / f"file_{i}.txt"
+        dummy.write_text(f"content {i}")
+        repo.index.add([str(dummy)])
+        repo.index.commit(f"commit {i}")
+
+    if branch is not None:
+        repo.create_head(branch)
+
+    return repo
+
+
+class TestGitClone:
+    """Test git_clone function"""
+
+    def setup_method(self):
+        self._tmpdirs: list[str] = []
+
+    def teardown_method(self):
+        for d in self._tmpdirs:
+            shutil.rmtree(d, ignore_errors=True)
+
+    def _tmpdir(self) -> Path:
+        d = tempfile.mkdtemp()
+        self._tmpdirs.append(d)
+        return Path(d)
+
+    # ------------------------------------------------------------------
+    # Happy-path tests
+    # ------------------------------------------------------------------
+
+    def test_clone_happy_path(self):
+        """Clone a local source repo into a fresh empty target and verify success."""
+        from src.mcp_server_git.git.operations import git_clone
+
+        src = self._tmpdir()
+        src_repo = _make_source_repo(src)
+        expected_sha = src_repo.head.commit.hexsha
+
+        target = self._tmpdir() / "cloned"
+
+        result = git_clone(str(src), str(target))
+
+        assert "✅" in result
+        assert str(src) in result
+        assert str(target) in result
+
+        cloned_repo = Repo(str(target))
+        assert cloned_repo.head.commit.hexsha == expected_sha
+
+    def test_clone_with_branch(self):
+        """Clone with branch= and verify active branch in cloned repo."""
+        from src.mcp_server_git.git.operations import git_clone
+
+        src = self._tmpdir()
+        _make_source_repo(src, num_commits=1, branch="feature-x")
+
+        target = self._tmpdir() / "cloned"
+
+        result = git_clone(str(src), str(target), branch="feature-x")
+
+        assert "✅" in result
+
+        cloned_repo = Repo(str(target))
+        assert cloned_repo.active_branch.name == "feature-x"
+
+    def test_clone_with_depth(self):
+        """Clone with depth=1 from a 3-commit repo and verify shallow history."""
+        from src.mcp_server_git.git.operations import git_clone
+
+        src = self._tmpdir()
+        _make_source_repo(src, num_commits=3)
+
+        target = self._tmpdir() / "cloned"
+
+        result = git_clone(f"file://{src}", str(target), depth=1)
+
+        assert "✅" in result
+
+        cloned_repo = Repo(str(target))
+        commit_count = cloned_repo.git.rev_list("--count", "HEAD")
+        assert commit_count.strip() == "1"
+
+    def test_clone_single_branch_flag(self):
+        """Clone with single_branch=True succeeds."""
+        from src.mcp_server_git.git.operations import git_clone
+
+        src = self._tmpdir()
+        _make_source_repo(src)
+
+        target = self._tmpdir() / "cloned"
+
+        result = git_clone(str(src), str(target), single_branch=True)
+
+        assert "✅" in result
+
+    # ------------------------------------------------------------------
+    # Validation / rejection tests
+    # ------------------------------------------------------------------
+
+    def test_clone_rejects_existing_nonempty_target(self):
+        """Raise ValueError when target directory already contains files."""
+        from src.mcp_server_git.git.operations import git_clone
+
+        src = self._tmpdir()
+        _make_source_repo(src)
+
+        target = self._tmpdir() / "nonempty"
+        target.mkdir()
+        (target / "existing.txt").write_text("not empty")
+
+        with pytest.raises(ValueError, match="not empty"):
+            git_clone(str(src), str(target))
+
+    def test_clone_rejects_missing_parent(self):
+        """Raise ValueError when the parent of target_path does not exist."""
+        from src.mcp_server_git.git.operations import git_clone
+
+        src = self._tmpdir()
+        _make_source_repo(src)
+
+        nonexistent_parent = self._tmpdir() / "ghost" / "cloned"
+
+        with pytest.raises(ValueError, match="Parent directory does not exist"):
+            git_clone(str(src), str(nonexistent_parent))
+
+    # ------------------------------------------------------------------
+    # Error-path tests
+    # ------------------------------------------------------------------
+
+    def test_clone_bad_url_returns_error_message(self):
+        """Return a '❌' string when repo_url does not point to a valid repo."""
+        from src.mcp_server_git.git.operations import git_clone
+
+        target = self._tmpdir() / "cloned"
+
+        # A path that does not exist is not a valid git repo; GitPython raises
+        # GitCommandError which the implementation catches and returns as "❌ Clone failed: ..."
+        bad_url = "/tmp/this_path_does_not_exist_at_all_xyz123"
+
+        result = git_clone(bad_url, str(target))
+
+        assert "❌" in result


### PR DESCRIPTION
## Summary

Adds first-class `git_clone(repo_url, target_path, branch, depth, single_branch, recurse_submodules)` to the lean git domain. Closes the gap noted in the CLAUDE.md "Git Mental Model" table and removes the need for the `git_init` + `git_remote_add` + `git_fetch` + `git_checkout` workaround in multi-repo standardization workflows.

## Changes

- `git/_remote_ops.py` — new `git_clone` using `Repo.clone_from(...)` with `multi_options=['--branch=…', '--depth=…', '--single-branch', '--recurse-submodules']`. The `=` form is required because GitPython passes each `multi_options` element as a single argv to `git`; a `--branch main` element would be rejected.
- `git/models.py` — new `GitClone` Pydantic model mirroring `GitInit`.
- `git/operations.py` — re-export so `from .operations import git_clone` works alongside the other tools.
- `lean/registry_git.py` — `ToolDefinition` between `git_init` and `git_push`, using `GitClone.model_json_schema()` (the model-based pattern from `git_init`, not the inline-dict pattern from `git_fetch`). Registered without `wrap_repo_op` since clone does not take an existing `Repo`.
- `README.md` — lean interface tool count: 50 → 51, git count: 25 → 26.
- `tests/unit/git/test_git_clone.py` — 7 tests, no network, local repos as sources.

## Test plan

- [x] `pixi run -e quality pytest tests/unit/git/test_git_clone.py -v` — 7/7 pass
  - happy path, `branch=` checkout, `depth=1` shallow (via `file://` source — local-path clone short-circuits `--depth`), `single_branch=True`, rejects non-empty target, rejects missing parent, bad URL returns `❌ Clone failed`
- [x] `pixi run -e quality pytest tests/unit/git/` — no regressions
- [x] `pixi run -e quality ruff check <changed files>` — clean
- [x] `pixi run -e quality ruff format --check <changed files>` — clean
- [x] `pyright` on changed files — clean

## Validation contract

- `target_path` must have an existing parent → otherwise `ValueError`
- `target_path` must not exist as a non-empty directory → otherwise `ValueError`
- `GitCommandError` returns `❌ Clone failed: <msg>` (consistent with other `_remote_ops.py` error returns)
- Any other exception returns `❌ Clone error: <msg>`

Closes #177