### PR TITLE
fix(github): reach any part of a large job log (#205) and unblock github_get_content (#206)

### DIFF
--- a/src/mcp_server_git/github/ci_logs.py
+++ b/src/mcp_server_git/github/ci_logs.py
@@ -1,4 +1,5 @@
 """GitHub Actions CI logs and workflow completion monitoring."""
+
 from __future__ import annotations
 import asyncio
 import json
@@ -6,6 +7,12 @@ import logging
 import time
 from datetime import datetime
 from mcp_server_git.github.client import github_client_context
+from mcp_server_git.github.job_log_selection import (
+    LogSelectionError,
+    build_log_response_lines,
+    write_full_log_response,
+)
+
 logger = logging.getLogger(__name__)
 
 # Constants for job logs processing - LLM-friendly defaults
@@ -244,6 +251,13 @@ async def github_get_job_logs(
     job_id: int,
     tail_lines: int | None = None,
     full_log: bool = False,
+    head_lines: int | None = None,
+    start_line: int | None = None,
+    end_line: int | None = None,
+    grep: str | None = None,
+    context_lines: int = 0,
+    ignore_case: bool = False,
+    output_path: str | None = None,
 ) -> str:
     """Get logs for a specific GitHub Actions job.
 
@@ -252,18 +266,33 @@ async def github_get_job_logs(
     github_get_failing_jobs or github_get_workflow_run output.
 
     IMPORTANT: By default, logs are truncated to the last 500 lines to be
-    LLM-context-friendly. Use tail_lines to adjust or full_log=True for complete logs.
+    LLM-context-friendly. Use head_lines/tail_lines/start_line+end_line/grep
+    to select a different slice, or output_path to get the complete log
+    without any of it entering context.
 
     Args:
         repo_owner: Repository owner/organization
         repo_name: Repository name
         job_id: The job ID (from check runs or workflow jobs)
         tail_lines: Return only last N lines (default: 500 for LLM efficiency)
-        full_log: If True, return complete log without line limit (still has 100KB char limit)
+        full_log: If True, return complete log without line limit (still has
+            100KB char limit unless output_path is given)
+        head_lines: Return only first N lines, reaching the start of the log
+        start_line: 1-indexed inclusive start of an explicit window
+        end_line: 1-indexed inclusive end of an explicit window
+        grep: Regex; return only matching lines. Searches the whole log by
+            default, not just the last 500 lines
+        context_lines: Lines of context to keep either side of a grep match
+        ignore_case: Case-insensitive grep
+        output_path: Absolute path to write the complete log to disk instead
+            of returning it inline; the response then carries only metadata
 
     Returns:
-        Formatted string with job information and log content.
-        Logs are automatically truncated to be LLM-context-friendly.
+        Formatted string with job information and log content (or, when
+        output_path is given, job information and write metadata only).
+        Every response reports total lines, total bytes, and whether the
+        returned content was truncated. Only one of head_lines, tail_lines,
+        or start_line/end_line may be given; grep composes with any of them.
     """
     logger.debug(f"🔍 Fetching logs for job {job_id} in {repo_owner}/{repo_name}")
 
@@ -273,28 +302,12 @@ async def github_get_job_logs(
             job_response = await client.get(
                 f"/repos/{repo_owner}/{repo_name}/actions/jobs/{job_id}"
             )
-            if job_response.status == 404:
-                return f"❌ Job #{job_id} not found in {repo_owner}/{repo_name}"
-            if job_response.status == 403:
-                return f"❌ Access denied for job #{job_id}. Check repository permissions or API rate limits."
-            if job_response.status == 429:
-                return "❌ GitHub API rate limit exceeded. Please wait and try again."
-            if job_response.status != 200:
-                return f"❌ Failed to get job #{job_id}: HTTP {job_response.status}"
+            job_error = _check_job_response(job_response, job_id, repo_owner, repo_name)
+            if job_error is not None:
+                return job_error
 
             job_data = await job_response.json()
-
-            # Build job info header
-            output = [f"Job #{job_id} - {job_data.get('name', 'N/A')}:\n"]
-            output.append(f"Status: {job_data.get('status', 'N/A')}")
-            if job_data.get("conclusion"):
-                output.append(f"Conclusion: {job_data['conclusion']}")
-            if job_data.get("started_at"):
-                output.append(f"Started: {job_data['started_at']}")
-            if job_data.get("completed_at"):
-                output.append(f"Completed: {job_data['completed_at']}")
-            if job_data.get("html_url"):
-                output.append(f"URL: {job_data['html_url']}")
+            output = _build_job_header(job_id, job_data)
 
             # Fetch the actual logs
             # Note: GitHub API returns logs as plain text, not JSON
@@ -303,20 +316,9 @@ async def github_get_job_logs(
                 f"/repos/{repo_owner}/{repo_name}/actions/jobs/{job_id}/logs",
                 allow_redirects=True,
             )
-
-            if logs_response.status == 404:
-                output.append("\n⚠️ Logs not available (may have been deleted)")
-                return "\n".join(output)
-            if logs_response.status == 403:
-                output.append(
-                    "\n❌ Access denied for logs. Check repository permissions."
-                )
-                return "\n".join(output)
-            if logs_response.status == 429:
-                output.append("\n❌ GitHub API rate limit exceeded for logs.")
-                return "\n".join(output)
-            if logs_response.status != 200:
-                output.append(f"\n❌ Failed to fetch logs: HTTP {logs_response.status}")
+            logs_error = _check_logs_response(logs_response)
+            if logs_error is not None:
+                output.append(logs_error)
                 return "\n".join(output)
 
             # Get logs as text
@@ -326,74 +328,28 @@ async def github_get_job_logs(
                 output.append("\n📭 Log content is empty")
                 return "\n".join(output)
 
-            # Check for oversized logs and truncate if necessary (memory protection)
-            original_size = len(logs_text)
-            was_size_truncated = False
-            if original_size > _JOB_LOGS_MAX_SIZE_BYTES:
-                logs_text = logs_text[-_JOB_LOGS_MAX_SIZE_BYTES:]
-                was_size_truncated = True
-                logger.warning(
-                    f"Job logs truncated from {original_size} to {_JOB_LOGS_MAX_SIZE_BYTES} bytes"
+            if output_path is not None:
+                return write_full_log_response(output, output_path, logs_text)
+
+            try:
+                output.extend(
+                    build_log_response_lines(
+                        logs_text,
+                        tail_lines=tail_lines,
+                        full_log=full_log,
+                        head_lines=head_lines,
+                        start_line=start_line,
+                        end_line=end_line,
+                        grep=grep,
+                        context_lines=context_lines,
+                        ignore_case=ignore_case,
+                        size_limit=_JOB_LOGS_MAX_SIZE_BYTES,
+                        char_limit=_JOB_LOGS_MAX_CHARS_FOR_LLM,
+                        separator_length=_JOB_LOGS_SEPARATOR_LENGTH,
+                    )
                 )
-
-            # Split lines once for efficient processing
-            lines = logs_text.splitlines()
-            total_lines = len(lines)
-
-            # Apply LLM-friendly truncation
-            # Priority: explicit tail_lines > full_log flag > default limit
-            effective_tail_lines = tail_lines
-            was_line_truncated = False
-
-            if tail_lines is None and not full_log:
-                # Apply default LLM-friendly limit
-                effective_tail_lines = _JOB_LOGS_DEFAULT_TAIL_LINES
-
-            if (
-                effective_tail_lines is not None
-                and effective_tail_lines > 0
-                and total_lines > effective_tail_lines
-            ):
-                lines = lines[-effective_tail_lines:]
-                was_line_truncated = True
-                output.append(
-                    f"\n📋 Logs (last {effective_tail_lines} of {total_lines} lines):"
-                )
-            else:
-                output.append(f"\n📋 Logs ({total_lines} lines):")
-
-            # Apply character limit for LLM context efficiency
-            logs_output = "\n".join(lines)
-            was_char_truncated = False
-            if len(logs_output) > _JOB_LOGS_MAX_CHARS_FOR_LLM:
-                logs_output = logs_output[-_JOB_LOGS_MAX_CHARS_FOR_LLM:]
-                # Find first complete line after truncation
-                first_newline = logs_output.find("\n")
-                if first_newline > 0:
-                    logs_output = logs_output[first_newline + 1 :]
-                was_char_truncated = True
-                logger.info(
-                    f"Job logs char-truncated to {_JOB_LOGS_MAX_CHARS_FOR_LLM} chars for LLM context"
-                )
-
-            # Add truncation warnings
-            truncation_notes = []
-            if was_size_truncated:
-                truncation_notes.append(f"size: {original_size:,} bytes")
-            if was_line_truncated:
-                truncation_notes.append(f"lines: {total_lines} total")
-            if was_char_truncated:
-                truncation_notes.append("chars: exceeded 100KB limit")
-
-            if truncation_notes:
-                output.append(
-                    f"⚠️ Truncated for LLM context ({', '.join(truncation_notes)})"
-                )
-
-            separator = "-" * _JOB_LOGS_SEPARATOR_LENGTH
-            output.append(separator)
-            output.append(logs_output)
-            output.append(separator)
+            except LogSelectionError as exc:
+                return f"❌ {exc}"
 
             return "\n".join(output)
 
@@ -406,3 +362,49 @@ async def github_get_job_logs(
     except Exception as e:
         logger.error(f"Unexpected error getting job logs: {e}", exc_info=True)
         return f"❌ Error getting job logs: {str(e)}"
+
+
+def _check_job_response(
+    response, job_id: int, repo_owner: str, repo_name: str
+) -> str | None:
+    """Translate a bad job-details HTTP response into a user-facing error."""
+    if response.status == 404:
+        return f"❌ Job #{job_id} not found in {repo_owner}/{repo_name}"
+    if response.status == 403:
+        return (
+            f"❌ Access denied for job #{job_id}. "
+            "Check repository permissions or API rate limits."
+        )
+    if response.status == 429:
+        return "❌ GitHub API rate limit exceeded. Please wait and try again."
+    if response.status != 200:
+        return f"❌ Failed to get job #{job_id}: HTTP {response.status}"
+    return None
+
+
+def _build_job_header(job_id: int, job_data: dict) -> list[str]:
+    """Render the job info lines shown above the log content."""
+    output = [f"Job #{job_id} - {job_data.get('name', 'N/A')}:\n"]
+    output.append(f"Status: {job_data.get('status', 'N/A')}")
+    if job_data.get("conclusion"):
+        output.append(f"Conclusion: {job_data['conclusion']}")
+    if job_data.get("started_at"):
+        output.append(f"Started: {job_data['started_at']}")
+    if job_data.get("completed_at"):
+        output.append(f"Completed: {job_data['completed_at']}")
+    if job_data.get("html_url"):
+        output.append(f"URL: {job_data['html_url']}")
+    return output
+
+
+def _check_logs_response(response) -> str | None:
+    """Translate a bad log-fetch HTTP response into a user-facing message."""
+    if response.status == 404:
+        return "\n⚠️ Logs not available (may have been deleted)"
+    if response.status == 403:
+        return "\n❌ Access denied for logs. Check repository permissions."
+    if response.status == 429:
+        return "\n❌ GitHub API rate limit exceeded for logs."
+    if response.status != 200:
+        return f"\n❌ Failed to fetch logs: HTTP {response.status}"
+    return None

--- a/src/mcp_server_git/github/job_log_selection.py
+++ b/src/mcp_server_git/github/job_log_selection.py
@@ -1,0 +1,406 @@
+"""Line selection and filtering for large CI job logs.
+
+``github_get_job_logs`` can only hand a small slice of a job log to an LLM.
+These helpers decide *which* slice, so that the start of a log is reachable
+(``head_lines``, ``start_line``/``end_line``) and so that a caller can pull
+just the lines they care about out of a 64k-line log (``grep``).
+
+Everything here is pure: it works on an already-fetched list of lines and
+never touches the network or the filesystem.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TAIL_LINES = 500
+MAX_CHARS_FOR_LLM = 100 * 1024
+
+_GREP_GROUP_SEPARATOR = "--"
+
+
+class LogSelectionError(ValueError):
+    """Raised when the requested selection parameters conflict or are invalid."""
+
+
+@dataclass(frozen=True)
+class LogSelection:
+    """The slice of a log chosen for return, plus how it was chosen."""
+
+    text: str
+    label: str
+    truncated: bool
+    match_count: int | None = None
+    char_truncated: bool = False
+    windowed: bool = False
+
+
+def _reject_conflicting_selectors(
+    head_lines: int | None,
+    tail_lines: int | None,
+    start_line: int | None,
+    end_line: int | None,
+) -> None:
+    """Reject more than one window selector, rather than silently picking one."""
+    selectors = (
+        head_lines,
+        tail_lines,
+        start_line if start_line is not None else end_line,
+    )
+    if sum(1 for selector in selectors if selector is not None) > 1:
+        raise LogSelectionError(
+            "Use only one of head_lines, tail_lines, or start_line/end_line."
+        )
+
+
+def _head_window(total_lines: int, count: int) -> tuple[int, int, str, bool]:
+    if count <= 0:
+        raise LogSelectionError("head_lines must be a positive integer.")
+    end = min(count, total_lines)
+    return 1, end, f"first {end} of {total_lines} lines", True
+
+
+def _tail_window(total_lines: int, count: int) -> tuple[int, int, str, bool]:
+    if count <= 0:
+        raise LogSelectionError("tail_lines must be a positive integer.")
+    start = max(1, total_lines - count + 1)
+    kept = total_lines - start + 1
+    return start, total_lines, f"last {kept} of {total_lines} lines", False
+
+
+def _range_window(
+    total_lines: int, start_line: int | None, end_line: int | None
+) -> tuple[int, int, str, bool]:
+    start = 1 if start_line is None else start_line
+    end = total_lines if end_line is None else end_line
+    if start < 1:
+        raise LogSelectionError("start_line is 1-indexed and must be >= 1.")
+    if end < start:
+        raise LogSelectionError("end_line must be >= start_line.")
+    if start > total_lines:
+        raise LogSelectionError(
+            f"start_line {start:,} is past the end of the log ({total_lines:,} lines)."
+        )
+    end = min(end, total_lines)
+    return start, end, f"lines {start}-{end} of {total_lines}", True
+
+
+def resolve_window(
+    total_lines: int,
+    *,
+    head_lines: int | None = None,
+    tail_lines: int | None = None,
+    start_line: int | None = None,
+    end_line: int | None = None,
+    full_log: bool = False,
+    whole_log_default: bool = False,
+) -> tuple[int, int, str, bool]:
+    """Resolve the 1-indexed inclusive window of lines to return.
+
+    Returns ``(start, end, label, anchored_at_head)``. ``anchored_at_head``
+    records which end matters if the character cap bites later: a window taken
+    from the start of the log must not then be trimmed from the front.
+
+    ``whole_log_default`` selects the whole log when no explicit selector was
+    given. It is used for ``grep``, where the filter already bounds the output
+    and defaulting to the last 500 lines would silently hide earlier matches.
+    """
+    _reject_conflicting_selectors(head_lines, tail_lines, start_line, end_line)
+
+    if start_line is not None or end_line is not None:
+        return _range_window(total_lines, start_line, end_line)
+    if head_lines is not None:
+        return _head_window(total_lines, head_lines)
+    if tail_lines is not None:
+        return _tail_window(total_lines, tail_lines)
+    if full_log or whole_log_default:
+        return 1, total_lines, f"all {total_lines} lines", True
+    return _tail_window(total_lines, DEFAULT_TAIL_LINES)
+
+
+def _expand_context(
+    match_indexes: list[int], context_lines: int, total: int
+) -> list[int]:
+    span = max(0, context_lines)
+    keep: set[int] = set()
+    for index in match_indexes:
+        keep.update(range(max(0, index - span), min(total, index + span + 1)))
+    return sorted(keep)
+
+
+def _render_groups(
+    numbered: list[tuple[int, str]], keep: list[int], matches: set[int]
+) -> list[str]:
+    """Render kept lines in grep's notation, separating discontiguous groups."""
+    rendered: list[str] = []
+    previous: int | None = None
+    for index in keep:
+        if previous is not None and index != previous + 1:
+            rendered.append(_GREP_GROUP_SEPARATOR)
+        number, text = numbered[index]
+        rendered.append(f"{number}{':' if index in matches else '-'} {text}")
+        previous = index
+    return rendered
+
+
+def filter_lines(
+    numbered: list[tuple[int, str]],
+    pattern: str,
+    *,
+    context_lines: int = 0,
+    ignore_case: bool = False,
+) -> tuple[list[str], int]:
+    """Keep only lines matching *pattern*, with optional surrounding context.
+
+    *numbered* is a list of ``(line_number, text)`` pairs. Returns
+    ``(rendered_lines, match_count)`` using grep's own notation: ``n: text``
+    for a match, ``n- text`` for context, ``--`` between separated groups.
+    """
+    try:
+        regex = re.compile(pattern, re.IGNORECASE if ignore_case else 0)
+    except re.error as exc:
+        raise LogSelectionError(f"Invalid grep pattern {pattern!r}: {exc}") from exc
+
+    match_indexes = [i for i, (_, text) in enumerate(numbered) if regex.search(text)]
+    if not match_indexes:
+        return [], 0
+
+    keep = _expand_context(match_indexes, context_lines, len(numbered))
+    return _render_groups(numbered, keep, set(match_indexes)), len(match_indexes)
+
+
+def cap_characters(
+    text: str, *, keep_head: bool, limit: int = MAX_CHARS_FOR_LLM
+) -> tuple[str, bool]:
+    """Trim *text* to *limit* characters, keeping whichever end was asked for.
+
+    Trimming stops at a line boundary so the result never starts or ends with
+    half a line.
+    """
+    if len(text) <= limit:
+        return text, False
+
+    if keep_head:
+        trimmed = text[:limit]
+        boundary = trimmed.rfind("\n")
+        if boundary > 0:
+            trimmed = trimmed[:boundary]
+    else:
+        trimmed = text[-limit:]
+        boundary = trimmed.find("\n")
+        if boundary >= 0:
+            trimmed = trimmed[boundary + 1 :]
+    return trimmed, True
+
+
+def select_log_text(
+    lines: list[str],
+    *,
+    head_lines: int | None = None,
+    tail_lines: int | None = None,
+    start_line: int | None = None,
+    end_line: int | None = None,
+    full_log: bool = False,
+    grep: str | None = None,
+    context_lines: int = 0,
+    ignore_case: bool = False,
+    limit: int = MAX_CHARS_FOR_LLM,
+) -> LogSelection:
+    """Choose the portion of *lines* to return, honouring the LLM char cap.
+
+    A window is resolved first, then ``grep`` (when given) filters within it,
+    so ``start_line``/``end_line`` and ``grep`` compose.
+    """
+    total_lines = len(lines)
+    start, end, label, anchored_at_head = resolve_window(
+        total_lines,
+        head_lines=head_lines,
+        tail_lines=tail_lines,
+        start_line=start_line,
+        end_line=end_line,
+        full_log=full_log,
+        whole_log_default=grep is not None,
+    )
+
+    window = list(enumerate(lines[start - 1 : end], start=start))
+    match_count: int | None = None
+
+    if grep is not None:
+        rendered, match_count = filter_lines(
+            window,
+            grep,
+            context_lines=context_lines,
+            ignore_case=ignore_case,
+        )
+        label = f"{match_count:,} match(es) for {grep!r} within {label}"
+        anchored_at_head = True
+    else:
+        rendered = [text for _, text in window]
+
+    text, char_truncated = cap_characters(
+        "\n".join(rendered), keep_head=anchored_at_head, limit=limit
+    )
+    windowed = (end - start + 1) < total_lines
+    return LogSelection(
+        text=text,
+        label=label,
+        truncated=char_truncated or windowed or grep is not None,
+        match_count=match_count,
+        char_truncated=char_truncated,
+        windowed=windowed,
+    )
+
+
+def format_totals(
+    *,
+    total_lines: int,
+    total_bytes: int,
+    label: str,
+    truncated: bool,
+    was_size_truncated: bool,
+) -> str:
+    """Render the one-line totals summary shown before every log body."""
+    truncated_text = "yes" if truncated else "no"
+    line = (
+        f"📊 Total: {total_lines:,} lines / {total_bytes:,} bytes | "
+        f"Returned: {label} | Truncated: {truncated_text}"
+    )
+    if was_size_truncated:
+        line += " (log clamped to 10MB before selection)"
+    return line
+
+
+def _truncation_notes(
+    *,
+    was_size_truncated: bool,
+    total_bytes: int,
+    windowed: bool,
+    total_lines: int,
+    char_truncated: bool,
+) -> list[str]:
+    """Build the comma-joined notes shown on the ⚠️ truncation line."""
+    notes: list[str] = []
+    if was_size_truncated:
+        notes.append(f"size: {total_bytes:,} bytes")
+    if windowed:
+        notes.append(f"lines: {total_lines} total")
+    if char_truncated:
+        notes.append("chars: exceeded 100KB limit")
+    return notes
+
+
+def write_full_log_response(output: list[str], output_path: str, logs_text: str) -> str:
+    """Write the complete log to disk and return metadata only (#205).
+
+    No log content enters the response — only the caller-supplied header
+    lines, the write confirmation, and the totals line.
+    """
+    path = Path(output_path)
+    if not path.is_absolute():
+        return f"❌ output_path must be an absolute path, got: {output_path}"
+
+    total_lines = len(logs_text.splitlines())
+    total_bytes = len(logs_text)
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(logs_text, encoding="utf-8")
+    except OSError as exc:
+        return f"❌ Failed to write log to {output_path}: {exc}"
+
+    output.append(f"💾 Full log written to {output_path}")
+    output.append(
+        format_totals(
+            total_lines=total_lines,
+            total_bytes=total_bytes,
+            label="written to disk",
+            truncated=False,
+            was_size_truncated=False,
+        )
+    )
+    return "\n".join(output)
+
+
+def build_log_response_lines(
+    logs_text: str,
+    *,
+    tail_lines: int | None,
+    full_log: bool,
+    head_lines: int | None,
+    start_line: int | None,
+    end_line: int | None,
+    grep: str | None,
+    context_lines: int,
+    ignore_case: bool,
+    size_limit: int,
+    char_limit: int,
+    separator_length: int = 60,
+) -> list[str]:
+    """Clamp, window, and render a fetched log for the LLM response.
+
+    Raises LogSelectionError if the requested selectors conflict or are
+    out of range.
+    """
+    total_bytes = len(logs_text)
+    wants_head = (
+        grep is not None
+        or head_lines is not None
+        or start_line is not None
+        or end_line is not None
+    )
+
+    logs_text, was_size_truncated = cap_characters(
+        logs_text, keep_head=wants_head, limit=size_limit
+    )
+    if was_size_truncated:
+        logger.warning(f"Job logs clamped to {size_limit} bytes before selection")
+
+    lines = logs_text.splitlines()
+    total_lines = len(lines)
+    selection = select_log_text(
+        lines,
+        head_lines=head_lines,
+        tail_lines=tail_lines,
+        start_line=start_line,
+        end_line=end_line,
+        full_log=full_log,
+        grep=grep,
+        context_lines=context_lines,
+        ignore_case=ignore_case,
+        limit=char_limit,
+    )
+
+    result = [
+        format_totals(
+            total_lines=total_lines,
+            total_bytes=total_bytes,
+            label=selection.label,
+            truncated=selection.truncated,
+            was_size_truncated=was_size_truncated,
+        )
+    ]
+
+    notes = _truncation_notes(
+        was_size_truncated=was_size_truncated,
+        total_bytes=total_bytes,
+        windowed=selection.windowed,
+        total_lines=total_lines,
+        char_truncated=selection.char_truncated,
+    )
+    if notes:
+        result.append(f"⚠️ Truncated for LLM context ({', '.join(notes)})")
+
+    if grep is not None and selection.match_count == 0:
+        result.append(f"🔍 No lines matched {grep!r}")
+        return result
+
+    separator = "-" * separator_length
+    result.append(f"\n📋 Logs ({selection.label}):")
+    result.append(separator)
+    result.append(selection.text)
+    result.append(separator)
+    return result

--- a/src/mcp_server_git/github/models.py
+++ b/src/mcp_server_git/github/models.py
@@ -923,11 +923,26 @@ class GitHubGetJobLogs(BaseModel):
         logs = github_get_job_logs(owner, repo, job_id=12345)
         # For more context, increase tail_lines
         logs = github_get_job_logs(owner, repo, job_id=12345, tail_lines=1000)
+        # Reach the start of the log instead of the end
+        logs = github_get_job_logs(owner, repo, job_id=12345, head_lines=200)
+        # An explicit 1-indexed window
+        logs = github_get_job_logs(owner, repo, job_id=12345, start_line=500, end_line=650)
+        # Search the whole log, with 2 lines of context around each match
+        logs = github_get_job_logs(owner, repo, job_id=12345, grep="FAILED", context_lines=2)
+        # Write the complete log to disk instead of returning it inline
+        logs = github_get_job_logs(owner, repo, job_id=12345, output_path="/tmp/job.log")
         # For complete logs (still capped at 100KB for LLM safety)
         logs = github_get_job_logs(owner, repo, job_id=12345, full_log=True)
 
     Note:
-        - Default: last 500 lines (LLM-friendly)
+        - Only one of head_lines / tail_lines / (start_line, end_line) may be
+          given; grep composes with any of them.
+        - grep searches the whole log by default, not just the last 500 lines.
+        - output_path writes the complete log to disk and returns only
+          metadata (no log content enters context); it must be an absolute
+          path.
+        - Every response reports total lines, total bytes, and whether the
+          returned content was truncated.
         - Hard limit: 100KB character limit for LLM context protection
         - Memory limit: 10MB for very large logs
         - Logs may not be available for old jobs (GitHub retention policy)
@@ -938,7 +953,14 @@ class GitHubGetJobLogs(BaseModel):
     repo_name: str  # GitHub repository name
     job_id: int  # Job ID from GitHub Actions (from check runs or workflow jobs)
     tail_lines: int | None = None  # Return only last N lines; None uses default (500)
+    head_lines: int | None = None  # Return only first N lines (reaches the log start)
+    start_line: int | None = None  # 1-indexed inclusive start of an explicit window
+    end_line: int | None = None  # 1-indexed inclusive end of an explicit window
     full_log: bool = False  # If True, skip line limit (still has 100KB char limit)
+    grep: str | None = None  # Regex; return only matching lines, searched log-wide
+    context_lines: int = 0  # Lines of context to keep either side of a grep match
+    ignore_case: bool = False  # Case-insensitive grep
+    output_path: str | None = None  # Absolute path; write the full log there instead
 
 
 # ============================================================================
@@ -1027,7 +1049,9 @@ class GitHubListRulesets(BaseModel):
 
     repo_owner: str
     repo_name: str
-    per_page: int | None = Field(default=None, ge=1, le=100, description="Results per page (max 100)")
+    per_page: int | None = Field(
+        default=None, ge=1, le=100, description="Results per page (max 100)"
+    )
     page: int | None = Field(default=None, ge=1, description="Page number")
 
 
@@ -1061,10 +1085,14 @@ class GitHubListCodeScanningAlerts(BaseModel):
     repo_owner: str
     repo_name: str
     state: Literal["open", "closed", "dismissed", "fixed"] | None = None
-    severity: Literal["critical", "high", "medium", "low", "warning", "note", "error"] | None = None
+    severity: (
+        Literal["critical", "high", "medium", "low", "warning", "note", "error"] | None
+    ) = None
     tool_name: str | None = None  # Code-scanning tool (e.g. 'CodeQL') — free-form
     ref: str | None = None  # Branch name or refs/pull/N/head
-    per_page: int | None = Field(default=None, ge=1, le=100, description="Results per page (max 100)")
+    per_page: int | None = Field(
+        default=None, ge=1, le=100, description="Results per page (max 100)"
+    )
     page: int | None = Field(default=None, ge=1, description="Page number")
 
 
@@ -1075,7 +1103,9 @@ class GitHubListCodeScanningAnalyses(BaseModel):
     repo_name: str
     ref: str | None = None  # Branch name or refs/pull/N/head
     tool_name: str | None = None  # Code-scanning tool (e.g. 'CodeQL')
-    per_page: int | None = Field(default=None, ge=1, le=100, description="Results per page (max 100)")
+    per_page: int | None = Field(
+        default=None, ge=1, le=100, description="Results per page (max 100)"
+    )
     page: int | None = Field(default=None, ge=1, description="Page number")
 
 
@@ -1092,5 +1122,7 @@ class GitHubListSecretScanningAlerts(BaseModel):
     repo_owner: str
     repo_name: str
     state: Literal["open", "resolved"] | None = None
-    per_page: int | None = Field(default=None, ge=1, le=100, description="Results per page (max 100)")
+    per_page: int | None = Field(
+        default=None, ge=1, le=100, description="Results per page (max 100)"
+    )
     page: int | None = Field(default=None, ge=1, description="Page number")

--- a/src/mcp_server_git/lean/registry_github.py
+++ b/src/mcp_server_git/lean/registry_github.py
@@ -585,6 +585,10 @@ def _register_github_tools(interface: Any, github_service: Any):
             schema=GitHubGetContent.model_json_schema(),
             domain="github",
             complexity="core",
+            # `path` is a repo-relative identifier for the GitHub contents API,
+            # not a local filesystem path — nothing is read from disk, so the
+            # absolute-path requirement would leave no valid input (#206).
+            relative_path_params={"path"},
         ),
         ToolDefinition(
             name="github_resolve_ref",

--- a/tests/unit/github/test_github_job_logs.py
+++ b/tests/unit/github/test_github_job_logs.py
@@ -408,6 +408,197 @@ class TestGitHubGetJobLogs:
             # Result should be under 150KB (100KB limit + overhead)
             assert len(result) < 150 * 1024
 
+    def _mock_job_logs_client(self, log_lines: str) -> MagicMock:
+        """Build a mock client returning a 200 job response and *log_lines* text."""
+        mock_client = MagicMock()
+
+        mock_job_response = AsyncMock()
+        mock_job_response.status = 200
+        mock_job_response.json = AsyncMock(
+            return_value={
+                "id": 12345,
+                "name": "Selector Job",
+                "status": "completed",
+            }
+        )
+
+        mock_logs_response = AsyncMock()
+        mock_logs_response.status = 200
+        mock_logs_response.text = AsyncMock(return_value=log_lines)
+
+        mock_client.get = AsyncMock(side_effect=[mock_job_response, mock_logs_response])
+        return mock_client
+
+    @pytest.mark.asyncio
+    async def test_get_job_logs_with_head_lines_returns_first_lines(self):
+        """head_lines=100 returns the first lines of the log, reaching the start."""
+        log_lines = "\n".join([f"Line {i}" for i in range(500)])
+        mock_client = self._mock_job_logs_client(log_lines)
+
+        with patch(
+            "src.mcp_server_git.github.ci_logs.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_context.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            result = await github_get_job_logs("owner", "repo", 12345, head_lines=100)
+
+            assert "first 100" in result
+            assert "Line 0" in result
+            assert "Line 99" in result
+            assert "Line 100\n" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_job_logs_with_start_end_line_returns_exact_window(self):
+        """start_line/end_line returns exactly that window of lines."""
+        log_lines = "\n".join([f"Line {i}" for i in range(500)])
+        mock_client = self._mock_job_logs_client(log_lines)
+
+        with patch(
+            "src.mcp_server_git.github.ci_logs.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_context.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            result = await github_get_job_logs(
+                "owner", "repo", 12345, start_line=10, end_line=15
+            )
+
+            for i in range(9, 15):  # Line 9 (1-indexed 10) .. Line 14 (1-indexed 15)
+                assert f"Line {i}" in result
+            assert "Line 15\n" not in result
+            assert "Line 8\n" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_job_logs_with_grep_returns_only_matching_lines(self):
+        """grep returns only matching lines, prefixed with their line numbers."""
+        lines = ["filler" for _ in range(50)]
+        lines[9] = "ERROR: something broke"
+        log_lines = "\n".join(lines)
+        mock_client = self._mock_job_logs_client(log_lines)
+
+        with patch(
+            "src.mcp_server_git.github.ci_logs.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_context.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            result = await github_get_job_logs("owner", "repo", 12345, grep="ERROR")
+
+            assert "10: ERROR: something broke" in result
+            assert "1: filler" not in result
+
+    @pytest.mark.asyncio
+    async def test_get_job_logs_with_conflicting_selectors_returns_error_message(self):
+        """A conflicting selector combination surfaces as a '❌ ' message, not a traceback."""
+        log_lines = "\n".join([f"Line {i}" for i in range(10)])
+        mock_client = self._mock_job_logs_client(log_lines)
+
+        with patch(
+            "src.mcp_server_git.github.ci_logs.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_context.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            result = await github_get_job_logs(
+                "owner", "repo", 12345, head_lines=5, tail_lines=5
+            )
+
+            assert result.startswith("❌ ")
+
+    @pytest.mark.asyncio
+    async def test_get_job_logs_with_output_path_writes_file_with_no_log_body(
+        self, tmp_path
+    ):
+        """output_path writes the file; the response carries no log body."""
+        output_path = tmp_path / "job_log.txt"
+        log_lines = "\n".join([f"Line {i}" for i in range(10)])
+        mock_client = self._mock_job_logs_client(log_lines)
+
+        with patch(
+            "src.mcp_server_git.github.ci_logs.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_context.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            result = await github_get_job_logs(
+                "owner", "repo", 12345, output_path=str(output_path)
+            )
+
+            assert output_path.exists()
+            assert output_path.read_text(encoding="utf-8") == log_lines
+            assert "Line 0" not in result
+            assert "written to" in result
+
+    @pytest.mark.asyncio
+    async def test_get_job_logs_with_relative_output_path_returns_error(self):
+        """A relative output_path returns the absolute-path error."""
+        log_lines = "\n".join([f"Line {i}" for i in range(10)])
+        mock_client = self._mock_job_logs_client(log_lines)
+
+        with patch(
+            "src.mcp_server_git.github.ci_logs.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_context.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            result = await github_get_job_logs(
+                "owner", "repo", 12345, output_path="relative/log.txt"
+            )
+
+            assert "❌ output_path must be an absolute path" in result
+
+    @pytest.mark.asyncio
+    async def test_get_job_logs_response_always_contains_totals_line(self):
+        """Every response reports the '📊 Total:' totals line."""
+        log_lines = "\n".join([f"Line {i}" for i in range(10)])
+        mock_client = self._mock_job_logs_client(log_lines)
+
+        with patch(
+            "src.mcp_server_git.github.ci_logs.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_context.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            result = await github_get_job_logs("owner", "repo", 12345)
+
+            assert "📊 Total:" in result
+
+    @pytest.mark.asyncio
+    async def test_get_job_logs_regression_tail_lines_only_still_returns_tail(self):
+        """Regression: a call with only tail_lines still returns the tail."""
+        log_lines = "\n".join([f"Line {i}" for i in range(100)])
+        mock_client = self._mock_job_logs_client(log_lines)
+
+        with patch(
+            "src.mcp_server_git.github.ci_logs.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_context.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            result = await github_get_job_logs("owner", "repo", 12345, tail_lines=10)
+
+            assert "last 10 of 100 lines" in result
+            assert "Line 99" in result
+
+    @pytest.mark.asyncio
+    async def test_get_job_logs_regression_no_selectors_defaults_to_last_500(self):
+        """Regression: a call with no selectors still defaults to the last 500 lines."""
+        log_lines = "\n".join([f"Line {i}" for i in range(1000)])
+        mock_client = self._mock_job_logs_client(log_lines)
+
+        with patch(
+            "src.mcp_server_git.github.ci_logs.github_client_context"
+        ) as mock_context:
+            mock_context.return_value.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_context.return_value.__aexit__ = AsyncMock(return_value=None)
+
+            result = await github_get_job_logs("owner", "repo", 12345)
+
+            assert "last 500 of 1000 lines" in result
+            assert "Line 999" in result
+            assert "Line 499\n" not in result
+
 
 class TestGitHubGetJobLogsModel:
     """Test GitHubGetJobLogs Pydantic model."""

--- a/tests/unit/github/test_job_log_selection.py
+++ b/tests/unit/github/test_job_log_selection.py
@@ -1,0 +1,516 @@
+"""
+Pure unit tests for mcp_server_git.github.job_log_selection (issue #205).
+
+No mocks, no network, no HTTP — every function under test is pure and
+operates on already-fetched line lists / text.
+"""
+
+import re
+
+import pytest
+
+from src.mcp_server_git.github.job_log_selection import (
+    LogSelectionError,
+    build_log_response_lines,
+    cap_characters,
+    filter_lines,
+    format_totals,
+    resolve_window,
+    select_log_text,
+    write_full_log_response,
+)
+
+
+# ---------------------------------------------------------------------------
+# resolve_window
+# ---------------------------------------------------------------------------
+
+
+class TestResolveWindow:
+    def test_resolve_window_returns_last_500_lines_when_no_selectors_given(self):
+        start, end, _label, anchored_at_head = resolve_window(1000)
+
+        assert (start, end) == (501, 1000)
+        assert anchored_at_head is False
+
+    def test_resolve_window_returns_first_n_lines_when_head_lines_given(self):
+        start, end, _label, anchored_at_head = resolve_window(1000, head_lines=200)
+
+        assert (start, end) == (1, 200)
+        assert anchored_at_head is True
+
+    def test_resolve_window_returns_last_n_lines_when_tail_lines_given(self):
+        start, end, _label, anchored_at_head = resolve_window(1000, tail_lines=50)
+
+        assert (start, end) == (951, 1000)
+        assert anchored_at_head is False
+
+    def test_resolve_window_returns_exact_window_when_start_and_end_given(self):
+        start, end, _label, anchored_at_head = resolve_window(
+            1000, start_line=100, end_line=200
+        )
+
+        assert (start, end) == (100, 200)
+        assert anchored_at_head is True
+
+    def test_resolve_window_clamps_end_line_when_beyond_total(self):
+        start, end, _label, _anchored = resolve_window(1000, end_line=2000)
+
+        assert (start, end) == (1, 1000)
+
+    def test_resolve_window_defaults_end_to_total_when_only_start_line_given(self):
+        start, end, _label, _anchored = resolve_window(1000, start_line=100)
+
+        assert (start, end) == (100, 1000)
+
+    def test_resolve_window_defaults_start_to_one_when_only_end_line_given(self):
+        start, end, _label, _anchored = resolve_window(1000, end_line=200)
+
+        assert (start, end) == (1, 200)
+
+    def test_resolve_window_returns_whole_log_when_full_log_true(self):
+        start, end, _label, anchored_at_head = resolve_window(1000, full_log=True)
+
+        assert (start, end) == (1, 1000)
+        assert anchored_at_head is True
+
+    def test_resolve_window_returns_whole_log_when_whole_log_default_and_no_selectors(
+        self,
+    ):
+        start, end, _label, anchored_at_head = resolve_window(
+            1000, whole_log_default=True
+        )
+
+        assert (start, end) == (1, 1000)
+        assert anchored_at_head is True
+
+    def test_resolve_window_raises_when_head_lines_and_tail_lines_combined(self):
+        with pytest.raises(LogSelectionError):
+            resolve_window(1000, head_lines=10, tail_lines=10)
+
+    def test_resolve_window_raises_when_head_lines_and_start_line_combined(self):
+        with pytest.raises(LogSelectionError):
+            resolve_window(1000, head_lines=10, start_line=5)
+
+    def test_resolve_window_raises_when_head_lines_is_zero(self):
+        with pytest.raises(LogSelectionError):
+            resolve_window(1000, head_lines=0)
+
+    def test_resolve_window_raises_when_tail_lines_is_negative(self):
+        with pytest.raises(LogSelectionError):
+            resolve_window(1000, tail_lines=-1)
+
+    def test_resolve_window_raises_when_start_line_is_zero(self):
+        with pytest.raises(LogSelectionError):
+            resolve_window(1000, start_line=0)
+
+    def test_resolve_window_raises_when_end_line_less_than_start_line(self):
+        with pytest.raises(LogSelectionError):
+            resolve_window(1000, start_line=100, end_line=50)
+
+    def test_resolve_window_raises_when_start_line_past_end_of_log(self):
+        with pytest.raises(LogSelectionError):
+            resolve_window(1000, start_line=1001)
+
+
+# ---------------------------------------------------------------------------
+# filter_lines
+# ---------------------------------------------------------------------------
+
+
+class TestFilterLines:
+    def _numbered(self, lines: list[str]) -> list[tuple[int, str]]:
+        return list(enumerate(lines, start=1))
+
+    def test_filter_lines_returns_matches_prefixed_with_original_line_numbers(self):
+        numbered = self._numbered(["alpha", "beta NEEDLE", "gamma", "delta NEEDLE"])
+
+        rendered, match_count = filter_lines(numbered, "NEEDLE")
+
+        assert match_count == 2
+        # Matches on non-adjacent lines are still separated groups even
+        # without context, so "--" appears between them.
+        assert rendered == ["2: beta NEEDLE", "--", "4: delta NEEDLE"]
+
+    def test_filter_lines_includes_context_and_separates_discontiguous_groups(self):
+        numbered = self._numbered(
+            ["a", "b", "MATCH1", "d", "e", "f", "g", "h", "MATCH2", "j"]
+        )
+
+        rendered, match_count = filter_lines(numbered, "MATCH", context_lines=2)
+
+        assert match_count == 2
+        assert "--" in rendered
+        assert "3: MATCH1" in rendered
+        assert "9: MATCH2" in rendered
+        assert "1- a" in rendered
+        assert "5- e" in rendered
+
+    def test_filter_lines_does_not_insert_separator_when_groups_are_adjacent(self):
+        numbered = self._numbered(["a", "MATCH1", "b", "MATCH2", "c"])
+
+        rendered, match_count = filter_lines(numbered, "MATCH", context_lines=1)
+
+        assert match_count == 2
+        assert "--" not in rendered
+
+    def test_filter_lines_matches_case_insensitively_when_ignore_case_true(self):
+        numbered = self._numbered(["Error: boom", "all good"])
+
+        rendered, match_count = filter_lines(numbered, "error", ignore_case=True)
+
+        assert match_count == 1
+        assert rendered == ["1: Error: boom"]
+
+    def test_filter_lines_is_case_sensitive_by_default(self):
+        numbered = self._numbered(["Error: boom", "all good"])
+
+        rendered, match_count = filter_lines(numbered, "error")
+
+        assert rendered == []
+        assert match_count == 0
+
+    def test_filter_lines_returns_empty_when_no_matches(self):
+        numbered = self._numbered(["alpha", "beta", "gamma"])
+
+        rendered, match_count = filter_lines(numbered, "NEEDLE")
+
+        assert (rendered, match_count) == ([], 0)
+
+    def test_filter_lines_raises_on_invalid_regex(self):
+        numbered = self._numbered(["alpha"])
+
+        with pytest.raises(LogSelectionError):
+            filter_lines(numbered, "[unclosed")
+
+
+# ---------------------------------------------------------------------------
+# cap_characters
+# ---------------------------------------------------------------------------
+
+
+class TestCapCharacters:
+    def test_cap_characters_returns_unchanged_when_under_limit(self):
+        text = "short text"
+
+        result, truncated = cap_characters(text, keep_head=True, limit=1000)
+
+        assert result == text
+        assert truncated is False
+
+    def test_cap_characters_keeps_beginning_when_keep_head_true(self):
+        lines = [f"L{i:04d}" for i in range(2000)]
+        text = "\n".join(lines)
+
+        result, truncated = cap_characters(text, keep_head=True, limit=5000)
+
+        assert truncated is True
+        assert text.startswith(result)
+        assert all(re.fullmatch(r"L\d{4}", line) for line in result.split("\n"))
+
+    def test_cap_characters_keeps_end_when_keep_head_false(self):
+        lines = [f"L{i:04d}" for i in range(2000)]
+        text = "\n".join(lines)
+
+        result, truncated = cap_characters(text, keep_head=False, limit=5000)
+
+        assert truncated is True
+        assert text.endswith(result)
+        assert all(re.fullmatch(r"L\d{4}", line) for line in result.split("\n"))
+
+    def test_cap_characters_result_never_starts_with_partial_line(self):
+        lines = [f"LINE-{i:05d}" for i in range(3000)]
+        text = "\n".join(lines)
+
+        result, _truncated = cap_characters(text, keep_head=True, limit=7003)
+
+        first_line = result.split("\n")[0]
+        assert re.fullmatch(r"LINE-\d{5}", first_line)
+
+    def test_cap_characters_result_never_ends_with_partial_line(self):
+        lines = [f"LINE-{i:05d}" for i in range(3000)]
+        text = "\n".join(lines)
+
+        result, _truncated = cap_characters(text, keep_head=False, limit=7003)
+
+        last_line = result.split("\n")[-1]
+        assert re.fullmatch(r"LINE-\d{5}", last_line)
+
+    def test_cap_characters_returns_truncated_true_when_it_bites(self):
+        text = "x" * 100
+
+        _result, truncated = cap_characters(text, keep_head=True, limit=10)
+
+        assert truncated is True
+
+
+# ---------------------------------------------------------------------------
+# select_log_text
+# ---------------------------------------------------------------------------
+
+
+class TestSelectLogTextRegressions:
+    """Regression tests for the default-500-line-hides-grep-matches bug (#205)."""
+
+    def test_grep_with_no_window_selector_searches_the_whole_log(self):
+        lines = ["filler line" for _ in range(10_000)]
+        lines[2] = "NEEDLE found here"  # line number 3 (1-indexed)
+
+        selection = select_log_text(lines, grep="NEEDLE")
+
+        assert selection.match_count == 1
+        assert "3: NEEDLE found here" in selection.text
+
+    def test_head_lines_on_large_log_reaches_start_of_log_not_end(self):
+        lines = [f"line {i}" for i in range(64_000)]
+
+        selection = select_log_text(lines, head_lines=200)
+
+        assert "line 0" in selection.text
+        assert "line 63999" not in selection.text
+
+    def test_start_end_window_composes_with_grep(self):
+        lines = ["filler" for _ in range(1000)]
+        lines[149] = "NEEDLE inside window"  # line 150, inside [100, 200]
+        lines[499] = "NEEDLE outside window"  # line 500, outside [100, 200]
+
+        selection = select_log_text(lines, start_line=100, end_line=200, grep="NEEDLE")
+
+        assert "150: NEEDLE inside window" in selection.text
+        assert "NEEDLE outside window" not in selection.text
+
+    def test_truncated_false_only_when_whole_log_returned_uncapped(self):
+        lines = [f"line {i}" for i in range(10)]
+
+        selection = select_log_text(lines, full_log=True)
+
+        assert selection.truncated is False
+
+    def test_truncated_true_for_windowed_selection(self):
+        lines = [f"line {i}" for i in range(1000)]
+
+        selection = select_log_text(lines, head_lines=10)
+
+        assert selection.truncated is True
+
+    def test_truncated_true_whenever_grep_was_used(self):
+        lines = [f"line {i}" for i in range(10)]
+        lines[0] = "NEEDLE"
+
+        selection = select_log_text(lines, full_log=True, grep="NEEDLE")
+
+        assert selection.truncated is True
+
+    def test_match_count_is_none_when_grep_not_used(self):
+        lines = [f"line {i}" for i in range(10)]
+
+        selection = select_log_text(lines)
+
+        assert selection.match_count is None
+
+    def test_match_count_is_int_when_grep_used(self):
+        lines = [f"line {i}" for i in range(10)]
+        lines[0] = "NEEDLE"
+
+        selection = select_log_text(lines, full_log=True, grep="NEEDLE")
+
+        assert selection.match_count == 1
+
+
+# ---------------------------------------------------------------------------
+# format_totals
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTotals:
+    def test_format_totals_includes_lines_bytes_label_and_truncated_yes(self):
+        line = format_totals(
+            total_lines=1234,
+            total_bytes=5678,
+            label="last 500 of 1234 lines",
+            truncated=True,
+            was_size_truncated=False,
+        )
+
+        assert "1,234" in line
+        assert "5,678" in line
+        assert "last 500 of 1234 lines" in line
+        assert "Truncated: yes" in line
+
+    def test_format_totals_reports_truncated_no_when_not_truncated(self):
+        line = format_totals(
+            total_lines=10,
+            total_bytes=20,
+            label="all 10 lines",
+            truncated=False,
+            was_size_truncated=False,
+        )
+
+        assert "Truncated: no" in line
+
+    def test_format_totals_appends_clamp_note_when_size_truncated(self):
+        line = format_totals(
+            total_lines=10,
+            total_bytes=20,
+            label="all 10 lines",
+            truncated=False,
+            was_size_truncated=True,
+        )
+
+        assert "10MB" in line
+
+    def test_format_totals_omits_clamp_note_when_not_size_truncated(self):
+        line = format_totals(
+            total_lines=10,
+            total_bytes=20,
+            label="all 10 lines",
+            truncated=False,
+            was_size_truncated=False,
+        )
+
+        assert "10MB" not in line
+
+
+# ---------------------------------------------------------------------------
+# build_log_response_lines
+# ---------------------------------------------------------------------------
+
+
+class TestBuildLogResponseLines:
+    def _logs_text(self, n: int = 50) -> str:
+        return "\n".join(f"line {i}" for i in range(n))
+
+    def test_totals_line_is_first_element_for_default_selection(self):
+        result = build_log_response_lines(
+            self._logs_text(),
+            tail_lines=None,
+            full_log=False,
+            head_lines=None,
+            start_line=None,
+            end_line=None,
+            grep=None,
+            context_lines=0,
+            ignore_case=False,
+            size_limit=10_000_000,
+            char_limit=100_000,
+        )
+
+        assert result[0].startswith("📊 Total:")
+
+    def test_totals_line_is_first_element_for_head_selection(self):
+        result = build_log_response_lines(
+            self._logs_text(),
+            tail_lines=None,
+            full_log=False,
+            head_lines=5,
+            start_line=None,
+            end_line=None,
+            grep=None,
+            context_lines=0,
+            ignore_case=False,
+            size_limit=10_000_000,
+            char_limit=100_000,
+        )
+
+        assert result[0].startswith("📊 Total:")
+
+    def test_totals_line_is_first_element_for_range_selection(self):
+        result = build_log_response_lines(
+            self._logs_text(),
+            tail_lines=None,
+            full_log=False,
+            head_lines=None,
+            start_line=5,
+            end_line=10,
+            grep=None,
+            context_lines=0,
+            ignore_case=False,
+            size_limit=10_000_000,
+            char_limit=100_000,
+        )
+
+        assert result[0].startswith("📊 Total:")
+
+    def test_totals_line_is_first_element_for_grep_selection(self):
+        result = build_log_response_lines(
+            self._logs_text(),
+            tail_lines=None,
+            full_log=False,
+            head_lines=None,
+            start_line=None,
+            end_line=None,
+            grep="line 3",
+            context_lines=0,
+            ignore_case=False,
+            size_limit=10_000_000,
+            char_limit=100_000,
+        )
+
+        assert result[0].startswith("📊 Total:")
+
+    def test_grep_with_zero_matches_returns_totals_and_no_matches_message_only(self):
+        result = build_log_response_lines(
+            self._logs_text(),
+            tail_lines=None,
+            full_log=False,
+            head_lines=None,
+            start_line=None,
+            end_line=None,
+            grep="NOPE_NO_MATCH",
+            context_lines=0,
+            ignore_case=False,
+            size_limit=10_000_000,
+            char_limit=100_000,
+        )
+
+        assert result[0].startswith("📊 Total:")
+        assert any("No lines matched" in entry for entry in result)
+        assert len(result) == 2
+        assert not any(entry.strip() == "" for entry in result)
+
+
+# ---------------------------------------------------------------------------
+# write_full_log_response
+# ---------------------------------------------------------------------------
+
+
+class TestWriteFullLogResponse:
+    def test_relative_output_path_returns_error_and_writes_nothing(self, tmp_path):
+        relative_path = "relative/nested/out.txt"
+
+        result = write_full_log_response([], relative_path, "some log text")
+
+        assert result.startswith("❌ output_path must be an absolute path")
+        from pathlib import Path
+
+        assert not Path(relative_path).exists()
+
+    def test_writes_complete_log_text_creating_missing_parent_dirs(self, tmp_path):
+        output_path = tmp_path / "sub" / "dir" / "log.txt"
+        logs_text = "line one\nline two\nline three\n"
+
+        write_full_log_response([], str(output_path), logs_text)
+
+        assert output_path.exists()
+        assert output_path.read_text(encoding="utf-8") == logs_text
+
+    def test_response_contains_write_confirmation_and_totals_but_not_log_body(
+        self, tmp_path
+    ):
+        output_path = tmp_path / "log.txt"
+        logs_text = "UNIQUE_MARKER_XYZ\nsecond line\n"
+
+        result = write_full_log_response([], str(output_path), logs_text)
+
+        assert "written to" in result
+        assert "📊 Total:" in result
+        assert "UNIQUE_MARKER_XYZ" not in result
+
+    def test_returns_error_when_write_fails(self, tmp_path):
+        blocker = tmp_path / "blocker"
+        blocker.write_text("i am a file, not a directory")
+        output_path = blocker / "log.txt"
+
+        result = write_full_log_response([], str(output_path), "some log text")
+
+        assert result.startswith("❌ Failed to write log to ")

--- a/tests/unit/lean/test_github_content_relative_path.py
+++ b/tests/unit/lean/test_github_content_relative_path.py
@@ -1,0 +1,134 @@
+"""Regression tests for issue #206 — github_get_content rejected relative paths.
+
+``path`` on ``github_get_content`` is a repo-relative identifier for the
+GitHub contents API (nothing is read from local disk), so the interface's
+blanket "must be absolute" path-guard left no valid input for it. Modeled on
+tests/unit/git/test_submodule_relative_path.py (issue #168's analogous fix
+for git_submodule_add's ``path``).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from mcp_server_git.lean.interface import GitLeanInterface
+
+
+def _make_minimal_interface() -> GitLeanInterface:
+    """Build a GitLeanInterface with the real tool registry (no network calls)."""
+    return GitLeanInterface(MagicMock(), MagicMock(), MagicMock())
+
+
+def _tool_def(iface: GitLeanInterface, name: str):
+    return iface.tool_registry[name]
+
+
+class TestGitHubGetContentRegistration:
+    """The registered github_get_content tool must exempt its ``path`` param."""
+
+    def setup_method(self):
+        self.iface = _make_minimal_interface()
+
+    def test_github_get_content_relative_path_params_contains_path(self):
+        tool_def = _tool_def(self.iface, "github_get_content")
+        assert "path" in tool_def.relative_path_params
+
+
+class TestValidatePathParametersExemptionForGithubGetContent:
+    """Unit-test the validator with github_get_content's exemption set."""
+
+    def setup_method(self):
+        self.iface = _make_minimal_interface()
+        self.relative_path_params = _tool_def(
+            self.iface, "github_get_content"
+        ).relative_path_params
+
+    def test_exact_issue_repro_call_accepted(self):
+        """Regression for #206: the exact call from the issue no longer raises."""
+        # Should not raise
+        self.iface._validate_path_parameters(
+            {
+                "repo_owner": "conda-forge",
+                "repo_name": "zig-feedstock",
+                "path": "recipe/recipe.yaml",
+                "ref": "dev",
+            },
+            relative_path_params=self.relative_path_params,
+        )
+
+    def test_bare_filename_accepted(self):
+        """Second repro from the issue: a bare filename with no directory."""
+        # Should not raise
+        self.iface._validate_path_parameters(
+            {"path": "build.zig"},
+            relative_path_params=self.relative_path_params,
+        )
+
+    def test_dotdot_traversal_still_rejected(self):
+        """ ".." traversal must still raise even for the exempted path param."""
+        with pytest.raises(ValueError, match="traversal"):
+            self.iface._validate_path_parameters(
+                {"path": "../escape"},
+                relative_path_params=self.relative_path_params,
+            )
+
+    def test_empty_string_still_rejected(self):
+        """An empty path value must still raise even for the exempted param."""
+        with pytest.raises(ValueError):
+            self.iface._validate_path_parameters(
+                {"path": ""},
+                relative_path_params=self.relative_path_params,
+            )
+
+
+class TestGithubUploadReleaseAssetNotExempted:
+    """file_path on github_upload_release_asset is a genuine local file path."""
+
+    def setup_method(self):
+        self.iface = _make_minimal_interface()
+
+    def test_upload_release_asset_relative_path_params_excludes_file_path(self):
+        tool_def = _tool_def(self.iface, "github_upload_release_asset")
+        assert "file_path" not in tool_def.relative_path_params
+
+    def test_upload_release_asset_file_path_still_requires_absolute(self):
+        tool_def = _tool_def(self.iface, "github_upload_release_asset")
+        with pytest.raises(ValueError, match="Relative path"):
+            self.iface._validate_path_parameters(
+                {"file_path": "dist/asset.tar.gz"},
+                relative_path_params=tool_def.relative_path_params,
+            )
+
+
+class TestGithubGetContentViaLeanInterface:
+    """Integration: execute_tool_direct no longer raises the path-guard error."""
+
+    def setup_method(self):
+        self.iface = _make_minimal_interface()
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_direct_no_longer_raises_relative_path_error(
+        self, monkeypatch
+    ):
+        """Regression for #206: driving the real tool through the interface
+        no longer produces "Relative path ... not supported" for ``path``.
+
+        No GITHUB_TOKEN is set, so the call still fails — but on the
+        (expected, unrelated) missing-credentials path, not on path
+        validation, and with no network access required.
+        """
+        monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+
+        result = await self.iface.execute_tool_direct(
+            "github_get_content",
+            {
+                "repo_owner": "conda-forge",
+                "repo_name": "zig-feedstock",
+                "path": "recipe/recipe.yaml",
+                "ref": "dev",
+            },
+        )
+
+        assert "Relative path" not in str(result)
+        assert result["status"] == "success"
+        assert "Relative path" not in result["result"]


### PR DESCRIPTION
Closes #205
Closes #206

Two independent GitHub-tool defects, shipped together as requested.

## #206 — `github_get_content` was uncallable

The path guard in `lean/interface.py` requires any parameter whose name contains `path` to be absolute, so MCP's process CWD can never be mistaken for the client's working directory. Right for local-git tools; wrong for `github_get_content`, whose `path` is a repo-relative identifier for `GET /repos/{owner}/{repo}/contents/{path}`. Nothing is read from disk, and an absolute path would 404 — so no input satisfied both the guard and the API and every call failed.

The per-tool exemption already existed (`relative_path_params`, used by `git_submodule_add`); `github_get_content` never declared it. One-line registration fix.

Deliberately scoped to that one parameter:

| parameter | kind | absolute required? |
|---|---|---|
| `github_get_content.path` | remote (contents API) | no — exempted here |
| `github_upload_release_asset.file_path` | local file | **yes**, unchanged |
| `github_get_job_logs.output_path` (new, #205) | local file | **yes** |

An audit confirmed those are the only path-shaped parameters in the GitHub registry. Empty strings and `..` traversal stay rejected even for exempt parameters.

## #205 — only the tail of a job log was reachable

The cap stays; what was missing was a way to choose *which* part is returned. All four options from the issue:

- **`grep`** (+ `context_lines`, `ignore_case`) — only matching lines, with line numbers, in grep's own notation (`n:` match, `n-` context, `--` between groups).
- **`head_lines`, `start_line`/`end_line`** — reach an arbitrary window.
- **`output_path`** — write the full log to disk, return only path and totals; no log content enters context.
- **Totals on every response** — `total_lines`, `total_bytes`, `Truncated: yes/no`. Truncation was previously silent, so a caller could not tell a short log from a truncated one and might read "no matches" as a real negative.

### Two things beyond the issue text

**`grep` searches the whole log by default**, not the last 500 lines. Inheriting the tail default would have reproduced exactly the blind spot being fixed — an early match returning nothing.

**The 10MB clamp was slicing `logs_text[-10MB:]`**, keeping the tail. On a log above that size it would have served even a correct `head_lines` request from the wrong end. Now direction-aware.

### Notes

Selection logic lives in a new pure module `job_log_selection.py` — operates on an already-fetched list of lines, touches neither network nor filesystem, so it is tested directly without HTTP mocks. Also keeps `ci_logs.py` under the 500-line decomposition limit.

Only one of `head_lines` / `tail_lines` / (`start_line`, `end_line`) may be given — conflicting selectors raise rather than silently picking one. `grep` composes with any of them. `tail_lines` and `full_log` keep their positions and behaviour, and the existing output contract (line-count format, `⚠️` truncation warning) is unchanged.

The Azure asymmetry noted in the issue is not addressed here.

## Testing

67 tests added. Full unit suite **958 passed, 0 failed** (baseline before this branch: 891).

Regression tests target the specific failures in both issues: the two exact `github_get_content` repro calls from #206; a 10,000-line log whose only match is on line 3 found by bare `grep`; `head_lines` reaching line 1 of a 64,000-line log; and `grep` with zero matches emitting an explicit "no lines matched" plus totals, so an empty result can never be mistaken for a real negative.

🤖 Generated with [Claude Code](https://claude.com/claude-code)