### PR TITLE
fix(git): add explicit commit_ish start point to git_worktree_add (#197)

### DIFF
--- a/src/mcp_server_git/git/models.py
+++ b/src/mcp_server_git/git/models.py
@@ -375,11 +375,24 @@ class GitWorktreeAdd(BaseModel):
     )
     branch: str | None = Field(
         default=None,
-        description="Existing branch to check out in the new worktree.",
+        description=(
+            "Existing branch to check out in the new worktree. When new_branch "
+            "is also set, this is instead used as the START POINT that the new "
+            "branch is created from (legacy form; prefer commit_ish)."
+        ),
     )
     new_branch: str | None = Field(
         default=None,
         description="Name of a NEW branch to create and check out (uses -b, or -B with force).",
+    )
+    commit_ish: str | None = Field(
+        default=None,
+        description=(
+            "Start point for new_branch: the trailing <commit-ish> of "
+            "`git worktree add` (branch, tag, or SHA). Without new_branch this "
+            "creates a detached worktree at that commit. Takes precedence over "
+            "branch when both are supplied alongside new_branch."
+        ),
     )
     force: bool = Field(
         default=False,

--- a/src/mcp_server_git/git/operations_extended.py
+++ b/src/mcp_server_git/git/operations_extended.py
@@ -190,15 +190,18 @@ def git_worktree_add(
     worktree_path: str,
     branch: str | None = None,
     new_branch: str | None = None,
+    commit_ish: str | None = None,
     force: bool = False,
 ) -> str:
     """Create a new linked worktree at `worktree_path`.
 
-    Wraps `git worktree add`. Supports four modes (see issue #167):
-    - No branch + no new_branch: detached HEAD at current HEAD
+    Wraps `git worktree add`. Supported modes:
+    - nothing set: detached HEAD at current HEAD
     - branch only: check out the existing branch
     - new_branch only: create new_branch from HEAD (uses -b, or -B with force)
-    - new_branch + branch: create new_branch from the given start-point
+    - new_branch + commit_ish: create new_branch from that start point
+    - new_branch + branch: legacy form of the above (commit_ish wins if both)
+    - commit_ish only: detached HEAD at that commit-ish
     """
     if DANGEROUS_CHARS.search(worktree_path):
         return f"❌ Invalid characters in worktree path: '{worktree_path}'"
@@ -206,8 +209,19 @@ def git_worktree_add(
         return f"❌ Invalid characters in branch: '{branch}'"
     if new_branch and DANGEROUS_CHARS.search(new_branch):
         return f"❌ Invalid characters in new_branch: '{new_branch}'"
+    if commit_ish and DANGEROUS_CHARS.search(commit_ish):
+        return f"❌ Invalid characters in commit_ish: '{commit_ish}'"
+
+    if commit_ish and branch and not new_branch:
+        return (
+            "❌ commit_ish and branch are mutually exclusive unless new_branch "
+            "is set: 'branch' checks out an existing branch, 'commit_ish' "
+            "creates a detached worktree."
+        )
 
     try:
+        start_point = commit_ish if commit_ish is not None else branch
+
         args = ["add"]
         if force:
             args.append("--force")
@@ -215,18 +229,20 @@ def git_worktree_add(
             args.append("-B" if force else "-b")
             args.append(new_branch)
         args.append(worktree_path)
-        if branch:
-            args.append(branch)
+        if start_point:
+            args.append(start_point)
 
         repo.git.worktree(*args)
 
-        suffix = (
-            f" (new branch {new_branch})"
-            if new_branch
-            else f" (branch {branch})"
-            if branch
-            else " (detached HEAD)"
-        )
+        if new_branch:
+            suffix = f" (new branch {new_branch}"
+            suffix += f" from {start_point})" if start_point else ")"
+        elif branch:
+            suffix = f" (branch {branch})"
+        elif commit_ish:
+            suffix = f" (detached HEAD at {commit_ish})"
+        else:
+            suffix = " (detached HEAD)"
         return f"✅ Worktree added at {worktree_path}{suffix}"
 
     except GitCommandError as e:

--- a/tests/unit/git/test_git_worktree.py
+++ b/tests/unit/git/test_git_worktree.py
@@ -313,6 +313,90 @@ class TestGitWorktreeAdd:
         assert "/tmp/wt-nb" in call_args
         assert "main" in call_args
 
+    def test_worktree_add_creates_new_branch_from_commit_ish_when_both_given(self):
+        """new_branch + commit_ish: creates new_branch from the given commit-ish."""
+        mock_repo = Mock()
+
+        result = git_worktree_add(
+            mock_repo,
+            worktree_path="/tmp/wt",
+            new_branch="feature",
+            commit_ish="development",
+        )
+
+        assert "✅" in result
+        assert "from development" in result
+        call_args = mock_repo.git.worktree.call_args[0]
+        assert call_args == ("add", "-b", "feature", "/tmp/wt", "development")
+
+    def test_worktree_add_uses_branch_as_start_point_when_new_branch_set(self):
+        """Legacy form: new_branch + branch still works as the start point."""
+        mock_repo = Mock()
+
+        result = git_worktree_add(
+            mock_repo,
+            worktree_path="/tmp/wt",
+            new_branch="feature",
+            branch="development",
+        )
+
+        assert "✅" in result
+        call_args = mock_repo.git.worktree.call_args[0]
+        assert call_args == ("add", "-b", "feature", "/tmp/wt", "development")
+
+    def test_worktree_add_prefers_commit_ish_over_branch_when_new_branch_set(self):
+        """When both branch and commit_ish are set, commit_ish wins."""
+        mock_repo = Mock()
+
+        result = git_worktree_add(
+            mock_repo,
+            worktree_path="/tmp/wt",
+            new_branch="feature",
+            branch="development",
+            commit_ish="v1.2.3",
+        )
+
+        assert "✅" in result
+        call_args = mock_repo.git.worktree.call_args[0]
+        assert call_args[-1] == "v1.2.3"
+        assert "development" not in call_args
+
+    def test_worktree_add_creates_detached_worktree_when_only_commit_ish_given(self):
+        """commit_ish only: detached HEAD at that commit-ish."""
+        mock_repo = Mock()
+
+        result = git_worktree_add(mock_repo, worktree_path="/tmp/wt", commit_ish="abc1234")
+
+        assert "✅" in result
+        assert "detached HEAD at abc1234" in result
+        call_args = mock_repo.git.worktree.call_args[0]
+        assert call_args == ("add", "/tmp/wt", "abc1234")
+
+    def test_worktree_add_returns_error_when_commit_ish_and_branch_without_new_branch(self):
+        """commit_ish + branch without new_branch is rejected as ambiguous."""
+        mock_repo = Mock()
+
+        result = git_worktree_add(
+            mock_repo,
+            worktree_path="/tmp/wt",
+            branch="development",
+            commit_ish="abc1234",
+        )
+
+        assert "❌" in result
+        assert "mutually exclusive" in result
+        mock_repo.git.worktree.assert_not_called()
+
+    def test_worktree_add_returns_error_when_commit_ish_has_dangerous_chars(self):
+        """Should reject dangerous characters in commit_ish."""
+        mock_repo = Mock()
+
+        result = git_worktree_add(mock_repo, worktree_path="/tmp/wt", commit_ish="abc; rm -rf /")
+
+        assert "❌" in result
+        assert "Invalid characters in commit_ish" in result
+        mock_repo.git.worktree.assert_not_called()
+
     def test_worktree_add_rejects_dangerous_chars_in_worktree_path(self):
         """Should reject dangerous characters in worktree_path."""
         mock_repo = Mock()


### PR DESCRIPTION
Closes #197.

## The issue's premise was wrong — please read this part

#197 reported that a worktree's new branch "can only ever start from the repo's current HEAD". That is not what the code does. `git_worktree_add` **already** appended `branch` as the trailing `<commit-ish>` when `new_branch` was set (`operations_extended.py:218-219`), and the docstring documented that fourth mode. So this already worked:

```
git_worktree_add {worktree_path: ..., new_branch: "foo", branch: "development"}
```

The real defect was **discoverability**: `GitWorktreeAdd.branch` was described only as *"Existing branch to check out in the new worktree"*, never mentioning its start-point role. So the two-call workaround described in the issue — and the HEAD-move hazard it warns about — were never necessary. The schema hid the one-call form.

There was also no test covering the `new_branch + branch` combined mode, which is why the gap went unnoticed.

## Change

- Add explicit `commit_ish`, naming the trailing `<commit-ish>` directly (matches native git and `git_create_branch`'s naming).
- Rewrite the `branch` description to document its dual role. Legacy `new_branch + branch` still works; `commit_ish` wins when both are given.
- `commit_ish` alone now creates a **detached worktree at that commit** — a mode the tool could not previously express.
- `commit_ish` + `branch` **without** `new_branch` is **rejected** rather than silently resolved. They mean contradictory things (check out an existing branch vs. detach at a commit); quietly honouring one would repeat the same "interface misrepresents the implementation" failure this issue is about.
- `commit_ish` gets the `DANGEROUS_CHARS` validation already applied to `branch`/`new_branch`, since it reaches a git command line.

## Verification

- `pixi run --environment quality test-unit` → **888 passed** (882 baseline + 6 new).
- `pixi run --environment quality lint` → clean.
- New tests: commit_ish as start point, legacy branch-as-start-point, commit_ish-wins precedence, commit_ish-only detached, mutual-exclusivity error, dangerous-chars rejection.
- Back-compat: success strings keep `"new branch X"`, `"detached HEAD"`, `"(branch X)"` as substrings, so the three pre-existing worktree_add tests are untouched.

## Caveat

I was never able to read #197's body past `"passed through as the trailing argum"` — `github_get_issue` truncates at 2000 chars (that's #201, fixed in PR #202, but the running MCP server still serves the old code). If the unread tail contains acceptance criteria that conflict with the above, this needs a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)