### PR TITLE
fix(git): bypass GitPython for stash ops to fix worktree failure (#189)

### DIFF
--- a/src/mcp_server_git/git/_stash_ops.py
+++ b/src/mcp_server_git/git/_stash_ops.py
@@ -1,8 +1,10 @@
 """Stash operations for MCP Git Server."""
 
 import logging
+import os
+import subprocess
 
-from ..utils.git_import import GitCommandError, Repo
+from ..utils.git_import import Repo
 
 logger = logging.getLogger(__name__)
 
@@ -13,16 +15,40 @@ __all__ = [
     "git_stash_drop",
 ]
 
+# Git environment variables that can interfere with worktree stash operations.
+# Stripping these lets git auto-detect the repo from the working directory,
+# which matches what a plain shell `git stash` does.
+_GIT_ENV_KEYS = frozenset(
+    {"GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"}
+)
+
+
+def _clean_git_env() -> dict[str, str]:
+    """Return os.environ without keys that confuse git in worktrees."""
+    return {k: v for k, v in os.environ.items() if k not in _GIT_ENV_KEYS}
+
+
+def _run_git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
+    """Run a git command in *cwd* with a worktree-safe environment."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        env=_clean_git_env(),
+        capture_output=True,
+        text=True,
+    )
+
 
 def git_stash_list(repo: Repo) -> str:
     """List all stashes"""
     try:
-        stash_list = repo.git.stash("list")
-        if not stash_list.strip():
+        result = _run_git(["stash", "list"], cwd=repo.working_dir)
+        if result.returncode != 0:
+            return f"❌ Stash list failed: {result.stderr.strip() or result.stdout.strip()}"
+        output = result.stdout.strip()
+        if not output:
             return "No stashes found"
-        return f"Stash list:\n{stash_list}"
-    except GitCommandError as e:
-        return f"❌ Stash list failed: {str(e)}"
+        return f"Stash list:\n{output}"
     except Exception as e:
         return f"❌ Stash list error: {str(e)}"
 
@@ -30,18 +56,29 @@ def git_stash_list(repo: Repo) -> str:
 def git_stash_push(
     repo: Repo, message: str | None = None, include_untracked: bool = False
 ) -> str:
-    """Create a new stash"""
+    """Create a new stash.
+
+    Uses subprocess rather than repo.git.stash() to avoid GitPython's GIT_DIR
+    handling that causes exit-code-1 failures in git linked worktrees (#189).
+    """
     try:
-        args = ["push"]
+        args = ["stash", "push"]
         if include_untracked:
             args.append("--include-untracked")
         if message:
             args.extend(["-m", message])
 
-        repo.git.stash(*args)
-        return "✅ Successfully created stash" + (f": {message}" if message else "")
-    except GitCommandError as e:
-        return f"❌ Stash push failed: {str(e)}"
+        result = _run_git(args, cwd=repo.working_dir)
+
+        if result.returncode == 0:
+            return "✅ Successfully created stash" + (f": {message}" if message else "")
+
+        output = result.stdout.strip()
+        if result.returncode == 1 and "No local changes to save" in output:
+            return "ℹ️ No local changes to stash"
+
+        error = result.stderr.strip() or output
+        return f"❌ Stash push failed: {error}"
     except Exception as e:
         return f"❌ Stash push error: {str(e)}"
 
@@ -49,14 +86,17 @@ def git_stash_push(
 def git_stash_pop(repo: Repo, stash_id: str | None = None) -> str:
     """Apply and remove a stash"""
     try:
+        args = ["stash", "pop"]
         if stash_id:
-            repo.git.stash("pop", stash_id)
+            args.append(stash_id)
+
+        result = _run_git(args, cwd=repo.working_dir)
+        if result.returncode != 0:
+            return f"❌ Stash pop failed: {result.stderr.strip() or result.stdout.strip()}"
+
+        if stash_id:
             return f"✅ Successfully popped stash {stash_id}"
-        else:
-            repo.git.stash("pop")
-            return "✅ Successfully popped latest stash"
-    except GitCommandError as e:
-        return f"❌ Stash pop failed: {str(e)}"
+        return "✅ Successfully popped latest stash"
     except Exception as e:
         return f"❌ Stash pop error: {str(e)}"
 
@@ -64,13 +104,16 @@ def git_stash_pop(repo: Repo, stash_id: str | None = None) -> str:
 def git_stash_drop(repo: Repo, stash_id: str | None = None) -> str:
     """Remove a stash without applying it"""
     try:
+        args = ["stash", "drop"]
         if stash_id:
-            repo.git.stash("drop", stash_id)
+            args.append(stash_id)
+
+        result = _run_git(args, cwd=repo.working_dir)
+        if result.returncode != 0:
+            return f"❌ Stash drop failed: {result.stderr.strip() or result.stdout.strip()}"
+
+        if stash_id:
             return f"✅ Successfully dropped stash {stash_id}"
-        else:
-            repo.git.stash("drop")
-            return "✅ Successfully dropped latest stash"
-    except GitCommandError as e:
-        return f"❌ Stash drop failed: {str(e)}"
+        return "✅ Successfully dropped latest stash"
     except Exception as e:
         return f"❌ Stash drop error: {str(e)}"

--- a/src/mcp_server_git/git/_stash_ops.py
+++ b/src/mcp_server_git/git/_stash_ops.py
@@ -42,6 +42,8 @@ def _run_git(args: list[str], cwd: str) -> subprocess.CompletedProcess[str]:
 def git_stash_list(repo: Repo) -> str:
     """List all stashes"""
     try:
+        if repo.working_dir is None:
+            return "❌ Stash operation requires a non-bare repository"
         result = _run_git(["stash", "list"], cwd=repo.working_dir)
         if result.returncode != 0:
             return f"❌ Stash list failed: {result.stderr.strip() or result.stdout.strip()}"
@@ -62,6 +64,8 @@ def git_stash_push(
     handling that causes exit-code-1 failures in git linked worktrees (#189).
     """
     try:
+        if repo.working_dir is None:
+            return "❌ Stash operation requires a non-bare repository"
         args = ["stash", "push"]
         if include_untracked:
             args.append("--include-untracked")
@@ -73,11 +77,11 @@ def git_stash_push(
         if result.returncode == 0:
             return "✅ Successfully created stash" + (f": {message}" if message else "")
 
-        output = result.stdout.strip()
-        if result.returncode == 1 and "No local changes to save" in output:
+        combined = result.stdout.strip() or result.stderr.strip()
+        if result.returncode == 1 and "No local changes to save" in combined:
             return "ℹ️ No local changes to stash"
 
-        error = result.stderr.strip() or output
+        error = result.stderr.strip() or result.stdout.strip()
         return f"❌ Stash push failed: {error}"
     except Exception as e:
         return f"❌ Stash push error: {str(e)}"
@@ -86,6 +90,8 @@ def git_stash_push(
 def git_stash_pop(repo: Repo, stash_id: str | None = None) -> str:
     """Apply and remove a stash"""
     try:
+        if repo.working_dir is None:
+            return "❌ Stash operation requires a non-bare repository"
         args = ["stash", "pop"]
         if stash_id:
             args.append(stash_id)
@@ -104,6 +110,8 @@ def git_stash_pop(repo: Repo, stash_id: str | None = None) -> str:
 def git_stash_drop(repo: Repo, stash_id: str | None = None) -> str:
     """Remove a stash without applying it"""
     try:
+        if repo.working_dir is None:
+            return "❌ Stash operation requires a non-bare repository"
         args = ["stash", "drop"]
         if stash_id:
             args.append(stash_id)

--- a/src/mcp_server_git/git/_stash_ops.py
+++ b/src/mcp_server_git/git/_stash_ops.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 import subprocess
 
 from ..utils.git_import import Repo
@@ -21,6 +22,8 @@ __all__ = [
 _GIT_ENV_KEYS = frozenset(
     {"GIT_DIR", "GIT_WORK_TREE", "GIT_INDEX_FILE", "GIT_COMMON_DIR"}
 )
+
+_STASH_ID_RE = re.compile(r"^stash@\{\d+\}$")
 
 
 def _clean_git_env() -> dict[str, str]:
@@ -92,6 +95,8 @@ def git_stash_pop(repo: Repo, stash_id: str | None = None) -> str:
     try:
         if repo.working_dir is None:
             return "❌ Stash operation requires a non-bare repository"
+        if stash_id and not _STASH_ID_RE.match(stash_id):
+            return f"❌ Invalid stash ID: {stash_id!r} (expected format: stash@{{N}})"
         args = ["stash", "pop"]
         if stash_id:
             args.append(stash_id)
@@ -112,6 +117,8 @@ def git_stash_drop(repo: Repo, stash_id: str | None = None) -> str:
     try:
         if repo.working_dir is None:
             return "❌ Stash operation requires a non-bare repository"
+        if stash_id and not _STASH_ID_RE.match(stash_id):
+            return f"❌ Invalid stash ID: {stash_id!r} (expected format: stash@{{N}})"
         args = ["stash", "drop"]
         if stash_id:
             args.append(stash_id)

--- a/src/mcp_server_git/github/models.py
+++ b/src/mcp_server_git/github/models.py
@@ -1019,7 +1019,7 @@ class GitHubGetBranchRules(BaseModel):
 
     repo_owner: str
     repo_name: str
-    branch: str  # Branch name (e.g. 'main') or pattern
+    branch: str  # Branch name or glob pattern — no ref-name validation (API accepts patterns)
 
 
 class GitHubListCodeScanningAlerts(BaseModel):

--- a/src/mcp_server_git/github/scanning.py
+++ b/src/mcp_server_git/github/scanning.py
@@ -41,7 +41,10 @@ async def github_list_rulesets(
     per_page: int | None = None,
     page: int | None = None,
 ) -> list[dict[str, Any]] | str:
-    """List rulesets defined on a repository."""
+    """List rulesets defined on a repository.
+
+    Note: Returns a single page of results. Use per_page/page for manual pagination.
+    """
     logger.debug("Getting rulesets for %s/%s", repo_owner, repo_name)
 
     params = _build_params(per_page=per_page, page=page)
@@ -163,6 +166,8 @@ async def github_list_code_scanning_alerts(
 ) -> list[dict[str, Any]] | str:
     """List code scanning alerts with optional filters.
 
+    Note: Returns a single page of results. Use per_page/page for manual pagination.
+
     Args:
         state: Filter by alert state ('open', 'closed', 'dismissed', 'fixed').
         severity: Filter by severity ('critical', 'high', 'medium', 'low', 'warning', 'note', 'error').
@@ -227,6 +232,8 @@ async def github_list_code_scanning_analyses(
     page: int | None = None,
 ) -> list[dict[str, Any]] | str:
     """List code scanning analyses for a repository.
+
+    Note: Returns a single page of results. Use per_page/page for manual pagination.
 
     Args:
         ref: Git ref to filter by (branch name or refs/pull/N/head).
@@ -339,6 +346,8 @@ async def github_list_secret_scanning_alerts(
     page: int | None = None,
 ) -> list[dict[str, Any]] | str:
     """List secret scanning alerts for a repository.
+
+    Note: Returns a single page of results. Use per_page/page for manual pagination.
 
     Args:
         state: Filter by alert state ('open' or 'resolved').

--- a/tests/unit/git/test_stash_ops.py
+++ b/tests/unit/git/test_stash_ops.py
@@ -1,0 +1,122 @@
+"""Tests for stash operations — including worktree scenarios (issue #189)."""
+
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from src.mcp_server_git.git._stash_ops import (
+    git_stash_drop,
+    git_stash_list,
+    git_stash_pop,
+    git_stash_push,
+)
+from src.mcp_server_git.utils.git_import import Repo
+
+
+def _make_repo(path: Path) -> Repo:
+    """Create a minimal git repo with an initial commit."""
+    repo = Repo.init(str(path))
+    repo.config_writer().set_value("user", "name", "Test").release()
+    repo.config_writer().set_value("user", "email", "test@test.com").release()
+    readme = path / "README.md"
+    readme.write_text("initial")
+    repo.index.add(["README.md"])
+    repo.index.commit("initial commit")
+    return repo
+
+
+class TestGitStashPush:
+    def setup_method(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.repo = _make_repo(self.tmp)
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_git_stash_push_returns_success_when_changes_exist(self):
+        (self.tmp / "README.md").write_text("modified")
+        result = git_stash_push(self.repo)
+        assert "✅" in result
+        assert "stash" in result.lower()
+
+    def test_git_stash_push_with_message(self):
+        (self.tmp / "README.md").write_text("modified")
+        result = git_stash_push(self.repo, message="my fix")
+        assert "✅" in result
+        assert "my fix" in result
+
+    def test_git_stash_push_with_message_containing_spaces(self):
+        (self.tmp / "README.md").write_text("modified")
+        result = git_stash_push(self.repo, message="my stash message")
+        assert "✅" in result
+        assert "my stash message" in result
+
+    def test_git_stash_push_returns_info_when_nothing_to_stash(self):
+        result = git_stash_push(self.repo)
+        assert "ℹ️" in result or "No local changes" in result
+
+    def test_git_stash_push_in_worktree(self, tmp_path):
+        """Regression test for issue #189: stash push must work in a linked worktree."""
+        worktree_path = tmp_path / "linked-wt"
+        self.repo.git.worktree("add", str(worktree_path), "HEAD")
+        try:
+            wt_repo = Repo(str(worktree_path))
+            (worktree_path / "README.md").write_text("worktree change")
+            result = git_stash_push(wt_repo)
+            assert "✅" in result, f"Expected success in worktree, got: {result}"
+        finally:
+            self.repo.git.worktree("remove", "--force", str(worktree_path))
+
+    def test_git_stash_push_include_untracked(self):
+        new_file = self.tmp / "untracked.txt"
+        new_file.write_text("new")
+        result = git_stash_push(self.repo, include_untracked=True)
+        assert "✅" in result
+
+
+class TestGitStashList:
+    def setup_method(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.repo = _make_repo(self.tmp)
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_git_stash_list_empty(self):
+        result = git_stash_list(self.repo)
+        assert "No stashes found" in result
+
+    def test_git_stash_list_shows_stash(self):
+        (self.tmp / "README.md").write_text("modified")
+        git_stash_push(self.repo, message="test-stash")
+        result = git_stash_list(self.repo)
+        assert "stash@{0}" in result
+        assert "test-stash" in result
+
+
+class TestGitStashPopDrop:
+    def setup_method(self):
+        self.tmp = Path(tempfile.mkdtemp())
+        self.repo = _make_repo(self.tmp)
+        (self.tmp / "README.md").write_text("modified")
+        git_stash_push(self.repo, message="pop-test")
+
+    def teardown_method(self):
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_git_stash_pop_latest(self):
+        result = git_stash_pop(self.repo)
+        assert "✅" in result
+        assert "popped" in result.lower()
+
+    def test_git_stash_drop_latest(self):
+        result = git_stash_drop(self.repo)
+        assert "✅" in result
+        assert "dropped" in result.lower()
+
+    def test_git_stash_drop_by_id(self):
+        result = git_stash_drop(self.repo, stash_id="stash@{0}")
+        assert "✅" in result
+        assert "stash@{0}" in result

--- a/tests/unit/git/test_stash_ops.py
+++ b/tests/unit/git/test_stash_ops.py
@@ -54,7 +54,33 @@ class TestGitStashPush:
         assert "my stash message" in result
 
     def test_git_stash_push_returns_info_when_nothing_to_stash(self):
-        result = git_stash_push(self.repo)
+        """Exit code 1 + 'No local changes to save' must return info, not error."""
+        from unittest.mock import MagicMock, patch
+        import subprocess as _sp
+
+        mock_result = MagicMock(spec=_sp.CompletedProcess)
+        mock_result.returncode = 1
+        mock_result.stdout = "No local changes to save"
+        mock_result.stderr = ""
+
+        with patch("src.mcp_server_git.git._stash_ops.subprocess.run", return_value=mock_result):
+            result = git_stash_push(self.repo)
+
+        assert "ℹ️" in result or "No local changes" in result
+
+    def test_git_stash_push_returns_info_when_nothing_to_stash_stderr(self):
+        """'No local changes to save' on stderr (some git versions) must also return info."""
+        from unittest.mock import MagicMock, patch
+        import subprocess as _sp
+
+        mock_result = MagicMock(spec=_sp.CompletedProcess)
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "No local changes to save"
+
+        with patch("src.mcp_server_git.git._stash_ops.subprocess.run", return_value=mock_result):
+            result = git_stash_push(self.repo)
+
         assert "ℹ️" in result or "No local changes" in result
 
     def test_git_stash_push_in_worktree(self, tmp_path):

--- a/tests/unit/github/test_github_ghas_forensics.py
+++ b/tests/unit/github/test_github_ghas_forensics.py
@@ -200,6 +200,36 @@ class TestGithubGetRuleset:
         assert "❌" in result
         assert "403" in result
 
+    @pytest.mark.asyncio
+    async def test_get_ruleset_returns_error_on_value_error(self):
+        """A ValueError raised by the client returns an error string."""
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(side_effect=ValueError("Auth error"))
+
+        with patch(_PATCH_CTX) as mock_ctx:
+            mock_ctx.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_ruleset(
+                repo_owner=_OWNER, repo_name=_REPO, ruleset_id=1
+            )
+
+        assert "❌" in result
+
+    @pytest.mark.asyncio
+    async def test_get_ruleset_returns_error_on_connection_error(self):
+        """A ConnectionError raised by the client returns a network-error string."""
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(side_effect=ConnectionError("Network error"))
+
+        with patch(_PATCH_CTX) as mock_ctx:
+            mock_ctx.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_ruleset(
+                repo_owner=_OWNER, repo_name=_REPO, ruleset_id=1
+            )
+
+        assert "❌" in result
+
 
 # ===========================================================================
 # github_get_branch_rules
@@ -256,6 +286,36 @@ class TestGithubGetBranchRules:
 
         assert "❌" in result
         assert "403" in result
+
+    @pytest.mark.asyncio
+    async def test_get_branch_rules_returns_error_on_value_error(self):
+        """A ValueError raised by the client returns an error string."""
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(side_effect=ValueError("Auth error"))
+
+        with patch(_PATCH_CTX) as mock_ctx:
+            mock_ctx.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_branch_rules(
+                repo_owner=_OWNER, repo_name=_REPO, branch="main"
+            )
+
+        assert "❌" in result
+
+    @pytest.mark.asyncio
+    async def test_get_branch_rules_returns_error_on_connection_error(self):
+        """A ConnectionError raised by the client returns a network-error string."""
+        mock_client = MagicMock()
+        mock_client.get = AsyncMock(side_effect=ConnectionError("Network error"))
+
+        with patch(_PATCH_CTX) as mock_ctx:
+            mock_ctx.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_branch_rules(
+                repo_owner=_OWNER, repo_name=_REPO, branch="main"
+            )
+
+        assert "❌" in result
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

- Replaces `repo.git.stash()` with `subprocess.run()` for all four stash operations so they work correctly in git linked worktrees
- Strips `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_COMMON_DIR` from the subprocess environment, matching what a plain shell `git stash` sees
- Converts exit-code-1 + "No local changes to save" to an info result (`ℹ️`) rather than an error — checked on both stdout and stderr
- Validates `stash_id` format (`stash@{N}`) in `git_stash_pop` and `git_stash_drop` before passing to git
- Guards all four stash functions against bare repos (`repo.working_dir is None`)
- Adds pagination notes to `scanning.py` listing function docstrings
- Adds missing `ValueError`/`ConnectionError` tests for `github_get_ruleset` and `github_get_branch_rules`
- Documents `GitHubGetBranchRules.branch` has no ref-name validator intentionally (API accepts glob patterns)

## Root cause

GitPython's `repo.git.stash()` fails with exit code 1 in linked worktrees even when changes exist. Git interprets the working tree as clean because GitPython may set `GIT_DIR` or run in a context that prevents git from finding the correct index/work-tree relationship. The plain shell `git stash` works because it inherits no such env vars and auto-detects everything from the `.git` file in the worktree directory.

## Test plan

- [x] `test_git_stash_push_returns_success_when_changes_exist` — basic happy path
- [x] `test_git_stash_push_with_message` / `test_git_stash_push_with_message_containing_spaces`
- [x] `test_git_stash_push_returns_info_when_nothing_to_stash` — mock-based (stdout path)
- [x] `test_git_stash_push_returns_info_when_nothing_to_stash_stderr` — mock-based (stderr path)
- [x] `test_git_stash_push_in_worktree` — **regression test for #189**; creates a real linked worktree
- [x] `test_git_stash_push_include_untracked`
- [x] `test_git_stash_list_empty` / `test_git_stash_list_shows_stash`
- [x] `test_git_stash_pop_latest` / `test_git_stash_drop_latest` / `test_git_stash_drop_by_id`
- [x] `ValueError`/`ConnectionError` tests for `github_get_ruleset` and `github_get_branch_rules`

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)