### PR TITLE
fix(lean): report status error when a tool result carries an error (#199)

### DIFF
--- a/src/mcp_server_git/lean/meta_tools.py
+++ b/src/mcp_server_git/lean/meta_tools.py
@@ -21,6 +21,62 @@ from .token_limiter import apply_token_limits
 logger = logging.getLogger(__name__)
 
 
+def _is_error_result(result: Any) -> bool:
+    """
+    Detect whether a tool implementation's return value is error-shaped.
+
+    Issue #196 defect 2: ``_wrap_tool`` in interface.py catches exceptions
+    raised by tool implementations and converts them into a dict of the
+    form ``{"error": str(e), "tool": tool_name, "success": False}`` rather
+    than re-raising. Previously, ``execute_tool`` unconditionally wrapped
+    *any* returned value (including this error dict) in a
+    ``{"status": "success", "result": ...}`` envelope, producing a
+    contradictory response where the outer envelope claims success while
+    the inner payload reports failure.
+
+    This check is intentionally strict to avoid false positives on tools
+    that legitimately carry an ``"error"`` key as *data* (e.g. a CI-log
+    payload describing someone else's error): a result is only considered
+    error-shaped when it is a dict, contains an ``"error"`` key, AND its
+    ``"success"`` key is precisely the value ``False`` (identity
+    comparison, not truthiness) as emitted by ``_wrap_tool``.
+
+    Args:
+        result: The raw value returned by a tool implementation.
+
+    Returns:
+        True if the result matches the ``_wrap_tool`` error shape.
+    """
+    if not isinstance(result, dict):
+        return False
+    if "error" not in result:
+        return False
+    return result.get("success") is False
+
+
+def _build_envelope(tool_name: str, result: Any) -> dict[str, Any]:
+    """Build the execute_tool response envelope.
+
+    Kept module-level so tests exercise the real construction rather than a
+    copy of it: the top-level status must never contradict an error payload
+    (issue #196 defect 2).
+    """
+    if _is_error_result(result):
+        return {
+            "tool": tool_name,
+            "status": "error",
+            "error": result.get("error"),
+            "result": result,
+            "execution_mode": "lean_mcp_dynamic",
+        }
+    return {
+        "tool": tool_name,
+        "status": "success",
+        "result": result,
+        "execution_mode": "lean_mcp_dynamic",
+    }
+
+
 def _sanitize_json_string(s: str) -> str:
     """
     Escape bare control characters inside JSON string values.
@@ -402,12 +458,7 @@ def setup_meta_tools(interface) -> None:
             else:
                 result = tool_def.implementation(**parameters)
 
-            return {
-                "tool": tool_name,
-                "status": "success",
-                "result": result,
-                "execution_mode": "lean_mcp_dynamic",
-            }
+            return _build_envelope(tool_name, result)
 
         except ValidationError as ve:
             # Catch any schema validation errors not caught above

--- a/tests/unit/lean/test_execute_tool_error_envelope.py
+++ b/tests/unit/lean/test_execute_tool_error_envelope.py
@@ -1,0 +1,237 @@
+"""
+Unit tests for the execute_tool error envelope fix (issue #196 defect 2).
+
+Bug: interface.py::_wrap_tool catches exceptions raised by tool
+implementations and returns an error-shaped dict
+``{"error": str(e), "tool": tool_name, "success": False}`` instead of
+raising. meta_tools.py::execute_tool then unconditionally wrapped *any*
+returned value in ``{"status": "success", "result": ...}``, so a genuine
+failure was reported as a contradictory
+``{"status": "success", "result": {"error": ..., "success": False}}``
+envelope.
+
+Fix: execute_tool now inspects the result via the ``_is_error_result``
+helper and reports ``status: "error"`` (with the message surfaced at the
+top level) when the result matches the ``_wrap_tool`` error shape.
+
+Test strategy: unit-test ``_is_error_result`` directly, then exercise the
+real ``_build_envelope`` helper extracted from ``execute_tool`` in
+meta_tools.py (not a test-local copy) so a regression that removes the
+``if _is_error_result(result):`` branch from production code fails these
+tests. An integration-style test drives a real
+``GitLeanInterface._wrap_tool`` (which is NOT modified by this fix) to
+confirm a raised exception still ends up correctly classified as an error
+by the envelope logic. Finally, an end-to-end test drives the actual
+registered ``execute_tool`` FastMCP tool (via ``fastmcp.Client`` in-memory
+transport) to reproduce the exact issue #196 scenario.
+"""
+
+import pytest
+from fastmcp import Client
+
+from mcp_server_git.lean.interface import GitLeanInterface, ToolDefinition
+from mcp_server_git.lean.meta_tools import _build_envelope, _is_error_result
+
+
+class MockService:
+    """Mock service for testing with dynamic method support."""
+
+    def __getattr__(self, name: str):
+        return lambda **kwargs: {"result": f"mock_{name}", "params": kwargs}
+
+
+class TestIsErrorResult:
+    """Direct unit tests for the _is_error_result helper."""
+
+    def test_is_error_result_returns_true_when_wrap_tool_error_shape(self):
+        """A dict with success is False and an error key is error-shaped."""
+        result = {"error": "boom", "tool": "x", "success": False}
+        assert _is_error_result(result) is True
+
+    def test_is_error_result_returns_false_when_success_true_and_error_present(self):
+        """A dict carrying 'error' as data with success True is not an error."""
+        result = {"error": "log line from CI", "success": True}
+        assert _is_error_result(result) is False
+
+    def test_is_error_result_returns_false_when_error_present_without_success_key(self):
+        """A dict with an 'error' key but no 'success' key is not an error."""
+        result = {"error": "some data field"}
+        assert _is_error_result(result) is False
+
+    def test_is_error_result_returns_false_when_success_is_zero_not_false(self):
+        """success: 0 is falsy but not identical to False; must not trigger."""
+        result = {"error": "boom", "success": 0}
+        assert _is_error_result(result) is False
+
+    def test_is_error_result_returns_false_when_no_error_key(self):
+        """A dict with success False but no 'error' key is not error-shaped."""
+        result = {"success": False, "message": "no error field here"}
+        assert _is_error_result(result) is False
+
+    def test_is_error_result_returns_false_when_result_is_not_dict(self):
+        """Non-dict results (str, list, None) are never error-shaped."""
+        assert _is_error_result("plain string") is False
+        assert _is_error_result(["error", False]) is False
+        assert _is_error_result(None) is False
+
+
+class TestExecuteToolEnvelope:
+    """Tests for the envelope status derived from a tool's raw result."""
+
+    def test_build_envelope_returns_error_status_when_wrap_tool_error_shape(self):
+        """execute_tool reports status 'error' for a _wrap_tool-style failure."""
+        result = {"error": "boom", "tool": "git_status", "success": False}
+        envelope = _build_envelope("git_status", result)
+
+        assert envelope["status"] == "error"
+        assert envelope["error"] == "boom"
+        assert envelope["result"] == result
+        assert envelope["execution_mode"] == "lean_mcp_dynamic"
+
+    def test_build_envelope_returns_success_status_for_dict_result(self):
+        """A normal successful dict result still yields status 'success'."""
+        result = {"branch": "main", "clean": True}
+        envelope = _build_envelope("git_status", result)
+
+        assert envelope["status"] == "success"
+        assert envelope["result"] == result
+        assert "error" not in envelope
+
+    def test_build_envelope_returns_success_status_for_string_result(self):
+        """A normal successful string result still yields status 'success'."""
+        result = "operation completed"
+        envelope = _build_envelope("git_status", result)
+
+        assert envelope["status"] == "success"
+        assert envelope["result"] == result
+
+    def test_build_envelope_returns_success_when_error_key_present_but_success_true(self):
+        """No false positive: 'error' as legitimate data must stay 'success'."""
+        result = {"error": "some CI job reported an error", "success": True, "log": "..."}
+        envelope = _build_envelope("azure_get_build_logs", result)
+
+        assert envelope["status"] == "success"
+        assert envelope["result"] == result
+
+    def test_build_envelope_returns_success_when_error_key_present_no_success_key(self):
+        """No false positive: 'error' data without a 'success' key stays 'success'."""
+        result = {"error": "no such branch in log output"}
+        envelope = _build_envelope("azure_get_build_logs", result)
+
+        assert envelope["status"] == "success"
+        assert envelope["result"] == result
+
+
+class TestWrapToolIntegrationWithEnvelope:
+    """Integration: a real _wrap_tool error dict flows through to status 'error'."""
+
+    def setup_method(self):
+        self.interface = GitLeanInterface(
+            git_service=MockService(),
+            github_service=MockService(),
+            azure_service=MockService(),
+        )
+
+    def test_build_envelope_returns_error_status_when_implementation_raises_typeerror(self):
+        """
+        Original issue reproduction: a TypeError raised by a tool implementation
+        is converted by the real (unmodified) _wrap_tool into an error dict, and
+        the envelope logic correctly classifies it as status 'error'.
+        """
+
+        def failing_impl(**kwargs):
+            raise TypeError("unexpected keyword argument 'foo'")
+
+        wrapped = self.interface._wrap_tool(failing_impl, "failing_tool")
+        raw_result = wrapped()
+
+        assert raw_result == {
+            "error": "unexpected keyword argument 'foo'",
+            "tool": "failing_tool",
+            "success": False,
+        }
+
+        envelope = _build_envelope("failing_tool", raw_result)
+
+        assert envelope["status"] == "error"
+        assert envelope["error"] == "unexpected keyword argument 'foo'"
+        assert envelope["result"] == raw_result
+
+    @pytest.mark.asyncio
+    async def test_build_envelope_returns_error_status_when_async_implementation_raises(self):
+        """Async variant: raised exception in an async implementation is also caught."""
+
+        async def failing_async_impl(**kwargs):
+            raise ValueError("async failure")
+
+        wrapped = self.interface._wrap_tool(failing_async_impl, "failing_async_tool")
+        raw_result = await wrapped()
+
+        envelope = _build_envelope("failing_async_tool", raw_result)
+
+        assert envelope["status"] == "error"
+        assert envelope["error"] == "async failure"
+
+
+class TestExecuteToolEndToEnd:
+    """
+    End-to-end reproduction of issue #196: drives the actual registered
+    ``execute_tool`` FastMCP tool (not a helper mirror) via ``fastmcp.Client``
+    using FastMCP's in-memory transport (passing the ``FastMCP`` app instance
+    directly to ``Client`` connects without any network/process boundary).
+
+    This closes the gap where deleting the
+    ``if _is_error_result(result):`` branch from the real ``execute_tool``
+    closure would not be caught by any test.
+    """
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_returns_error_status_when_implementation_raises_typeerror(
+        self,
+    ):
+        """
+        Original issue #196 reproduction: a tool implementation raises
+        TypeError("git_log() got an unexpected keyword argument 'format'").
+        The registered execute_tool must report status 'error' (not
+        'success') and preserve the original error text in the result.
+        """
+        interface = GitLeanInterface(
+            git_service=MockService(),
+            github_service=MockService(),
+            azure_service=MockService(),
+        )
+
+        def failing_git_log(**kwargs):
+            raise TypeError(
+                "git_log() got an unexpected keyword argument 'format'"
+            )
+
+        interface.register_tool(
+            ToolDefinition(
+                name="git_log_broken",
+                implementation=failing_git_log,
+                description="Reproduces issue #196 for end-to-end coverage",
+                schema={"type": "object", "properties": {}},
+                domain="test",
+                complexity="focused",
+            )
+        )
+
+        async with Client(interface.app) as client:
+            call_result = await client.call_tool(
+                "execute_tool",
+                {"tool_name": "git_log_broken", "parameters": {}},
+            )
+
+        envelope = call_result.data
+
+        assert envelope["status"] == "error"
+        assert (
+            "git_log() got an unexpected keyword argument 'format'"
+            in envelope["error"]
+        )
+        assert envelope["result"]["success"] is False
+        assert (
+            "git_log() got an unexpected keyword argument 'format'"
+            in envelope["result"]["error"]
+        )


### PR DESCRIPTION
Fixes the last outstanding defect from #196 (defect 2), tracked as #199. Defects 1 and 3 shipped in #198.

## The bug

`execute_tool` wrapped **any** returned value as `status: "success"`. Since `_wrap_tool` (`lean/interface.py` ~258/~280) catches exceptions and *returns* `{"error": ..., "success": false}` instead of raising, every wrapper-caught failure was laundered into a success envelope:

```json
{"tool": "git_log", "status": "success",
 "result": {"error": "git_log() got an unexpected keyword argument 'format'",
            "tool": "git_log", "success": false}}
```

Two contradictory success signals at different nesting levels. Callers checking the documented top-level `status` treated failures as passes.

## The fix

`execute_tool` now returns `status: "error"` when the result carries one, surfacing the message at the top level while keeping the full `result` payload intact for callers that read it.

**Detection is deliberately strict** — dict **and** `result.get("success") is False` (identity comparison, so a falsy `0` does not trigger) **and** an `"error"` key present. That is the exact shape `_wrap_tool` emits. A looser check would misreport tools that legitimately carry an `error` field as *data* — a CI-log payload describing someone else's failure, for instance. Two guard tests cover that false-positive risk explicitly.

`_wrap_tool`'s catching behaviour is **intentionally unchanged** — other callers depend on it. The contradiction was in the envelope, so that is where it is fixed.

## On the tests

Worth calling out, because it nearly went wrong: an earlier draft of this test file defined a **test-local copy** of the envelope logic. All 13 tests passed, and every one of them would have passed with the fix deleted from the source. That is why `_build_envelope` is now a module-level function the tests import rather than reproduce.

Verified by mutation — neutralising the `if _is_error_result(result):` branch fails 4 tests:

```
FAILED TestExecuteToolEnvelope::test_build_envelope_returns_error_status_when_wrap_tool_error_shape
FAILED TestWrapToolIntegrationWithEnvelope::test_build_envelope_returns_error_status_when_implementation_raises_typeerror
FAILED TestWrapToolIntegrationWithEnvelope::test_build_envelope_returns_error_status_when_async_implementation_raises
FAILED TestExecuteToolEndToEnd::test_execute_tool_returns_error_status_when_implementation_raises_typeerror
```

The last of those drives the **actually-registered** `execute_tool` through `fastmcp.Client`'s in-memory transport with the issue's exact reproduction, rather than testing a helper in isolation.

## Gates

pyright 0 errors · ruff F/E9 clean · **882** unit · **20** integration

## Not covered here

The same error-laundering was observed live on **two other MCP servers** built from the shared 3-meta-tool template — `quality-assurance` (`quality_execute_lint_assessment`) and `pixi-task` (`pixi_install`) — both returning unexpected-kwarg errors under `status: "success"`. `quality-assurance` also shows the inverse: `status: "failure"` alongside `total_violations: 0` and "No linting violations found".

This PR fixes mcp-git only. Whether the template itself should be fixed is a separate call — documented in #199.

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)