### PR TITLE
fix(github): return full issue bodies by default (#201)

### DIFF
--- a/src/mcp_server_git/github/issues.py
+++ b/src/mcp_server_git/github/issues.py
@@ -156,13 +156,23 @@ async def github_get_issue(
     repo_owner: str,
     repo_name: str,
     issue_number: int,
+    max_body_chars: int | None = None,
 ) -> str:
     """Get a single GitHub issue by number.
 
     Returns full issue details including title, body, state, labels,
     assignees, milestone, comments count, and timestamps.
+
+    The body is returned in full by default (issue #201). Previously it was
+    silently cut at a hardcoded 2000 characters, which hid requirements from
+    callers with no way to opt out. Pass ``max_body_chars`` to opt in to
+    truncation; when it triggers, the marker reports the real body size so the
+    caller knows something was withheld.
+
+    Args:
+        max_body_chars: Optional cap on body length. ``None`` (the default)
+            means no truncation. Values <= 0 are treated as no truncation.
     """
-    BODY_TRUNCATION_LIMIT = 2000
     logger.debug(f"🔍 Getting issue #{issue_number} for {repo_owner}/{repo_name}")
 
     try:
@@ -219,14 +229,17 @@ async def github_get_issue(
             # Add URL
             output.append(f"URL: {issue.get('html_url', 'N/A')}")
 
-            # Add body (with truncation for very long bodies)
+            # Add body (full by default; truncated only on explicit request)
             body = issue.get("body") or "(No description provided)"
             output.append("")
             output.append("Description:")
             output.append("-" * 40)
-            # Truncate very long bodies
-            if len(body) > BODY_TRUNCATION_LIMIT:
-                output.append(body[:BODY_TRUNCATION_LIMIT] + "\n\n... (truncated)")
+            if max_body_chars and max_body_chars > 0 and len(body) > max_body_chars:
+                output.append(
+                    body[:max_body_chars]
+                    + f"\n\n... (truncated: showing {max_body_chars} "
+                    f"of {len(body)} chars)"
+                )
             else:
                 output.append(body)
 

--- a/src/mcp_server_git/github/models.py
+++ b/src/mcp_server_git/github/models.py
@@ -239,6 +239,14 @@ class GitHubGetIssue(BaseModel):
     repo_owner: str
     repo_name: str
     issue_number: int
+    max_body_chars: int | None = Field(
+        default=None,
+        description=(
+            "Optional cap on the returned issue body length. Default None "
+            "returns the body in full. When set, the truncation marker "
+            "reports the real body size."
+        ),
+    )
 
 
 class GitHubUpdateIssue(BaseModel):

--- a/tests/unit/github/test_github_get_issue.py
+++ b/tests/unit/github/test_github_get_issue.py
@@ -6,7 +6,7 @@ Tests the GitHub issue retrieval functionality including:
 - 404 error handling with helpful suggestions
 - Pull request rejection logic (when issue is actually a PR)
 - Authentication error handling
-- Body truncation logic (>2000 chars)
+- Body returned in full by default; opt-in truncation via max_body_chars (issue #201)
 - Connection error handling
 """
 
@@ -15,6 +15,31 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from src.mcp_server_git.github.api import github_get_issue
+
+
+def _issue_response(body: str, number: int = 77) -> AsyncMock:
+    """Build a minimal 200 response for an issue with the given body."""
+    mock_response = AsyncMock()
+    mock_response.status = 200
+    mock_response.json = AsyncMock(
+        return_value={
+            "number": number,
+            "title": "Issue with a body",
+            "state": "open",
+            "user": {"login": "alice"},
+            "created_at": "2023-01-15T10:30:00Z",
+            "updated_at": "2023-01-16T14:20:00Z",
+            "closed_at": None,
+            "labels": [],
+            "assignees": [],
+            "milestone": None,
+            "comments": 0,
+            "html_url": f"https://github.com/owner/repo/issues/{number}",
+            "body": body,
+            "pull_request": None,
+        }
+    )
+    return mock_response
 
 
 class TestGitHubGetIssue:
@@ -231,8 +256,8 @@ class TestGitHubGetIssue:
             assert "Network timeout" in result
 
     @pytest.mark.asyncio
-    async def test_body_truncation_long_description(self):
-        """Test that very long issue bodies are truncated at 2000 chars."""
+    async def test_get_issue_returns_full_body_when_max_body_chars_not_set(self):
+        """Issue #201: a long body is returned in full when no cap is given."""
         mock_client = MagicMock()
 
         # Create a long body > 2000 characters
@@ -271,12 +296,11 @@ class TestGitHubGetIssue:
                 issue_number=99,
             )
 
-            # Verify truncation message appears
-            assert "... (truncated)" in result
-            # Verify that body truncation occurred (contains 2000 A's but not all 2500)
-            assert result.count("A") >= 2000
-            # Verify it doesn't contain the full 2500 characters
-            assert long_body not in result
+            # No cap requested: the whole body must survive, no marker emitted.
+            # Assert on the body itself rather than a character count: the
+            # header ("Author: alice") also contains an "A".
+            assert long_body in result
+            assert "truncated" not in result
 
     @pytest.mark.asyncio
     async def test_body_not_truncated_short_description(self):
@@ -451,3 +475,78 @@ class TestGitHubGetIssue:
             assert "Author: N/A" in result
             # URL is None since we explicitly set it to None in the mock
             assert "URL:" in result
+
+    @pytest.mark.asyncio
+    async def test_get_issue_truncates_body_and_reports_real_size_when_max_body_chars_set(
+        self,
+    ):
+        """Issue #201: body is truncated and marker reports the real size."""
+        mock_client = MagicMock()
+        long_body = "A" * 2500
+        mock_client.get = AsyncMock(return_value=_issue_response(long_body))
+
+        with patch(
+            "src.mcp_server_git.github.issues.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_issue(
+                repo_owner="owner",
+                repo_name="repo",
+                issue_number=77,
+                max_body_chars=2000,
+            )
+
+            assert "... (truncated: showing 2000 of 2500 chars)" in result
+            assert "A" * 2000 in result
+            assert long_body not in result
+
+    @pytest.mark.asyncio
+    async def test_get_issue_returns_full_body_when_body_shorter_than_max_body_chars(
+        self,
+    ):
+        """Issue #201: body shorter than cap is returned in full, no marker."""
+        mock_client = MagicMock()
+        short_body = "short description"
+        mock_client.get = AsyncMock(return_value=_issue_response(short_body))
+
+        with patch(
+            "src.mcp_server_git.github.issues.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__.return_value = mock_client
+
+            result = await github_get_issue(
+                repo_owner="owner",
+                repo_name="repo",
+                issue_number=77,
+                max_body_chars=2000,
+            )
+
+            assert short_body in result
+            assert "truncated" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_issue_returns_full_body_when_max_body_chars_is_zero_or_negative(
+        self,
+    ):
+        """Issue #201: a nonsense cap (<=0) must not silently blank the body."""
+        mock_client = MagicMock()
+        long_body = "A" * 2500
+
+        for cap in (0, -5):
+            mock_client.get = AsyncMock(return_value=_issue_response(long_body))
+
+            with patch(
+                "src.mcp_server_git.github.issues.github_client_context"
+            ) as mock_context:
+                mock_context.return_value.__aenter__.return_value = mock_client
+
+                result = await github_get_issue(
+                    repo_owner="owner",
+                    repo_name="repo",
+                    issue_number=77,
+                    max_body_chars=cap,
+                )
+
+                assert long_body in result
+                assert "truncated" not in result


### PR DESCRIPTION
Closes #201.

## Problem

`github_get_issue` cut issue bodies at a hardcoded `BODY_TRUNCATION_LIMIT = 2000` and appended `... (truncated)`. Callers had no way to opt out and no indication of how much was withheld.

This is not hypothetical. While working this issue, the truncation hid the tail of **issue #197's own body** — the fix suggestion cut off mid-word at `"passed through as the trailing argum"`. The sanctioned path for reading this repo's requirements could not convey them.

## Change

- `max_body_chars: int | None = None` replaces the constant. **Default is no truncation.**
- When a caller opts in, the marker reports the real size: `... (truncated: showing 2000 of 8431 chars)`.
- Values `<= 0` are treated as no truncation, so a nonsense cap cannot blank the body.
- `max_body_chars` is also added to the `GitHubGetIssue` model. `lean/registry_github.py` derives the tool schema from `GitHubGetIssue.model_json_schema()`, so a function-only change would have left the parameter unreachable and the fix inert for MCP callers.

## Verification

- `pixi run --environment quality test-unit` → **885 passed** (882 baseline + 3 new).
- `pixi run --environment quality lint` → clean.
- New tests cover: opt-in truncation with a real-size marker, a body shorter than the cap, and zero/negative caps.

## Note

`format-check` is red on this branch, but it is **already red on `development`** — 38 files repo-wide, most untouched by this PR. Left alone deliberately rather than burying the fix under 37 unrelated reformats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)