### PR TITLE
chore(ci): stop running claude-review on pull requests

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,14 +1,20 @@
 name: Claude Code Review
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-    # Optional: Only run on specific file changes
-    # paths:
-    #   - "src/**/*.ts"
-    #   - "src/**/*.tsx"
-    #   - "src/**/*.js"
-    #   - "src/**/*.jsx"
+  # Disabled as an automatic PR check: this workflow authenticates with
+  # CLAUDE_CODE_OAUTH_TOKEN, which expires and needs manual rotation. It failed
+  # on every recent PR (#200, #202, #203) purely on expired credentials, so it
+  # produced a permanently red check that reviewers learned to ignore.
+  #
+  # It is NOT a required status check (branch protection on `development`
+  # requires only "CI Success"), so this never blocked a merge.
+  #
+  # Kept here rather than deleted so it can be re-enabled by restoring the
+  # pull_request trigger below once the token situation is sorted out:
+  #
+  #   pull_request:
+  #     types: [opened, synchronize]
+  workflow_dispatch:
 
 jobs:
   claude-review:


### PR DESCRIPTION
## Why

`claude-review` has failed on every recent PR (#200, #202, #203) while every other check passed. Confirmed from the job log for PR #203 ([run](https://github.com/MementoRC/mcp-git/actions/runs/31438866004/job/93619075301)):

```
API Error: 401 {"type":"error","error":{"type":"authentication_error",
"message":"OAuth access token has expired. Re-authenticate to continue."}}
```

`CLAUDE_CODE_OAUTH_TOKEN` is expired. The job burns ~3 minutes of runner time per PR retrying before surfacing the 401 (`duration_ms: 189429`, `is_error: true`, `total_cost_usd: 0` — it never reaches the model).

A permanently red check carries no signal and trains reviewers to ignore check status, which is worse than having no check at all.

## What

Trigger changes from `pull_request: types: [opened, synchronize]` to `workflow_dispatch:`.

The workflow is **kept rather than deleted** so it can be re-enabled by restoring the two trigger lines, which are recorded in a comment in the file itself. Also drops a commented-out `paths:` filter that only had meaning under the removed trigger.

## Safety

`claude-review` is **not** a required status check — branch protection on `development` requires only `CI Success` — so this job has never blocked a merge and no branch-protection changes are needed.

## Deliberately out of scope

`.github/workflows/claude.yml` is untouched. It uses the same expiring token but only fires on issue/PR comments and reviews, so it produces no unattended red checks. It will hit the same 401 the next time it's actually invoked — flagging that rather than silently gutting the on-demand `@claude` bot.

## Self-verifying

This PR is its own test: `claude-review` should be **absent** from its check list. If it still appears, the check originates somewhere other than this workflow and needs chasing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)