### PR TITLE
fix(azure): fetch build-log content as text/plain to avoid ISecuredObject 500 (#192)

### DIFF
--- a/src/mcp_server_git/azure/api.py
+++ b/src/mcp_server_git/azure/api.py
@@ -145,10 +145,14 @@ async def azure_get_build_logs(
 
                 return "\n".join(output)
             else:
-                # Get specific log content
+                # Get specific log content.
                 # API: GET https://dev.azure.com/{organization}/{project}/_apis/build/builds/{buildId}/logs/{logId}?api-version=7.1
+                # Request text/plain: the single-log endpoint returns a bare
+                # List<String>, which Azure refuses to serialize as JSON
+                # (500 "doesn't implement ISecuredObject"). Plain text works.
                 response = await client.get(
-                    f"{project}/_apis/build/builds/{build_id}/logs/{log_id}?api-version=7.1"
+                    f"{project}/_apis/build/builds/{build_id}/logs/{log_id}?api-version=7.1",
+                    accept="text/plain",
                 )
 
                 if response.status != 200:
@@ -290,12 +294,16 @@ async def azure_get_failing_jobs(
                         message = issue.get("message", "No message")
                         output.append(f"     [{issue_type}] {message}")
 
-                # Include log excerpt if requested
-                if include_logs and record.get("log", {}).get("id"):
+                # Include log excerpt if requested.
+                # Use `record.get("log") or {}`: the log key may be present but
+                # explicitly null, in which case `.get("log", {})` returns None
+                # and `.get("id")` would raise 'NoneType' object has no attribute 'get'.
+                if include_logs and (record.get("log") or {}).get("id"):
                     log_id = record["log"]["id"]
                     try:
                         log_response = await client.get(
-                            f"{project}/_apis/build/builds/{build_id}/logs/{log_id}?api-version=7.1"
+                            f"{project}/_apis/build/builds/{build_id}/logs/{log_id}?api-version=7.1",
+                            accept="text/plain",
                         )
                         if log_response.status == 200:
                             # Azure DevOps returns log content as JSON with a "value" array

--- a/src/mcp_server_git/azure/client.py
+++ b/src/mcp_server_git/azure/client.py
@@ -56,14 +56,25 @@ class AzureClient:
             return aiohttp.BasicAuth("", self.token)
         return None
 
-    async def get(self, endpoint: str, **kwargs) -> aiohttp.ClientResponse:
-        """Make GET request to Azure DevOps API"""
+    async def get(
+        self, endpoint: str, accept: str = "application/json", **kwargs
+    ) -> aiohttp.ClientResponse:
+        """Make GET request to Azure DevOps API.
+
+        Args:
+            endpoint: API endpoint (organization is prepended automatically).
+            accept: Value for the Accept header. Defaults to
+                "application/json". Pass "text/plain" for endpoints that return
+                a bare ``List<String>`` — notably build log *content*
+                (``.../logs/{logId}``), which Azure DevOps refuses to serialize
+                as JSON with a 500 "doesn't implement ISecuredObject" error.
+        """
         # Azure DevOps API expects the organization in the URL
         # Format: https://dev.azure.com/{organization}/{project}/_apis/...
         url = f"{self.base_url}/{self.organization}/{endpoint.lstrip('/')}"
 
         headers = {
-            "Accept": "application/json",
+            "Accept": accept,
             "User-Agent": "MCP-Git-Server/1.1.0",
         }
 

--- a/tests/unit/azure/test_azure_api.py
+++ b/tests/unit/azure/test_azure_api.py
@@ -199,6 +199,35 @@ class TestAzureGetBuildLogs:
             assert "truncated 80 lines" in result
             assert "showing last 20 of 100 lines" in result  # New format
 
+    @pytest.mark.asyncio
+    async def test_get_specific_log_requests_text_plain_accept_header(self):
+        """Fetching a specific log must call client.get with accept='text/plain'."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.headers = {"Content-Type": "text/plain"}
+        mock_response.text = AsyncMock(
+            return_value="Build log line 1\nBuild log line 2\nBuild log line 3"
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch("src.mcp_server_git.azure.api.azure_client_context") as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await azure_get_build_logs(
+                project="myproject", build_id=123, log_id=1
+            )
+
+            mock_client.get.assert_called_once()
+            _, kwargs = mock_client.get.call_args
+            assert kwargs.get("accept") == "text/plain"
+
+            assert "Log #1" in result
+            assert "Build log line 1" in result
+            assert "Build log line 2" in result
+            assert "Build log line 3" in result
+
 
 class TestAzureGetFailingJobs:
     """Test azure_get_failing_jobs function."""
@@ -271,6 +300,58 @@ class TestAzureGetFailingJobs:
             assert "failed" in result
             assert "Build failed with error" in result
             assert "Error log line" in result
+
+    @pytest.mark.asyncio
+    async def test_get_failing_jobs_does_not_raise_when_log_is_none(self):
+        """A failed record whose 'log' key is present but null must not raise
+        AttributeError ('NoneType' object has no attribute 'get') and must
+        not attempt a log fetch for that record."""
+        mock_client = MagicMock()
+
+        build_response = AsyncMock()
+        build_response.status = 200
+        build_response.json = AsyncMock(
+            return_value={"id": 123, "result": "failed"}
+        )
+
+        timeline_response = AsyncMock()
+        timeline_response.status = 200
+        timeline_response.json = AsyncMock(
+            return_value={
+                "records": [
+                    {
+                        "id": "job1",
+                        "type": "Job",
+                        "name": "Build Job",
+                        "result": "failed",
+                        "state": "completed",
+                        "log": None,
+                    }
+                ]
+            }
+        )
+
+        async def mock_get(url, **kwargs):
+            if "timeline" in url:
+                return timeline_response
+            elif "logs" in url:
+                raise AssertionError(
+                    "Log fetch should not be attempted when log is None"
+                )
+            return build_response
+
+        mock_client.get = AsyncMock(side_effect=mock_get)
+
+        with patch("src.mcp_server_git.azure.api.azure_client_context") as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await azure_get_failing_jobs(
+                project="myproject", build_id=123, include_logs=True
+            )
+
+            assert isinstance(result, str)
+            assert "Failed Jobs" in result
+            assert "Build Job" in result
 
 
 class TestAzureClientAnonymousMode:

--- a/tests/unit/azure/test_azure_client.py
+++ b/tests/unit/azure/test_azure_client.py
@@ -135,6 +135,41 @@ class TestAzureClientMethods:
         assert isinstance(auth, BasicAuth)
 
     @pytest.mark.asyncio
+    async def test_get_sends_text_plain_accept_header_when_accept_arg_passed(self):
+        """GET with accept='text/plain' must send that value in the Accept header."""
+        mock_session = AsyncMock()
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_session.get = AsyncMock(return_value=mock_response)
+
+        client = AzureClient(token=None, organization="myorg", session=mock_session)
+
+        await client.get(
+            "myproject/_apis/build/builds/123/logs/5?api-version=7.1",
+            accept="text/plain",
+        )
+
+        mock_session.get.assert_called_once()
+        _, kwargs = mock_session.get.call_args
+        assert kwargs["headers"]["Accept"] == "text/plain"
+
+    @pytest.mark.asyncio
+    async def test_get_defaults_accept_header_to_application_json(self):
+        """GET without an accept arg must default the Accept header to application/json."""
+        mock_session = AsyncMock()
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_session.get = AsyncMock(return_value=mock_response)
+
+        client = AzureClient(token=None, organization="myorg", session=mock_session)
+
+        await client.get("myproject/_apis/build/builds/123")
+
+        mock_session.get.assert_called_once()
+        _, kwargs = mock_session.get.call_args
+        assert kwargs["headers"]["Accept"] == "application/json"
+
+    @pytest.mark.asyncio
     async def test_post_request(self):
         """Test Azure client POST request."""
         session = MagicMock()


### PR DESCRIPTION
## Summary

Fixes #192. `azure_get_build_logs` returned a 500 `ISecuredObject` error on **every** single-log content fetch for the conda-forge org.

### Root cause
The single build-log content endpoint (`GET .../build/builds/{id}/logs/{logId}?api-version=7.1`) returns a bare `List<String>`. `AzureClient.get` hardcoded `Accept: application/json`, so Azure DevOps refused to serialize it and returned:

```
500 - Cannot return type System.Collections.Generic.List`1[System.String], from a public API as it doesn't implement ISecuredObject
```

A plain `curl` worked because its default `Accept: */*` yields `text/plain`. The log-**list** path (no `log_id`) was unaffected — it returns a proper JSON object.

### Changes
- `AzureClient.get` gains an `accept` parameter (default `application/json`) that sets the Accept header; the list path is unchanged.
- `azure_get_build_logs` requests single-log content with `accept="text/plain"`; the existing text/plain response branch handles it.
- `azure_get_failing_jobs`: same `text/plain` fix on its inline log fetch, **plus** a NoneType crash fix — `record.get("log", {}).get("id")` raised `'NoneType' object has no attribute 'get'` when a timeline record's `log` key was present but `null` (the secondary symptom reported in #192); now `(record.get("log") or {}).get("id")`.

### Tests
Adds 4 tests (Accept-header override + default on `AzureClient.get`, the `text/plain` request for single-log content, and a regression test that `azure_get_failing_jobs` does not raise when a failed record has `log=None`). Full azure unit suite: **31 passed**.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)