### PR TITLE
feat(github): add github_get_content and github_resolve_ref read-by-ref tools (#193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ The server provides Azure DevOps integration for monitoring and analyzing Azure 
 
 ### Lean MCP Interface (Context-Optimized)
 
-The server provides an alternative **lean interface** that reduces context consumption by ~97% (from ~30k tokens to ~900 tokens). Instead of exposing all 63 tools upfront, it uses a 3-meta-tool pattern:
+The server provides an alternative **lean interface** that reduces context consumption by ~97% (from ~30k tokens to ~900 tokens). Instead of exposing all 64 tools upfront, it uses a 3-meta-tool pattern:
 
 | Meta-Tool | Purpose |
 |-----------|---------|
@@ -145,7 +145,7 @@ The server provides an alternative **lean interface** that reduces context consu
 | `get_tool_spec(tool_name)` | Get full schema for a specific tool on-demand |
 | `execute_tool(tool_name, params)` | Execute any tool dynamically |
 
-**Tool Coverage**: All 62 tools remain accessible (27 git, 32 GitHub, 3 Azure DevOps).
+**Tool Coverage**: All 64 tools remain accessible (27 git, 34 GitHub, 3 Azure DevOps).
 
 **Usage Example**:
 ```python

--- a/src/mcp_server_git/github/api.py
+++ b/src/mcp_server_git/github/api.py
@@ -4,6 +4,7 @@ import logging
 
 from .ci_logs import *  # noqa: F401,F403
 from .client import github_client_context  # noqa: F401
+from .contents import *  # noqa: F401,F403
 from .issue_search import *  # noqa: F401,F403
 from .issues import *  # noqa: F401,F403
 from .patches import PatchMemoryManager  # noqa: F401  # re-export

--- a/src/mcp_server_git/github/contents.py
+++ b/src/mcp_server_git/github/contents.py
@@ -1,0 +1,176 @@
+"""Lightweight GitHub read-by-ref tools.
+
+Two read-only operations that avoid cloning a whole repository:
+
+- ``github_get_content``: fetch a single file's decoded contents at a ref.
+- ``github_resolve_ref``: resolve a branch/tag/short-SHA to its full commit SHA.
+
+Both work on private repos with the server's existing GITHUB_TOKEN.
+"""
+
+import base64
+import logging
+
+from .client import github_client_context
+
+logger = logging.getLogger(__name__)
+
+
+async def github_get_content(
+    repo_owner: str,
+    repo_name: str,
+    path: str,
+    ref: str | None = None,
+) -> str:
+    """Get a single file's contents from a GitHub repo at an optional ref.
+
+    Wraps GET /repos/{owner}/{repo}/contents/{path}?ref={ref}. Decodes
+    base64-encoded file content and reports the blob sha and size. For a
+    directory path, lists the entries instead.
+
+    Args:
+        repo_owner: Repository owner
+        repo_name: Repository name
+        path: File path within the repo (no leading slash required)
+        ref: Optional branch, tag, or commit SHA (defaults to the repo's
+            default branch)
+    """
+    logger.debug(
+        f"🔍 Getting content for {repo_owner}/{repo_name}/{path}"
+        + (f" @ {ref}" if ref else "")
+    )
+    try:
+        async with github_client_context() as client:
+            endpoint = f"/repos/{repo_owner}/{repo_name}/contents/{path.lstrip('/')}"
+            if ref:
+                endpoint += f"?ref={ref}"
+
+            response = await client.get(endpoint)
+
+            if response.status == 404:
+                where = f" at ref '{ref}'" if ref else ""
+                return (
+                    f"❌ Path '{path}' not found in "
+                    f"{repo_owner}/{repo_name}{where}"
+                )
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to get content: {response.status} - {error_text}"
+
+            data = await response.json()
+
+            # A directory returns a JSON array of entries.
+            if isinstance(data, list):
+                output = [
+                    f"Directory listing for {repo_owner}/{repo_name}/{path}"
+                    + (f" @ {ref}" if ref else "")
+                    + f" ({len(data)} entries):\n"
+                ]
+                for entry in data:
+                    output.append(
+                        f"  [{entry.get('type')}] {entry.get('name')} "
+                        f"({entry.get('size', 0)} bytes)"
+                    )
+                return "\n".join(output)
+
+            entry_type = data.get("type")
+            if entry_type != "file":
+                return (
+                    f"❌ Path '{path}' is a {entry_type}, not a file "
+                    f"(sha: {data.get('sha')})"
+                )
+
+            sha = data.get("sha")
+            size = data.get("size", 0)
+            encoding = data.get("encoding")
+            raw = data.get("content", "")
+
+            if encoding == "base64":
+                try:
+                    text = base64.b64decode(raw).decode("utf-8", errors="replace")
+                except Exception as decode_error:  # pragma: no cover - defensive
+                    return f"❌ Failed to decode content: {decode_error}"
+            elif encoding == "none" or not raw:
+                # Files larger than 1MB are not returned by the contents API.
+                return (
+                    f"❌ File '{path}' is too large for the contents API "
+                    f"({size} bytes). Use the Git blobs API or a raw download. "
+                    f"(sha: {sha})"
+                )
+            else:
+                # Unexpected encoding; return the raw payload as-is.
+                text = raw
+
+            header = (
+                f"Content of {repo_owner}/{repo_name}/{path}"
+                + (f" @ {ref}" if ref else "")
+                + f"\nsha: {sha} | size: {size} bytes\n"
+            )
+            return header + "\n" + text
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error getting content: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error getting content: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error getting content: {e}", exc_info=True)
+        return f"❌ Error getting content: {str(e)}"
+
+
+async def github_resolve_ref(
+    repo_owner: str,
+    repo_name: str,
+    ref: str,
+) -> str:
+    """Resolve a branch, tag, or short SHA to its full commit SHA.
+
+    Wraps GET /repos/{owner}/{repo}/commits/{ref}, which resolves branches,
+    tags (including annotated tags), and short SHAs to the full commit SHA.
+
+    Args:
+        repo_owner: Repository owner
+        repo_name: Repository name
+        ref: Branch name, tag name, or (short/full) commit SHA
+    """
+    logger.debug(f"🔍 Resolving ref '{ref}' for {repo_owner}/{repo_name}")
+    try:
+        async with github_client_context() as client:
+            endpoint = f"/repos/{repo_owner}/{repo_name}/commits/{ref}"
+            response = await client.get(endpoint)
+
+            if response.status in (404, 422):
+                return f"❌ Ref '{ref}' not found in {repo_owner}/{repo_name}"
+            if response.status != 200:
+                error_text = await response.text()
+                return f"❌ Failed to resolve ref: {response.status} - {error_text}"
+
+            data = await response.json()
+            sha = data.get("sha")
+            commit = data.get("commit", {})
+            author = commit.get("author", {})
+            message = (commit.get("message") or "").split("\n", 1)[0]
+
+            output = [
+                f"Ref '{ref}' in {repo_owner}/{repo_name}:",
+                f"🔑 Commit SHA: {sha}",
+            ]
+            if author:
+                output.append(
+                    f"👤 Author: {author.get('name')} <{author.get('email')}>"
+                )
+                output.append(f"📅 Date: {author.get('date')}")
+            if message:
+                output.append(f"📝 Message: {message}")
+            return "\n".join(output)
+
+    except ValueError as auth_error:
+        logger.error(f"Authentication error resolving ref: {auth_error}")
+        return f"❌ {str(auth_error)}"
+    except ConnectionError as conn_error:
+        logger.error(f"Connection error resolving ref: {conn_error}")
+        return f"❌ Network connection failed: {str(conn_error)}"
+    except Exception as e:
+        logger.error(f"Unexpected error resolving ref: {e}", exc_info=True)
+        return f"❌ Error resolving ref: {str(e)}"

--- a/src/mcp_server_git/github/models.py
+++ b/src/mcp_server_git/github/models.py
@@ -783,6 +783,31 @@ class GitHubGetRelease(BaseModel):
         return self
 
 
+class GitHubGetContent(BaseModel):
+    """Model for fetching a single file's contents at an optional ref.
+
+    Wraps the GitHub contents API; returns decoded file text plus the blob
+    sha and size. A directory path returns a listing instead.
+    """
+
+    repo_owner: str
+    repo_name: str
+    path: str
+    ref: str | None = None  # branch, tag, or SHA; default = repo default branch
+
+
+class GitHubResolveRef(BaseModel):
+    """Model for resolving a branch/tag/short-SHA to a full commit SHA.
+
+    Wraps GET /repos/{owner}/{repo}/commits/{ref}, which dereferences
+    annotated tags and expands short SHAs.
+    """
+
+    repo_owner: str
+    repo_name: str
+    ref: str
+
+
 class GitHubListReleases(BaseModel):
     """Model for listing repository releases.
 

--- a/src/mcp_server_git/lean/registry_github.py
+++ b/src/mcp_server_git/lean/registry_github.py
@@ -25,6 +25,7 @@ from ..github.models import (
     GitHubGetBranchProtection,
     GitHubGetBranchRules,
     GitHubGetCodeScanningDefaultSetup,
+    GitHubGetContent,
     GitHubGetFailingJobs,
     GitHubGetIssue,
     GitHubGetJobLogs,
@@ -49,6 +50,7 @@ from ..github.models import (
     GitHubListRulesets,
     GitHubListSecretScanningAlerts,
     GitHubListWorkflowRuns,
+    GitHubResolveRef,
     GitHubSearchIssues,
     GitHubUpdateActionsPermissions,
     GitHubUpdateBranchProtection,
@@ -574,6 +576,23 @@ def _register_github_tools(interface: Any, github_service: Any):
             schema=GitHubListSecretScanningAlerts.model_json_schema(),
             domain="github",
             complexity="focused",
+        ),
+        # Read-by-ref Tools (#193)
+        ToolDefinition(
+            name="github_get_content",
+            implementation=github_ops.github_get_content,
+            description="Read a file's decoded contents at a ref (branch/tag/SHA) without cloning",
+            schema=GitHubGetContent.model_json_schema(),
+            domain="github",
+            complexity="core",
+        ),
+        ToolDefinition(
+            name="github_resolve_ref",
+            implementation=github_ops.github_resolve_ref,
+            description="Resolve a branch/tag/short-SHA to its full commit SHA",
+            schema=GitHubResolveRef.model_json_schema(),
+            domain="github",
+            complexity="core",
         ),
         # Release Management Tools
         ToolDefinition(

--- a/tests/unit/github/test_github_contents.py
+++ b/tests/unit/github/test_github_contents.py
@@ -1,0 +1,232 @@
+"""
+Unit tests for GitHub read-by-ref content functions (Issue #193).
+
+Tests the lightweight read-by-ref GitHub tools:
+- github_get_content: fetch a file's decoded contents at an optional ref
+- github_resolve_ref: resolve a branch/tag/short-SHA to a full commit SHA
+"""
+
+import base64
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.mcp_server_git.github.api import github_get_content, github_resolve_ref
+
+
+class TestGitHubGetContent:
+    """Test github_get_content function."""
+
+    @pytest.mark.asyncio
+    async def test_get_content_returns_decoded_text_when_file_found(self):
+        """Test that file content is decoded and sha/size are reported."""
+        mock_client = MagicMock()
+
+        raw_text = "print('hello world')\n"
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "type": "file",
+                "encoding": "base64",
+                "content": base64.b64encode(raw_text.encode("utf-8")).decode(
+                    "ascii"
+                ),
+                "sha": "abc123def456",
+                "size": len(raw_text),
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.contents.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_content(
+                repo_owner="owner",
+                repo_name="repo",
+                path="src/main.py",
+                ref="main",
+            )
+
+            assert "print('hello world')" in result
+            assert "abc123def456" in result
+            assert f"{len(raw_text)} bytes" in result
+
+    @pytest.mark.asyncio
+    async def test_get_content_returns_not_found_message_when_status_404(self):
+        """Test that a 404 status yields a not-found message."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.contents.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_content(
+                repo_owner="owner",
+                repo_name="repo",
+                path="missing.py",
+                ref="main",
+            )
+
+            assert "❌" in result
+            assert "not found" in result
+            assert "missing.py" in result
+
+    @pytest.mark.asyncio
+    async def test_get_content_lists_entries_when_path_is_directory(self):
+        """Test that a directory path returns a listing of entries."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value=[
+                {"type": "file", "name": "a.py", "size": 100},
+                {"type": "dir", "name": "subdir", "size": 0},
+            ]
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.contents.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_content(
+                repo_owner="owner",
+                repo_name="repo",
+                path="src",
+            )
+
+            assert "Directory listing" in result
+            assert "a.py" in result
+            assert "subdir" in result
+
+    @pytest.mark.asyncio
+    async def test_get_content_reports_too_large_when_encoding_none(self):
+        """Test that files too large for the contents API report a clear error."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "type": "file",
+                "encoding": "none",
+                "content": "",
+                "sha": "bigfilesha",
+                "size": 5_000_000,
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.contents.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_content(
+                repo_owner="owner",
+                repo_name="repo",
+                path="big/asset.bin",
+            )
+
+            assert "❌" in result
+            assert "too large" in result
+            assert "5000000" in result
+
+
+class TestGitHubResolveRef:
+    """Test github_resolve_ref function."""
+
+    @pytest.mark.asyncio
+    async def test_resolve_ref_returns_full_sha_when_ref_found(self):
+        """Test that a branch/tag/short-SHA resolves to the full commit SHA."""
+        mock_client = MagicMock()
+
+        full_sha = "a" * 40
+        mock_response = AsyncMock()
+        mock_response.status = 200
+        mock_response.json = AsyncMock(
+            return_value={
+                "sha": full_sha,
+                "commit": {
+                    "author": {
+                        "name": "Test Author",
+                        "email": "author@example.com",
+                        "date": "2024-01-01T00:00:00Z",
+                    },
+                    "message": "Fix bug\n\nDetailed description here",
+                },
+            }
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.contents.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_resolve_ref(
+                repo_owner="owner",
+                repo_name="repo",
+                ref="main",
+            )
+
+            assert full_sha in result
+            assert "Fix bug" in result
+            mock_client.get.assert_called_once_with("/repos/owner/repo/commits/main")
+
+    @pytest.mark.asyncio
+    async def test_resolve_ref_returns_not_found_message_when_status_404(self):
+        """Test that a 404 status yields a not-found message."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 404
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.contents.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_resolve_ref(
+                repo_owner="owner",
+                repo_name="repo",
+                ref="nonexistent-branch",
+            )
+
+            assert "❌" in result
+            assert "not found" in result
+
+    @pytest.mark.asyncio
+    async def test_resolve_ref_returns_not_found_message_when_status_422(self):
+        """Test that a 422 status (unprocessable ref) yields a not-found message."""
+        mock_client = MagicMock()
+
+        mock_response = AsyncMock()
+        mock_response.status = 422
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        with patch(
+            "src.mcp_server_git.github.contents.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_resolve_ref(
+                repo_owner="owner",
+                repo_name="repo",
+                ref="deadbeef",
+            )
+
+            assert "❌" in result
+            assert "not found" in result


### PR DESCRIPTION
## Summary

Closes #193. Adds two lightweight, read-only GitHub tools so two very common lookups no longer require cloning an entire repository.

### New tools
- **`github_get_content`** — wraps `GET /repos/{owner}/{repo}/contents/{path}?ref={ref}`. Returns the base64-decoded file text plus blob `sha` and `size`. Lists entries for a directory path; reports too-large files (>1MB, which the contents API omits) with a pointer to the blobs API. `ref` is optional (defaults to the repo's default branch).
- **`github_resolve_ref`** — wraps `GET /repos/{owner}/{repo}/commits/{ref}` to resolve a branch, tag (including **annotated** tags), or short SHA to its full commit SHA (plus author/date/subject).

Both reuse `github_client_context` and work on **private** repos with the server's existing `GITHUB_TOKEN`.

### Motivation (from the issue)
Resolving `tag v2.9.6 → commit SHA` and reading one workflow file from a private repo previously forced a full `git_clone` of a 71,000-file repo into scratchpad, then `git_show` + local `Read` — a heavyweight workaround for two one-line lookups. These tools also make the MCP a complete substitute for the `gh api contents`/`commits` calls the routing policy intentionally blocks.

### Wiring
- New module `github/contents.py`; models `GitHubGetContent` / `GitHubResolveRef`; registered as **core** tools in the lean interface and re-exported via `api.py`.
- README tool counts updated to **64** (27 git, 34 GitHub, 3 Azure DevOps), which also reconciles a pre-existing 63-vs-62 doc inconsistency.

### Tests
Adds 7 tests (decoded file, 404, directory listing, too-large; ref resolution success, 404, 422). Full github unit suite passes.

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)