### PR TITLE
fix(git): wire git_log format through and derive server_info from registry (#196)

### DIFF
--- a/src/mcp_server_git/git/_commit_ops.py
+++ b/src/mcp_server_git/git/_commit_ops.py
@@ -9,6 +9,10 @@ from ..utils.git_import import GitCommandError, Repo
 
 logger = logging.getLogger(__name__)
 
+# Signature-aware pretty format used when show_signature=True (issue #196).
+# %G? = signature validity code (G/B/U/X/Y/R/E/N), %GS = signer name.
+SIGNATURE_LOG_FORMAT = "%h %G? %GS %s"
+
 __all__ = [
     "git_status",
     "git_commit",
@@ -132,6 +136,7 @@ def git_log(
     oneline: bool = False,
     graph: bool = False,
     format_str: str | None = None,  # Renamed from 'format'
+    show_signature: bool = False,
     since: str | None = None,
     until: str | None = None,
     author: str | None = None,
@@ -149,6 +154,8 @@ def git_log(
         oneline: Compact "hash message" format (equivalent to --oneline)
         graph: Show merge graph (--graph)
         format_str: Custom format string (e.g., "%h - %s (%an)")
+        show_signature: Include GPG signature status via %G? / %GS placeholders.
+            Ignored when `oneline` or `format_str` is given.
         since: Date filter - commits after this date (e.g., "2024-01-01", "1 week ago")
         until: Date filter - commits before this date (e.g., "yesterday", "2024-12-31")
         author: Filter by commit author (email or name)
@@ -177,6 +184,8 @@ def git_log(
             args.append("--oneline")
         elif format_str:  # Use format_str
             args.extend(["--pretty=format:" + format_str])
+        elif show_signature:
+            args.extend(["--pretty=format:" + SIGNATURE_LOG_FORMAT])
 
         if graph:
             args.append("--graph")

--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -71,6 +71,7 @@ class GitLog(BaseModel):
     oneline: bool = False
     graph: bool = False
     format: str | None = None
+    show_signature: bool = False  # Include GPG signature status (%G? / %GS)
     since: str | None = None  # Date filter: "2024-01-01", "1 week ago"
     until: str | None = None  # Date filter: "yesterday", "2024-12-31"
     author: str | None = None  # Author filter: email or name

--- a/src/mcp_server_git/lean/meta_tools.py
+++ b/src/mcp_server_git/lean/meta_tools.py
@@ -15,6 +15,7 @@ from typing import Any
 
 from jsonschema import ValidationError, validate
 
+from ..server_metadata import build_server_info
 from .token_limiter import apply_token_limits
 
 logger = logging.getLogger(__name__)
@@ -95,7 +96,7 @@ def setup_meta_tools(interface) -> None:
 
         Args:
             pattern: Filter tools by name (e.g., "status", "pr", "merge", "rebase")
-                     Leave empty "" to see all 51 tools
+                     Leave empty "" to see all registered tools
 
         Returns:
             Dictionary containing:
@@ -104,9 +105,9 @@ def setup_meta_tools(interface) -> None:
               * description: What the tool does
               * domain: "git", "github", or "azure"
               * complexity: "core", "focused", "advanced", or "comprehensive"
-            - total_tools: Total tools in registry (51)
+            - total_tools: Total tools in registry
             - filtered_count: How many matched your pattern
-            - domains: Breakdown by domain (git: 25, github: 22, azure: 4)
+            - domains: Breakdown by domain (counted live from the registry)
 
             Example output for discover_tools("status"):
             {
@@ -115,11 +116,11 @@ def setup_meta_tools(interface) -> None:
                 {"name": "github_get_pr_status", "description": "Get PR status", "domain": "github"}
               ],
               "filtered_count": 2,
-              "total_tools": 51
+              "total_tools": 115
             }
 
         Examples:
-            discover_tools("")              # List all 51 tools
+            discover_tools("")              # List all registered tools
             discover_tools("status")        # Find: git_status, github_get_pr_status
             discover_tools("pr")            # Find all PR tools: create, list, merge, etc.
             discover_tools("rebase")        # Find: git_rebase, git_abort, git_continue
@@ -445,35 +446,12 @@ def setup_meta_tools(interface) -> None:
             - issues: URL to file bug reports or feature requests
             - documentation: README / docs URL
             - support: Specific URLs for bug reports and feature requests
-            - domains: Supported operation domains with descriptions
+            - domains: Supported operation domains with live tool counts
+            - total_tools: Number of registered tools
             - transport: MCP transport type
             - protocol_version: MCP protocol version
 
         Examples:
             server_info()  # Get server metadata and support URLs
         """
-        try:
-            from importlib.metadata import version
-
-            pkg_version = version("mcp-server-git")
-        except Exception:
-            pkg_version = "unknown"
-        return {
-            "name": "mcp-git",
-            "version": pkg_version,
-            "description": "MCP server for Git, GitHub, and Azure DevOps operations",
-            "repository": "https://github.com/MementoRC/mcp-git",
-            "issues": "https://github.com/MementoRC/mcp-git/issues",
-            "documentation": "https://github.com/MementoRC/mcp-git#readme",
-            "support": {
-                "bug_reports": "https://github.com/MementoRC/mcp-git/issues/new?template=bug_report.md",
-                "feature_requests": "https://github.com/MementoRC/mcp-git/issues/new?template=feature_request.md",
-            },
-            "domains": {
-                "git": "Local git operations",
-                "github": "GitHub API",
-                "azure": "Azure DevOps",
-            },
-            "transport": "HTTP (SSE)",
-            "protocol_version": "2024-11-05",
-        }
+        return build_server_info(interface.tool_registry, "HTTP (SSE)")

--- a/src/mcp_server_git/lean/registry_git.py
+++ b/src/mcp_server_git/lean/registry_git.py
@@ -66,10 +66,21 @@ def _register_git_tools(interface: Any, git_service: Any):
 
     # Create wrapper functions that convert repo_path to Repo object
     # The underlying operations expect Repo objects, not path strings
-    def wrap_repo_op(op_func):
-        """Wrap a git operation that takes Repo as first argument."""
+    def wrap_repo_op(op_func, param_map: dict[str, str] | None = None):
+        """Wrap a git operation that takes Repo as first argument.
+
+        param_map renames public schema parameter names to the implementation's
+        internal names (e.g. "format" -> "format_str", where the internal name
+        avoids shadowing a builtin). Without it the public name is forwarded
+        verbatim and the call fails with an unexpected-keyword TypeError
+        (issue #196).
+        """
 
         def wrapper(repo_path: str, **kwargs):
+            if param_map:
+                for public_name, internal_name in param_map.items():
+                    if public_name in kwargs:
+                        kwargs[internal_name] = kwargs.pop(public_name)
             repo = Repo(repo_path)
             return op_func(repo, **kwargs)
 
@@ -134,7 +145,7 @@ def _register_git_tools(interface: Any, git_service: Any):
         ),
         ToolDefinition(
             name="git_log",
-            implementation=wrap_repo_op(git_ops.git_log),
+            implementation=wrap_repo_op(git_ops.git_log, param_map={"format": "format_str"}),
             description="Shows the commit logs",
             schema=GitLog.model_json_schema(),
             domain="git",

--- a/src/mcp_server_git/server_metadata.py
+++ b/src/mcp_server_git/server_metadata.py
@@ -1,0 +1,68 @@
+"""Shared server metadata used by every transport's ``server_info`` tool.
+
+The lean server and the HTTP server each used to build this payload
+independently, which let their domain counts drift apart and disagree with
+``discover_tools`` (issue #196).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Keep in sync with [project] version in pyproject.toml. The sync is asserted
+# by tests/unit/test_server_metadata.py.
+__version__ = "0.6.3"
+
+_DOMAIN_DESCRIPTIONS = {
+    "git": "Local git operations",
+    "github": "GitHub API",
+    "azure": "Azure DevOps",
+}
+
+
+def get_version() -> str:
+    """Return the installed distribution version, falling back to ``__version__``.
+
+    A source checkout has no installed distribution metadata; that case used to
+    report ``"unknown"``, which made bug reports impossible to pin to a release
+    (issue #196).
+    """
+    try:
+        from importlib.metadata import version
+
+        return version("mcp-server-git")
+    except Exception:
+        return __version__
+
+
+def domain_counts(tool_registry: dict[str, Any]) -> dict[str, int]:
+    """Count registered tools per domain, from the registry ``discover_tools`` reads."""
+    counts = dict.fromkeys(_DOMAIN_DESCRIPTIONS, 0)
+    for tool_def in tool_registry.values():
+        if tool_def.domain in counts:
+            counts[tool_def.domain] += 1
+    return counts
+
+
+def build_server_info(tool_registry: dict[str, Any], transport: str) -> dict[str, Any]:
+    """Build the ``server_info`` payload with live, registry-derived tool counts."""
+    counts = domain_counts(tool_registry)
+    return {
+        "name": "mcp-git",
+        "version": get_version(),
+        "description": "MCP server for Git, GitHub, and Azure DevOps operations",
+        "repository": "https://github.com/MementoRC/mcp-git",
+        "issues": "https://github.com/MementoRC/mcp-git/issues",
+        "documentation": "https://github.com/MementoRC/mcp-git#readme",
+        "support": {
+            "bug_reports": "https://github.com/MementoRC/mcp-git/issues/new?template=bug_report.md",
+            "feature_requests": "https://github.com/MementoRC/mcp-git/issues/new?template=feature_request.md",
+        },
+        "domains": {
+            domain: f"{description} ({counts[domain]} tools)"
+            for domain, description in _DOMAIN_DESCRIPTIONS.items()
+        },
+        "total_tools": len(tool_registry),
+        "transport": transport,
+        "protocol_version": "2024-11-05",
+    }

--- a/src/mcp_server_git/transport/http_server.py
+++ b/src/mcp_server_git/transport/http_server.py
@@ -32,6 +32,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from ..repository_binding import RemoteContaminationError, RepositoryBindingError
+from ..server_metadata import build_server_info
 from .http_session_manager import HTTPSessionManager
 from .security import APIKeyMiddleware, LocalhostOnlyMiddleware
 
@@ -599,31 +600,15 @@ class HTTPGitServer:
                             args=tool_params,
                         )
                     elif tool_name == "server_info":
-                        try:
-                            from importlib.metadata import version as pkg_version
-
-                            ver = pkg_version("mcp-server-git")
-                        except Exception:
-                            ver = "unknown"
-                        result = {
-                            "name": "mcp-git",
-                            "version": ver,
-                            "description": "MCP server for Git, GitHub, and Azure DevOps operations",
-                            "repository": "https://github.com/MementoRC/mcp-git",
-                            "issues": "https://github.com/MementoRC/mcp-git/issues",
-                            "documentation": "https://github.com/MementoRC/mcp-git#readme",
-                            "support": {
-                                "bug_reports": "https://github.com/MementoRC/mcp-git/issues/new?template=bug_report.md",
-                                "feature_requests": "https://github.com/MementoRC/mcp-git/issues/new?template=feature_request.md",
-                            },
-                            "domains": {
-                                "git": "Local git operations (30 tools)",
-                                "github": "GitHub API (52 tools)",
-                                "azure": "Azure DevOps (4 tools)",
-                            },
-                            "transport": "HTTP (SSE)",
-                            "protocol_version": "2024-11-05",
-                        }
+                        session_context = (
+                            await self.session_manager.get_or_create_session(
+                                mcp_session_id
+                            )
+                        )
+                        result = build_server_info(
+                            session_context.lean_interface.tool_registry,
+                            "HTTP (SSE)",
+                        )
                     else:
                         # Direct tool execution (legacy/fallback)
                         result = await self.session_manager.execute_tool(

--- a/src/mcp_server_git/transport/http_server.py
+++ b/src/mcp_server_git/transport/http_server.py
@@ -605,6 +605,19 @@ class HTTPGitServer:
                                 mcp_session_id
                             )
                         )
+                        if session_context is None:
+                            return JSONResponse(
+                                content={
+                                    "jsonrpc": "2.0",
+                                    "id": req_id,
+                                    "error": {
+                                        "code": -32000,
+                                        "message": (
+                                            f"Session not found: {mcp_session_id}"
+                                        ),
+                                    },
+                                }
+                            )
                         result = build_server_info(
                             session_context.lean_interface.tool_registry,
                             "HTTP (SSE)",

--- a/tests/integration/transport/test_http_server.py
+++ b/tests/integration/transport/test_http_server.py
@@ -21,6 +21,7 @@ import asyncio
 import subprocess
 import tempfile
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import httpx
 import pytest
@@ -696,3 +697,43 @@ class TestToolsListAndServerInfo:
         )
         # Should work - server_info doesn't need repo access
         assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_server_info_returns_session_not_found_error_when_session_unresolvable(
+        self, http_server, async_client, temp_git_repo, monkeypatch
+    ):
+        """Test server_info returns -32000 when session lookup resolves to None."""
+        # Create a valid session so the MCP-Session-Id header passes the
+        # earlier missing-header branch and reaches the server_info branch.
+        create_response = await async_client.post(
+            "/mcp/session/create",
+            json={
+                "repository_path": str(temp_git_repo),
+                "expected_remote_url": "https://github.com/test/repo.git",
+            },
+        )
+        assert create_response.status_code == 201
+        session_id = create_response.json()["session_id"]
+
+        monkeypatch.setattr(
+            http_server.session_manager,
+            "get_or_create_session",
+            AsyncMock(return_value=None),
+        )
+
+        response = await async_client.post(
+            "/mcp",
+            json={
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": "server_info", "arguments": {}},
+                "id": 4,
+            },
+            headers={"MCP-Session-Id": session_id},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["jsonrpc"] == "2.0"
+        assert data["error"]["code"] == -32000
+        assert "Session not found" in data["error"]["message"]

--- a/tests/unit/git/test_git_log.py
+++ b/tests/unit/git/test_git_log.py
@@ -9,6 +9,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 
+from mcp_server_git.git._commit_ops import SIGNATURE_LOG_FORMAT
 from mcp_server_git.git.operations import git_log
 from mcp_server_git.utils.git_import import GitCommandError
 
@@ -500,3 +501,70 @@ class TestGitLogRealWorldScenarios:
         assert "--since" in args
         assert "--until" in args
         assert "--grep" in args
+
+
+class TestGitLogShowSignature:
+    """Test show_signature parameter (issue #196)."""
+
+    def test_git_log_returns_signature_format_when_show_signature_true_and_no_oneline_or_format(
+        self,
+    ):
+        """Should use SIGNATURE_LOG_FORMAT when show_signature=True and neither
+        oneline nor format_str is given."""
+        # Arrange
+        mock_repo = Mock()
+        mock_repo.git.log.return_value = "abc123 G Alice Fix bug"
+
+        # Act
+        result = git_log(mock_repo, max_count=10, show_signature=True)
+
+        # Assert
+        args = mock_repo.git.log.call_args[0]
+        assert "--pretty=format:" + SIGNATURE_LOG_FORMAT in args
+
+    def test_git_log_prefers_format_str_when_show_signature_true_and_format_str_given(
+        self,
+    ):
+        """Should use format_str, not the signature format, when both are given."""
+        # Arrange
+        mock_repo = Mock()
+        mock_repo.git.log.return_value = "abc123 Fix bug"
+        format_str = "%h - %s"
+
+        # Act
+        result = git_log(
+            mock_repo, max_count=10, show_signature=True, format_str=format_str
+        )
+
+        # Assert
+        args = mock_repo.git.log.call_args[0]
+        assert "--pretty=format:" + format_str in args
+        assert "--pretty=format:" + SIGNATURE_LOG_FORMAT not in args
+
+    def test_git_log_prefers_oneline_when_show_signature_true_and_oneline_true(self):
+        """Should use --oneline, not the signature format, when both are given."""
+        # Arrange
+        mock_repo = Mock()
+        mock_repo.git.log.return_value = "abc123 Fix bug"
+
+        # Act
+        result = git_log(mock_repo, max_count=10, show_signature=True, oneline=True)
+
+        # Assert
+        args = mock_repo.git.log.call_args[0]
+        assert "--oneline" in args
+        assert "--pretty=format:" + SIGNATURE_LOG_FORMAT not in args
+
+    def test_git_log_omits_pretty_format_when_show_signature_false(self):
+        """Should not add any --pretty=format: argument when show_signature is
+        left at its default (False)."""
+        # Arrange
+        mock_repo = Mock()
+        mock_repo.git.log.return_value = "commit abc123"
+
+        # Act
+        result = git_log(mock_repo, max_count=10, show_signature=False)
+
+        # Assert
+        args = mock_repo.git.log.call_args[0]
+        assert not any(str(a).startswith("--pretty=format:") for a in args)

--- a/tests/unit/lean/test_registry_git_param_map.py
+++ b/tests/unit/lean/test_registry_git_param_map.py
@@ -1,0 +1,137 @@
+"""Regression tests for the git_log schema/implementation param mismatch
+(GitHub issue #196, defect 1).
+
+The GitLog schema exposes a public ``format`` field (it can't be named
+``format_str`` since that would leak an internal implementation detail into
+the tool's public API), but the underlying ``git_log`` operation's parameter
+is named ``format_str`` to avoid shadowing the ``format`` builtin. Without
+the ``param_map={"format": "format_str"}`` rename in
+``_register_git_tools``, calling the registered tool with ``format=...``
+raised ``TypeError: git_log() got an unexpected keyword argument 'format'``.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from mcp_server_git.git.models import GitLog
+from mcp_server_git.lean.registry_git import _register_git_tools
+
+
+class _StubInterface:
+    """Minimal stand-in for GitLeanInterface.register_tool.
+
+    Collects ToolDefinitions exactly as production's register_tool does,
+    without the token-limiting/offloading wrapper, so tests can call
+    tool_def.implementation directly and see the real registry wiring
+    (including param_map) without needing a full GitLeanInterface.
+    """
+
+    def __init__(self):
+        self.tool_registry = {}
+
+    def register_tool(self, tool_def):
+        self.tool_registry[tool_def.name] = tool_def
+
+
+def _build_git_log_tool_def():
+    interface = _StubInterface()
+    _register_git_tools(interface, git_service=Mock())
+    return interface.tool_registry["git_log"]
+
+
+class TestGitLogRegistryParamMap:
+    """Reproduce the exact reported failure via the real ToolDefinition."""
+
+    def test_git_log_implementation_does_not_raise_when_called_with_schema_format_kwarg(
+        self, tmp_path
+    ):
+        """Calling the registered git_log tool with the schema's ``format``
+        keyword must not raise TypeError (issue #196 defect 1)."""
+        # Arrange
+        mock_repo_instance = Mock()
+        mock_repo_instance.git.log.return_value = "abc123 G Alice Fix bug"
+
+        with patch(
+            "mcp_server_git.lean.registry_git.Repo", return_value=mock_repo_instance
+        ):
+            tool_def = _build_git_log_tool_def()
+
+            # Act
+            try:
+                result = tool_def.implementation(
+                    repo_path=str(tmp_path), format="%h %G? %GS", max_count=1
+                )
+            except TypeError as e:
+                pytest.fail(
+                    f"git_log tool raised TypeError for schema 'format' kwarg: {e}"
+                )
+
+        # Assert
+        assert "unexpected keyword argument" not in str(result)
+        args = mock_repo_instance.git.log.call_args[0]
+        assert "--pretty=format:%h %G? %GS" in args
+
+    def test_git_log_implementation_forwards_format_as_format_str_not_format(
+        self, tmp_path
+    ):
+        """The underlying op must receive format_str, never the raw 'format'
+        keyword, confirming param_map did the rename (issue #196 defect 1)."""
+        # Arrange
+        mock_repo_instance = Mock()
+        mock_repo_instance.git.log.return_value = ""
+
+        with (
+            patch(
+                "mcp_server_git.lean.registry_git.Repo",
+                return_value=mock_repo_instance,
+            ),
+            patch("mcp_server_git.git.operations.git_log") as mock_git_log,
+        ):
+            mock_git_log.return_value = "abc123 - fix"
+            tool_def = _build_git_log_tool_def()
+
+            # Act
+            tool_def.implementation(
+                repo_path=str(tmp_path), format="%h - %s", max_count=1
+            )
+
+        # Assert
+        _, call_kwargs = mock_git_log.call_args
+        assert call_kwargs.get("format_str") == "%h - %s"
+        assert "format" not in call_kwargs
+
+
+class TestGitLogSchemaImplementationContract:
+    """The schema's public parameter name must be a key the implementation
+    actually accepts — this is the exact contract that broke in issue #196."""
+
+    def test_git_log_schema_exposes_format_field(self):
+        # Arrange / Act
+        properties = GitLog.model_json_schema()["properties"]
+
+        # Assert
+        assert "format" in properties
+
+    def test_git_log_registered_implementation_accepts_schema_format_key(
+        self, tmp_path
+    ):
+        """The exact key exposed in GitLog's schema ('format') must be
+        accepted by the registered implementation without raising."""
+        # Arrange
+        assert "format" in GitLog.model_json_schema()["properties"]
+        mock_repo_instance = Mock()
+        mock_repo_instance.git.log.return_value = ""
+
+        with patch(
+            "mcp_server_git.lean.registry_git.Repo", return_value=mock_repo_instance
+        ):
+            tool_def = _build_git_log_tool_def()
+
+            # Act
+            try:
+                tool_def.implementation(repo_path=str(tmp_path), format="%h")
+            except TypeError as e:
+                pytest.fail(
+                    f"schema key 'format' rejected by registered implementation: {e}"
+                )

--- a/tests/unit/test_server_metadata.py
+++ b/tests/unit/test_server_metadata.py
@@ -1,0 +1,150 @@
+"""Unit tests for src/mcp_server_git/server_metadata.py (issue #196 defect 3).
+
+Issue #196 reported two related metadata defects: the fallback version could
+silently drift from pyproject.toml (reporting "unknown" in source checkouts),
+and server_info's domain tool counts disagreed with discover_tools' counts
+for the same registry (git 30/github 52/azure 4 vs 48/64/3) because each was
+computed independently.
+"""
+
+import re
+import tomllib
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from mcp_server_git.lean.interface import GitLeanInterface
+from mcp_server_git.server_metadata import (
+    __version__,
+    build_server_info,
+    domain_counts,
+    get_version,
+)
+
+
+def _find_pyproject_toml() -> Path:
+    for parent in Path(__file__).resolve().parents:
+        candidate = parent / "pyproject.toml"
+        if candidate.exists():
+            return candidate
+    raise FileNotFoundError("pyproject.toml not found walking up from test file")
+
+
+class TestServerMetadataVersion:
+    """Guard against __version__ silently going stale relative to pyproject.toml."""
+
+    def test_dunder_version_matches_pyproject_version_when_compared(self):
+        """Regression test for issue #196: __version__ is the fallback used
+        whenever importlib.metadata lookup fails (e.g. an editable/source
+        checkout with no installed distribution). If it drifts from
+        [project].version in pyproject.toml, bug reports can no longer be
+        reliably pinned to a release. This test fails loudly instead of
+        letting that fallback go stale.
+        """
+        pyproject_path = _find_pyproject_toml()
+        with pyproject_path.open("rb") as f:
+            data = tomllib.load(f)
+
+        assert __version__ == data["project"]["version"]
+
+
+class TestDomainCounts:
+    """Test domain_counts() per-domain tallying."""
+
+    def test_domain_counts_returns_totals_per_domain_when_registry_has_mixed_domains(
+        self,
+    ):
+        # Arrange
+        registry = {
+            "a": types.SimpleNamespace(domain="git"),
+            "b": types.SimpleNamespace(domain="git"),
+            "c": types.SimpleNamespace(domain="github"),
+            "d": types.SimpleNamespace(domain="azure"),
+        }
+
+        # Act
+        counts = domain_counts(registry)
+
+        # Assert
+        assert counts == {"git": 2, "github": 1, "azure": 1}
+
+    def test_domain_counts_ignores_unknown_domain_when_present_in_registry(self):
+        # Arrange
+        registry = {
+            "a": types.SimpleNamespace(domain="git"),
+            "b": types.SimpleNamespace(domain="totally-unknown"),
+        }
+
+        # Act
+        counts = domain_counts(registry)
+
+        # Assert
+        assert counts == {"git": 1, "github": 0, "azure": 0}
+        assert "totally-unknown" not in counts
+
+
+class TestBuildServerInfo:
+    """Test build_server_info() live count reporting."""
+
+    def test_build_server_info_reports_live_counts_when_registry_given(self):
+        # Arrange
+        registry = {
+            "a": types.SimpleNamespace(domain="git"),
+            "b": types.SimpleNamespace(domain="git"),
+            "c": types.SimpleNamespace(domain="github"),
+        }
+
+        # Act
+        info = build_server_info(registry, transport="http")
+
+        # Assert
+        assert info["domains"]["git"] == "Local git operations (2 tools)"
+        assert info["domains"]["github"] == "GitHub API (1 tools)"
+        assert info["domains"]["azure"] == "Azure DevOps (0 tools)"
+        assert info["total_tools"] == len(registry)
+
+
+class TestGetVersion:
+    """Test get_version() fallback behavior."""
+
+    def test_get_version_returns_dunder_fallback_when_metadata_lookup_raises(self):
+        # Arrange / Act
+        with patch(
+            "importlib.metadata.version", side_effect=Exception("not installed")
+        ):
+            result = get_version()
+
+        # Assert
+        assert result == __version__
+        assert result != "unknown"
+
+
+def _extract_tool_count(domain_description: str) -> int:
+    match = re.search(r"\((\d+) tools\)", domain_description)
+    assert match, f"unexpected domain description format: {domain_description}"
+    return int(match.group(1))
+
+
+class TestServerMetadataConsistency:
+    """Regression test for issue #196: server_info and discover_tools must
+    agree on domain tool counts for the SAME registry. The reported bug had
+    them disagree (git 30/github 52/azure 4 vs 48/64/3) because server_info
+    and discover_tools computed counts independently.
+    """
+
+    def test_build_server_info_domain_counts_match_discover_tools_when_same_registry_used(
+        self,
+    ):
+        # Arrange
+        interface = GitLeanInterface(MagicMock(), MagicMock(), MagicMock())
+
+        # Act
+        discover_counts = interface.discover_tools()["domains"]
+        info = build_server_info(interface.tool_registry, "test")
+        info_counts = {
+            domain: _extract_tool_count(text) for domain, text in info["domains"].items()
+        }
+
+        # Assert
+        assert info_counts == discover_counts
+        assert info["total_tools"] == interface.discover_tools()["total_tools"]


### PR DESCRIPTION
Addresses **defects 1 and 3** of #196. Defect 2 is deliberately left for a follow-up PR — see below.

## Defect 1 — `git_log` rejected its own schema-declared `format`

`GitLog` declares `format`, but the implementation was renamed to `format_str` to avoid shadowing the builtin, and `wrap_repo_op` forwarded `**kwargs` verbatim. JSON Schema validation therefore *accepted* `format`, and the call then died on `git_log() got an unexpected keyword argument 'format'`.

`wrap_repo_op` now takes an optional `param_map` that renames public schema keys to internal ones; `git_log` registers with `param_map={"format": "format_str"}`.

This restores the only route to git's signature placeholders (`%G?`, `%GS`) — the concrete blocker described in the report. A `show_signature` flag is added as the narrower alternative the issue suggested, emitting `%h %G? %GS %s`. **Existing precedence is preserved**: `oneline` > `format` > `show_signature`.

## Defect 3 — `server_info` reported `version: "unknown"` and contradictory tool counts

Root cause was not just stale numbers: `transport/http_server.py` built its **own** `server_info` payload with hardcoded counts (git 30 / github 52 / azure 4), entirely separate from `lean/meta_tools.py`'s, while `discover_tools` counted the registry live (48 / 64 / 3). Correcting the numbers in place would fix today's symptom and leave the drift mechanism intact.

Both implementations now delegate to a new shared `server_metadata` module that derives counts from **the same `tool_registry` `discover_tools` reads**, so they cannot diverge again.

`get_version()` falls back to a package `__version__` when no distribution metadata is installed (i.e. a source checkout) — that was what produced `"unknown"`. A test asserts the fallback matches `pyproject.toml`, so the fallback cannot itself become the next stale hardcoded value. Stale counts in the `discover_tools` docstring are removed for the same reason.

## Testing

- **868 unit tests** (14 new), **19 integration tests** — all passing; ruff F/E9 clean
- The key regression test drives `format="%h %G? %GS"` through the **real registered `git_log` `ToolDefinition`**, not `wrap_repo_op` in isolation — reproducing the exact call from the report
- A consistency test asserts `server_info`'s domain counts equal `discover_tools`' counts for the same registry — the precise contradiction reported

## Deliberately out of scope

**Defect 2** (errors returned under a `status: "success"` envelope) is not fixed here. `lean/interface.py::_wrap_tool` catches exceptions and *returns* `{"error": ..., "success": false}`, which `execute_tool` then wraps as `status: "success"`; only *raised* exceptions reach the error path. Fixing it changes the error contract for all 115 tools, so it deserves review on its own rather than riding along with these two low-risk fixes.

Worth noting for that follow-up: this same shape was observed live on **three different MCP servers** in one session (git, quality-assurance, pixi-task), which points at the shared 3-meta-tool template rather than anything specific to this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)