### PR TITLE
ci: pin current claude-sonnet-4-6 model in claude-code-action workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,8 +49,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           allowed_bots: claude
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Pin an explicit current model; the action's old default (claude-sonnet-4-20250514) was removed from the API
+          model: "claude-sonnet-4-6"
           
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -56,8 +56,8 @@ jobs:
           additional_permissions: |
             actions: read
           
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-          # model: "claude-opus-4-20250514"
+          # Pin an explicit current model; the action's old default (claude-sonnet-4-20250514) was removed from the API
+          model: "claude-sonnet-4-6"
           
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"


### PR DESCRIPTION
## Summary

The `anthropics/claude-code-action@beta` review/assistant jobs were failing with:

```
API Error: 404 not_found_error model: claude-sonnet-4-20250514
```

The action's built-in default model (`claude-sonnet-4-20250514`) has been removed from the API, so any job that didn't pin a model 404'd. Both workflows only had a commented-out example (`# model: "claude-opus-4-20250514"`, itself deprecated), so they fell back to the dead default.

## Change

Pin an explicit current model in both workflows' `with:` blocks:

- `.github/workflows/claude.yml`
- `.github/workflows/claude-code-review.yml`

```yaml
model: "claude-sonnet-4-6"
```

YAML-only change; no code or tests affected. Unblocks the Claude review bot on PRs (e.g. the failure observed on #182).

🤖 Generated with [Claude Code](https://claude.com/claude-code)